### PR TITLE
[DOC VALIDATION] Hide pathOld attribute by default

### DIFF
--- a/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
+++ b/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
@@ -22,6 +22,7 @@ const defaultHiddenColumns = [
   'massif',
   'pages',
   'parent',
+  'pathOld',
   'publication',
   'publicationFasciculeBBSOld',
   'refBbs',


### PR DESCRIPTION
pathOld (i.e, old url from Grottocenter v2) was added recently by the document's API to the document objects sent. We must hide it in documentValidation by default.