### PR TITLE
[DOC DETAILS] Translate regions, subjects & document type

### DIFF
--- a/assets/js/react/pages/DocumentDetails/index.jsx
+++ b/assets/js/react/pages/DocumentDetails/index.jsx
@@ -65,7 +65,9 @@ const DocumentPage = ({
           },
           {
             label: formatMessage({ id: 'Document type' }),
-            value: details.documentType,
+            value:
+              details.documentType &&
+              formatMessage({ id: details.documentType }),
           },
           {
             label: formatMessage({ id: 'Publication date' }),
@@ -83,12 +85,22 @@ const DocumentPage = ({
           },
           {
             label: formatMessage({ id: 'Subjects' }),
-            value: details.subjects,
+            value: details.subjects.map((s) =>
+              formatMessage({
+                id: s.code,
+                defaultMessage: s.subject,
+              }),
+            ),
             type: 'list',
           },
           {
             label: formatMessage({ id: 'Regions' }),
-            value: details.regions,
+            value: details.regions.map((r) =>
+              formatMessage({
+                id: r.code,
+                defaultMessage: r.name,
+              }),
+            ),
             type: 'list',
           },
         ]}
@@ -165,8 +177,18 @@ DocumentPage.propTypes = {
     publicationDate: PropTypes.string,
     parentDocument: PropTypes.string,
     pages: PropTypes.string,
-    subjects: PropTypes.arrayOf(PropTypes.string),
-    regions: PropTypes.arrayOf(PropTypes.string),
+    subjects: PropTypes.arrayOf(
+      PropTypes.shape({
+        code: PropTypes.string,
+        subject: PropTypes.string,
+      }),
+    ),
+    regions: PropTypes.arrayOf(
+      PropTypes.shape({
+        code: PropTypes.string,
+        name: PropTypes.string,
+      }),
+    ),
   }),
   entities: PropTypes.shape({
     massif: PropTypes.string,

--- a/assets/js/react/pages/DocumentDetails/transformers.js
+++ b/assets/js/react/pages/DocumentDetails/transformers.js
@@ -48,19 +48,11 @@ export const makeDetails = (data) => {
     parentDocument: pipe(
       pathOr([], ['parent', 'titles']),
       head,
-      propOr('No title provided', 'text'),
+      propOr('', 'text'),
     )(data),
     pages: propOr('', 'pages', data),
-    subjects: pipe(
-      propOr([], 'subjects'),
-      map(propOr('', 'subject')),
-      reject(isEmpty),
-    )(data),
-    regions: pipe(
-      propOr([], 'regions'),
-      map(propOr('', 'name')),
-      reject(isEmpty),
-    )(data),
+    subjects: pipe(propOr([], 'subjects'), reject(isEmpty))(data),
+    regions: pipe(propOr([], 'regions'), reject(isEmpty))(data),
   };
 };
 


### PR DESCRIPTION
Pour les régoins et les sujets, dans **transformers.js**, il est nécessaire de conserver l'objet entier (et pas juste une string). 

En effet, on traduit grâce à l'attribut **code** mais si la traduction n'existe pas, il faut utiliser l'attribut **subject** (pour un sujet) ou l'attribut **name** (pour une région)