### PR TITLE
feat(cleanup): hides the columns prefixed with `@`

### DIFF
--- a/assets/js/react/components/common/Table/TableHead.jsx
+++ b/assets/js/react/components/common/Table/TableHead.jsx
@@ -1,5 +1,15 @@
 import { TableHead as MuiTableHead, TableRow } from '@material-ui/core';
-import { defaultTo, head, isNil, keys, map, pipe } from 'ramda';
+import {
+  __,
+  concat,
+  defaultTo,
+  filter,
+  head,
+  isNil,
+  keys,
+  map,
+  pipe,
+} from 'ramda';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -14,6 +24,13 @@ export const createColumns = (rawData, makeTranslation) => {
 
   return pipe(head, defaultTo({}), keys, map(makeColumn))(rawData);
 };
+
+export const createDefaultHiddenColumns = (columns, defaults) =>
+  pipe(
+    filter((column) => column.id[0] === '@'),
+    map((column) => column.id),
+    concat(__, defaults),
+  )(columns);
 
 const TableHead = ({
   visibleColumns,

--- a/assets/js/react/pages/Admin/UserList.jsx
+++ b/assets/js/react/pages/Admin/UserList.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
 import Table from '../../components/common/Table';
-import { createColumns } from '../../components/common/Table/TableHead';
+import {
+  createColumns,
+  createDefaultHiddenColumns,
+} from '../../components/common/Table/TableHead';
 
 // ==========
 const defaultHiddenColumns = ['groups'];
@@ -32,6 +35,10 @@ const UserList = ({ isLoading, title, userList }) => {
   useEffect(() => {
     setColumns(createColumns(userList, makeTranslation));
   }, [userList]);
+
+  useEffect(() => {
+    setHiddenColumns(createDefaultHiddenColumns(columns, defaultHiddenColumns));
+  }, [columns]);
 
   const userListOrdered = userList.sort((u1, u2) => {
     if (order === 'asc') {

--- a/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
+++ b/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
@@ -4,7 +4,10 @@ import { useIntl } from 'react-intl';
 import makeCustomCellRenders from './customCellRenders';
 import makeCustomHeaderCellRenders from './customHeaderCellRenders';
 import Table from '../../components/common/Table';
-import { createColumns } from '../../components/common/Table/TableHead';
+import {
+  createColumns,
+  createDefaultHiddenColumns,
+} from '../../components/common/Table/TableHead';
 
 const defaultHiddenColumns = [
   'author',
@@ -63,6 +66,10 @@ const DocumentsTable = ({
       ),
     );
   }, [documents]);
+
+  useEffect(() => {
+    setHiddenColumns(createDefaultHiddenColumns(columns, defaultHiddenColumns));
+  }, [columns]);
 
   return (
     <Table

--- a/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
+++ b/assets/js/react/pages/DocumentValidation/DocumentsTable.jsx
@@ -23,6 +23,7 @@ const defaultHiddenColumns = [
   'id',
   'identifier',
   'identifierType',
+  'isValidated',
   'library',
   'license',
   'massif',
@@ -33,6 +34,8 @@ const defaultHiddenColumns = [
   'publicationFasciculeBBSOld',
   'refBbs',
   'reviewer',
+  'validationComment',
+  'validator',
 ];
 
 const DocumentsTable = ({


### PR DESCRIPTION
For UserList and DocumentsTable only: if a column's ID starts with `@` it will be automatically added to the default hidden columns.
Closes issue #500 