### PR TITLE
[POLICIES] Add adminAuth policy

### DIFF
--- a/api/policies/adminAuth.js
+++ b/api/policies/adminAuth.js
@@ -1,0 +1,20 @@
+/**
+ * adminAuth
+ *
+ * @module      :: Policy
+ * @description :: Admin authentication. This policy assumes that there is a valid token in req.token
+ *                which is the case when the request has been proceeded by the tokenAuth policy.
+ *                So, use this policy ONLY after using the tokenAuth policy!
+ * @docs        :: http://sailsjs.org/#!documentation/policies
+ *
+ */
+module.exports = (req, res, next) => {
+  const { token } = req;
+  if (token.groups.some((g) => g.name === 'Administrator')) {
+    next();
+  } else {
+    return res.forbidden(
+      'You are not permitted to perform this action: you must be an administrator.',
+    );
+  }
+};


### PR DESCRIPTION
This policy assumes that there is a valid token in req.token which is the case when the request has been proceeded by the tokenAuth policy.
 So, use this policy ONLY after using the tokenAuth policy!