### PR TITLE
[INTL ERRORS] Collapse missing translations

### DIFF
--- a/assets/js/react/App.jsx
+++ b/assets/js/react/App.jsx
@@ -33,8 +33,29 @@ gcStore.dispatch(changeLanguage(locale));
 
 const theme = createMuiTheme(grottoTheme);
 
+const customOnIntlError = (err) => {
+  /* 
+      Custom handler for missing translation. 
+      By default, it shows the stacktrace which is very annoying. 
+      This handler wrap everything in a collapsed group.
+      */
+  if (err.code === 'MISSING_TRANSLATION') {
+    console.groupCollapsed('MISSING_TRANSLATION'); // eslint-disable-line no-console
+    console.warn(
+      `Missing Translation for message with id: \n${err.descriptor.id}`,
+    );
+    console.groupEnd(); // eslint-disable-line no-console
+    return;
+  }
+  throw err;
+};
+
 ReactDOM.render(
-  <IntlProvider locale={locale} messages={window.catalog}>
+  <IntlProvider
+    locale={locale}
+    messages={window.catalog}
+    onError={customOnIntlError}
+  >
     <StylesProvider injectFirst>
       <CssBaseline />
       <StyledThemeProvider theme={theme}>


### PR DESCRIPTION
Custom handler for missing translation. 
By default, it shows the stacktrace which is very annoying (it takes a lot of place on the screen).
This handler wrap everything in a collapsed group.

## BEFORE
![before_collapsing](https://user-images.githubusercontent.com/20704943/90608995-ad63ce80-e203-11ea-8e94-a0ac39bc9647.gif)

## AFTER
![with_collapsing](https://user-images.githubusercontent.com/20704943/90608993-ac32a180-e203-11ea-95fb-ad457251b7ac.gif)

