### PR TITLE
Bump Elasticsearch version in development (6.5.0 => 7.5.1)

### DIFF
--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -223,7 +223,7 @@ module.exports = {
       values.push(data);
     });
     res.results = values;
-    res.totalNbResults = source.hits.total;
+    res.totalNbResults = source.hits.total.value;
     return res;
   },
 
@@ -265,7 +265,7 @@ module.exports = {
         // Convert from a collection of keys newKeys, rename the keys of obj
         const renameKeys = (obj, newKeys) => {
           Object.keys(obj).map((key) => {
-            if(newKeys[key]) {
+            if (newKeys[key]) {
               obj[newKeys[key]] = obj[key];
               delete obj[key];
             }
@@ -294,10 +294,10 @@ module.exports = {
             renameKeys(data.highlights, replacementKeys);
 
             // Fill data with appropriate keys
-            for(var key in item['_source']) {
+            for (let key in item['_source']) {
               data[key] = item['_source'][key];
             }
-            
+
             break;
 
           default:
@@ -307,7 +307,7 @@ module.exports = {
     }
 
     res.results = values;
-    res.totalNbResults = source.hits ? source.hits.total : 0;
+    res.totalNbResults = source.hits.total.value;
     return res;
   },
 

--- a/deployDev.sh
+++ b/deployDev.sh
@@ -29,6 +29,9 @@ ES_LOCAL_PORT=9200
 # Logstash
 LS_TAGNAME="logstashgrotto"
 
+# Keep the same version as the production one (on AWS)
+ES_AND_LS_VERSION="7.6.1"
+
 ##################################################### FUNCTIONS #########################################################
 
 # Get the status of the health of the container name passed in parameter.
@@ -108,7 +111,7 @@ docker run -d \
     -p 9300:9300 \
     -e "discovery.type=single-node" \
     --cpus=0.5 \
-    elasticsearch:6.5.0
+    elasticsearch:${ES_AND_LS_VERSION}
 echo "### Elasticsearch available on port ${ES_LOCAL_PORT} ###"
 
 # Dowload and extract a plugin to be used by Logstash to load data from MySQL
@@ -140,7 +143,7 @@ docker run --rm -d \
     -e JDBC_USER=${DOCKER_MYSQL_USER} \
     -e JDBC_PASSWORD=${DOCKER_MYSQL_PASSWORD} \
     -e ES_HOSTS="${ES_TAGNAME}:${ES_LOCAL_PORT}" \
-    -v "$PWD":/config-dir docker.elastic.co/logstash/logstash:6.5.2 \
+    -v "$PWD":/config-dir docker.elastic.co/logstash/logstash:${ES_AND_LS_VERSION} \
     -f /config-dir/logstash.conf
 
 # Wait the container to be running


### PR DESCRIPTION
In development, we now use the same Elasticsearch & Logstash version as in production. Also, there were breaking changes when passing to v7 (https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html) : I fixed one of these. 