### PR TITLE
fix(#115): fix syntax for creating store

### DIFF
--- a/assets/js/react/App.jsx
+++ b/assets/js/react/App.jsx
@@ -23,12 +23,11 @@ import Admin from './components/pages/Admin';
 
 addLocaleData(localeData);
 
+const middlewares = applyMiddleware(createDebounce(), thunkMiddleware);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const gcStore = createStore(
   GCReducer,
-  compose(
-    applyMiddleware(createDebounce(), thunkMiddleware),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  )
+  composeEnhancers(middlewares),
 );
 
 /* gcStore.subscribe(function() {


### PR DESCRIPTION
This syntax works both on Chrome and Firefox for using the redux dev tool extension.