### PR TITLE
fix(officialPartnersApi) - Use count + controllerService

### DIFF
--- a/api/controllers/GrottoController.js
+++ b/api/controllers/GrottoController.js
@@ -74,16 +74,16 @@ module.exports = {
   },
 
   getOfficialPartnersNumber: (req, res) => {
-    TGrotto.count({ isOfficialPartner: true })
-      .then((total) => {
-        return res.json(total);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(
-          `GrottoController.getOfficialPartnersNumber error : ${err}`,
-        );
-      });
+    TGrotto.count({ isOfficialPartner: true }).exec((err, found) => {
+      const params = {
+        controllerMethod: 'GrottoController.getOfficialPartnersNumber',
+        notFoundMessage: 'Problem while getting number of official partners.',
+      };
+      const count = {
+        count: found,
+      };
+      return ControllerService.treat(req, err, count, params, res);
+    });
   },
 
   getPartnersNumber: (req, res) => {


### PR DESCRIPTION
Le nombre de partenaires officiels sur la page d'accueil a sauté depuis quelques temps. Voilà le correctif qui utilise le ControllerService au lieu de renvoyer des données brutes.