### PR TITLE
[DOC VALIDATION] Fix sort columns by label translated + fix findAll documents API error message

### DIFF
--- a/api/controllers/DocumentController.js
+++ b/api/controllers/DocumentController.js
@@ -333,6 +333,13 @@ module.exports = {
               return res.serverError('An unexpected server error occured.');
             }
 
+            if (!found) {
+              res.status(404);
+              return res.json({
+                error: `There is no document matching your criterias. It can be because sorting by ${sort} is not supported.`,
+              });
+            }
+
             await Promise.all(
               await found.map(async (doc) => {
                 await NameService.setNames(

--- a/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
+++ b/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
@@ -55,17 +55,21 @@ const DocumentsTable = ({
   );
 
   useEffect(() => {
-    setColumns(createColumns(documents, makeTranslation));
+    setColumns(
+      createColumns(documents, makeTranslation).sort(
+        (c1, c2) => c1.label.localeCompare(c2.label) > 0,
+      ),
+    );
   }, [documents]);
 
   return (
     <Table
-      columns={columns.sort((c1, c2) => c1.label > c2.label)}
+      columns={columns}
       currentPage={currentPage}
       customCellRenders={makeCustomCellRenders()}
       customHeaderCellRenders={makeCustomHeaderCellRenders()}
       data={documents || []}
-      hiddenColumns={hiddenColumns.sort((c1, c2) => c1.label > c2.label)}
+      hiddenColumns={hiddenColumns}
       loading={loading}
       openDetailedView={openDetailedView}
       order={order}


### PR DESCRIPTION
Previously, when a hidden column was marked as "visible" it broke the table by putting data in the wrong column.
Also, using localeCompare instead of a simple "sort" is more intl-friendly.

Also, when fetching all documents, if there is no document found, an appropriate error is returned.