### PR TITLE
[DOCUMENT API] Trim document identifier type id

### DIFF
--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -556,7 +556,12 @@ module.exports = {
     result.dateValidation = source.dateValidation;
     result.entrance = source.entrance;
     result.identifier = source.identifier;
-    result.identifierType = source.identifierType;
+    result.identifierType = {
+      ...source.identifierType,
+      id: ramda.pipe(ramda.pathOr(undefined, ['identifierType', 'id']), (id) =>
+        id ? id.trim() : id,
+      )(source),
+    };
     result.languages = source.languages;
     result.license = source.license;
     result.mainLanguage = source.mainLanguage;


### PR DESCRIPTION
In the DB, the id can be a string of 5-characters long. We need to trim them because some of them are 3 (or 4)-characters long (DOI, URL...)