### PR TITLE
fix(#435) [QUICK SEARCH] Click on entrance result redirection

### DIFF
--- a/assets/js/react/features/QuickSearch.jsx
+++ b/assets/js/react/features/QuickSearch.jsx
@@ -41,7 +41,7 @@ const QuickSearch = ({
   const handleSelection = (selection) => {
     if (selection.id) {
       switch (selection.type) {
-        case 'entry':
+        case 'entrance':
           history.push(`/ui/entries/${encodeURIComponent(selection.id)}`);
           break;
         case 'massif':


### PR DESCRIPTION
### Fix #435 

"type" of an entrance result is "entrance" now, not "entry".