### PR TITLE
[ENTRANCE API] Add delete route

### DIFF
--- a/api/controllers/EntranceController.js
+++ b/api/controllers/EntranceController.js
@@ -5,6 +5,8 @@
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 
+const esCli = require('../../config/elasticsearch').elasticsearchCli;
+
 module.exports = {
   find: (req, res, converter) => {
     TEntrance.findOne(req.params.id)
@@ -107,5 +109,50 @@ module.exports = {
       count.count = found;
       return ControllerService.treat(req, err, count, params, res);
     });
+  },
+
+  delete: async (req, res) => {
+    const hasRight = await sails.helpers.checkRight
+      .with({
+        groups: req.token.groups,
+        rightEntity: RightService.RightEntities.ENTRANCE,
+        rightAction: RightService.RightActions.DELETE_ANY,
+      })
+      .intercept('rightNotFound', (err) => {
+        return res.serverError(
+          'A server error occured when checking your right to delete an entrance.',
+        );
+      });
+    if (!hasRight) {
+      return res.forbidden('You are not authorized to delete an entrance.');
+    }
+
+    // Check if entrance exists and if it's not already deleted
+    const entranceId = req.param('id');
+    const currentEntrance = await TEntrance.findOne(entranceId);
+    if (currentEntrance) {
+      if (currentEntrance.isDeleted) {
+        return res.status(410).send({
+          message: `The entrance with id ${entranceId} has already been deleted.`,
+        });
+      }
+    } else {
+      return res.status(404).send({
+        message: `Entrance of id ${entranceId} not found.`,
+      });
+    }
+
+    // Delete Entrance
+    const updatedEntrance = await TEntrance.destroyOne({
+      id: entranceId,
+    }).intercept((err) => {
+      return res.serverError(
+        `An unexpected error occured when trying to delete entrance with id ${entranceId}.`,
+      );
+    });
+
+    ElasticsearchService.deleteResource('entrances', entranceId);
+
+    return res.sendStatus(204);
   },
 };

--- a/api/controllers/v1/EntranceController.js
+++ b/api/controllers/v1/EntranceController.js
@@ -34,4 +34,8 @@ module.exports = {
       MappingV1Service.convertToCountResultModel,
     );
   },
+
+  delete: (req, res) => {
+    entranceController.delete(req, res);
+  },
 };

--- a/api/models/TEntrance.js
+++ b/api/models/TEntrance.js
@@ -151,6 +151,13 @@ module.exports = {
       columnName: 'is_of_interest',
     },
 
+    isDeleted: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_deleted',
+      defaultsTo: false,
+    },
+
     cave: {
       columnName: 'id_cave',
       model: 'TCave',

--- a/api/services/ControllerService.js
+++ b/api/services/ControllerService.js
@@ -13,7 +13,6 @@ module.exports = {
       sails.log.debug(parameters.notFoundMessage);
       return res.notFound();
     }
-    ElasticSearch.updateIndex(found, req);
     return res.json(found);
   },
 
@@ -85,11 +84,9 @@ module.exports = {
         `<${first}>; rel="first",  <${prev}>; rel="prev", <${next}>; rel="next",  <${last}>; rel="last"`,
       );
 
-      ElasticSearch.updateIndex(found, req);
       return res.json(206, converter(found));
     }
 
-    ElasticSearch.updateIndex(found, req);
     return res.json(converter(found));
   },
 };

--- a/api/services/ElasticsearchService.js
+++ b/api/services/ElasticsearchService.js
@@ -32,6 +32,24 @@ const FUZZINESS = 1;
 // eslint-disable-next-line no-multi-assign
 const self = (module.exports = {
   /**
+   * Delete a resource indexed by Elasticsearch. No check performed on the parameters given.
+   * The action is asynchronous and if an error occurs, it will simply logged.
+   * @param {string} indexName  An Elasticsearch index (@see ElasticsearchService indexNames)
+   * @param {string} resourceId The id of the resource to delete.
+   */
+  deleteResource: (indexName, resourceId) => {
+    try {
+      client.delete({
+        // Asynchronous operation
+        index: indexName + '-index',
+        type: 'data',
+        id: resourceId,
+      });
+    } catch (error) {
+      sails.log.error(error);
+    }
+  },
+  /**
    * Retrieve data from elasticsearch on various index according to a string.
    * The indexes used are: ['grottos', 'entrances', 'massifs', 'documents', 'cavers'] (document-collections and document-issues are excluded by default)
    * Params should contain an attribute 'query': others params are facultative.

--- a/api/services/ElasticsearchService.js
+++ b/api/services/ElasticsearchService.js
@@ -32,68 +32,6 @@ const FUZZINESS = 1;
 // eslint-disable-next-line no-multi-assign
 const self = (module.exports = {
   /**
-   * Update the Elasticsearch index according to the request.
-   * @param {*} found resource to be updated
-   * @param {*} req req object of the client
-   */
-  updateIndex: (found, req) => {
-    const { url, verb } = req;
-
-    // Parse request resource
-    const urlPieces = url.split('/');
-
-    // Resource name is right after "/api/"
-    let i = 0;
-    let resourceIndex = -1;
-    while (resourceIndex === -1 && i < urlPieces.length) {
-      if (urlPieces[i] === 'api') {
-        // eslint-disable-next-line no-unused-expressions
-        advancedSearchMetaParams;
-        resourceIndex = i + 1;
-      }
-      i += 1;
-    }
-
-    if (resourceIndex === -1) {
-      sails.log.info('Resource not found');
-      return;
-    }
-
-    const resourceName = urlPieces[resourceIndex];
-    // Update index resources appropriately
-    if (indexNames.includes(resourceName)) {
-      if (verb === 'PUT') {
-        // Asynchronous operation, no callback
-        client.update({
-          index: `${resourceName}-index`,
-          type: resourceName,
-          id: found.id,
-          body: found,
-        });
-      }
-
-      if (verb === 'POST') {
-        // Asynchronous operation, no callback
-        client.create({
-          index: `${resourceName}-index`,
-          type: resourceName,
-          id: found.id,
-          body: found,
-        });
-      }
-
-      if (verb === 'DELETE') {
-        // Asynchronous operation, no callback
-        client.delete({
-          index: `${resourceName}-index`,
-          type: resourceName,
-          id: found.id,
-        });
-      }
-    }
-  },
-
-  /**
    * Retrieve data from elasticsearch on various index according to a string.
    * The indexes used are: ['grottos', 'entrances', 'massifs', 'documents', 'cavers'] (document-collections and document-issues are excluded by default)
    * Params should contain an attribute 'query': others params are facultative.

--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -909,6 +909,25 @@ paths:
                 $ref: '#/components/schemas/Entrance'
         '404':
           description: Entrance not found.
+  
+    delete:
+      tags:
+      - entrances
+      description: Delete an entrance.
+      parameters:
+      - name: id
+        in: path
+        description: Entrance id
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Successful operation
+        '404':
+          description: Entrance not found.
+        '410':
+          description: Entrance already deleted.
 
   '/entrances/publicCount':
     get:

--- a/config/policies.js
+++ b/config/policies.js
@@ -63,6 +63,7 @@ module.exports.policies = {
   'v1/EntranceController': {
     '*': false,
     count: true,
+    delete: ['tokenAuth', 'moderatorAuth'],
     find: 'apiKeyAuth',
     findAll: ['apiKeyAuth', 'paginate'],
     findRandom: true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -113,6 +113,7 @@ module.exports.routes = {
   'PUT /api/v1/cavers/:caverId/groups/:groupId': 'v1/Caver.putOnGroup',
 
   /* Entrance controller */
+  'DELETE /api/v1/entrances/:id': 'v1/Entrance.delete',
   'GET /api/v1/entrances/count': 'v1/Entrance.count',
   'GET /api/v1/entrances/findRandom': 'v1/Entrance.findRandom',
   'GET /api/v1/entrances/publicCount': {


### PR DESCRIPTION
Where an entrance is deleted, the controller checks if :
- the user can delete it
- the entrance is not already deleted

Then it performs the delete action, which fires the historization database triggers. Finally, it tries to delete the entrance from Elasticsearch: this can fail silently because I don't want to return an error to the user just for this. Additionally, Elasticsearch is updated every day. If a deletion doesn't work, it will be performed in the incoming 24h.

Also, I have deleted the *ElasticsearchService.updateIndex()* method. updateIndex() was never used and can't work in the way it's implemented (automatically deduce the action to perform by looking only at the request).
