### PR TITLE
[RIGHT CHECKER] Fix right syntax research in database + log error

### DIFF
--- a/api/helpers/check-right.js
+++ b/api/helpers/check-right.js
@@ -40,21 +40,14 @@ module.exports = {
   fn: async function(inputs, exits) {
     TRight.findOne()
       .where({
-        and: [
-          {
-            name: {
-              contains: inputs.rightEntity,
-            },
-          },
-          {
-            name: {
-              contains: inputs.rightAction,
-            },
-          },
-        ],
+        name: inputs.rightEntity + ' - ' + inputs.rightAction,
       })
       .populate('groups')
       .exec((err, rightFound) => {
+        if (err) {
+          sails.log.error(err.message);
+          return exits.success(false);
+        }
         if (!rightFound) {
           throw exits.rightNotFound();
         }


### PR DESCRIPTION
A right in the database has ALWAYS the following syntax : 

**ENTITY - ACTION**

**Examples:**

- *Caver - view any*
- *Cave - delete  any*