### PR TITLE
[BBS & mapping service] Fix renaming keys + Fix total number of results returned by Elasticsearch

### DIFF
--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -307,7 +307,7 @@ module.exports = {
     }
 
     res.results = values;
-    res.totalNbResults = source.hits ? source.hits.total.value : 0;
+    res.totalNbResults = source.hits ? source.hits.total : 0;
     return res;
   },
 

--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -223,7 +223,7 @@ module.exports = {
       values.push(data);
     });
     res.results = values;
-    res.totalNbResults = source.hits.total.value;
+    res.totalNbResults = source.hits.total;
     return res;
   },
 
@@ -264,13 +264,12 @@ module.exports = {
 
         // Convert from a collection of keys newKeys, rename the keys of obj
         const renameKeys = (obj, newKeys) => {
-          const keyValues = Object.keys(obj).map((key) => {
-            const newKey = newKeys[key] || key;
-            return {
-              [newKey]: obj[key],
-            };
+          Object.keys(obj).map((key) => {
+            if(newKeys[key]) {
+              obj[newKeys[key]] = obj[key];
+              delete obj[key];
+            }
           });
-          return keyValues;
         };
 
         switch (item['_source'].type) {
@@ -290,15 +289,13 @@ module.exports = {
             break;
 
           case 'bbs':
-            // Rename keys of data and highlights
-            const newHighLights = renameKeys(data.highlights, replacementKeys);
-            const newSource = renameKeys(item['_source'], replacementKeys);
+            // Rename keys of source and highlights
+            renameKeys(item['_source'], replacementKeys);
+            renameKeys(data.highlights, replacementKeys);
 
-            // Fill data with appropriate key
-            for(var key in replacementKeys) {
-              let value = replacementKeys[key];
-              data[value] = newSource[value];
-              data.highlights[value] = newHighLights[value];
+            // Fill data with appropriate keys
+            for(var key in item['_source']) {
+              data[key] = item['_source'][key];
             }
             
             break;
@@ -310,7 +307,7 @@ module.exports = {
     }
 
     res.results = values;
-    res.totalNbResults = source.hits ? source.hits.total : 0;
+    res.totalNbResults = source.hits ? source.hits.total.value : 0;
     return res;
   },
 


### PR DESCRIPTION
On the previous PR fixing the quick search, the renaming keys was broken by me (example : the key "bbs title" from Elasticsearch must be renamed "title", "bbs authors" => "authors" etc.). 
I simplified the code renaming the keys, it's cleaner and works properly now.