### PR TITLE
[AUTH TOKEN] Put auth token in authorization header

### DIFF
--- a/api/policies/tokenAuth.js
+++ b/api/policies/tokenAuth.js
@@ -7,13 +7,16 @@
  *
  */
 module.exports = (req, res, next) => {
-  const token =
-    (req.body && req.body.token) ||
-    req.query.token ||
-    req.headers['x-access-token'];
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res
+      .status(401)
+      .send(
+        'Bearer token not found: you need to be authenticated to perform this action.',
+      );
+  }
 
-  // We delete the token from param to not mess with blueprints
-  delete req.query.token;
+  const token = authHeader.substring(7, authHeader.length);
 
   if (token) {
     TokenAuthService.verify(token, (err, responseToken) => {

--- a/assets/js/react/actions/Document.jsx
+++ b/assets/js/react/actions/Document.jsx
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch';
-import { identificationTokenName, postDocumentUrl } from '../conf/Config';
+import { postDocumentUrl } from '../conf/Config';
+import { getAuthHTTPHeader } from '../helpers/AuthHelper';
 
 // ==========
 export const POST_DOCUMENT = 'POST_DOCUMENT';
@@ -27,10 +28,10 @@ export function postDocument(docAttributes) {
   return (dispatch) => {
     dispatch(postDocumentAction());
 
-    const authToken = window.localStorage.getItem(identificationTokenName);
     const requestOptions = {
       method: 'POST',
-      body: JSON.stringify({ ...docAttributes, token: authToken }),
+      body: JSON.stringify({ ...docAttributes }),
+      headers: getAuthHTTPHeader(),
     };
 
     return fetch(postDocumentUrl, requestOptions).then((response) => {

--- a/assets/js/react/helpers/AuthHelper.jsx
+++ b/assets/js/react/helpers/AuthHelper.jsx
@@ -11,6 +11,12 @@ export const getAuthToken = () => {
   return window.localStorage.getItem(identificationTokenName);
 };
 
+export const getAuthHTTPHeader = () => {
+  return {
+    Authorization: `Bearer ${getAuthToken()}`,
+  };
+};
+
 /**
  * True if the user has a group with the name "Administrator", else false.
  */


### PR DESCRIPTION
Auth token must be in Authorization header instead of in the body request.