### PR TITLE
[ENTRANCE API] For sensitive entrances, show info depending on user rights

### DIFF
--- a/api/policies/facultativeTokenAuth.js
+++ b/api/policies/facultativeTokenAuth.js
@@ -1,0 +1,28 @@
+/**
+ * facultativeTokenAuth
+ *
+ * @module      :: Policy
+ * @description :: Facultative JSON Web Token authentication. If there is no token provided, keep going.
+ * @docs        :: http://sailsjs.org/#!documentation/policies
+ *
+ */
+module.exports = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next();
+  }
+
+  const token = authHeader.substring(7, authHeader.length);
+
+  if (token) {
+    TokenService.verify(token, (err, responseToken) => {
+      if (err) {
+        return res.forbidden('Invalid Token');
+      }
+      req.token = responseToken; // This is the decrypted token or the payload you provided
+      return next();
+    });
+  } else {
+    return next();
+  }
+};

--- a/api/services/RightService.js
+++ b/api/services/RightService.js
@@ -23,6 +23,7 @@ module.exports = {
     EDIT_OWN: 'edit own',
     MERGE_DUPLICATES: 'merge duplicates',
     VIEW_ANY: 'view any',
+    VIEW_COMPLETE: 'view complete',
     VIEW_LIMITED: 'view limited',
   },
 };

--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -1220,7 +1220,11 @@ paths:
     get:
       tags:
       - entrances
-      description: Get an entrance by id. If the entrance is sensitive (i.e. not public), the locations, logintude and latitude attributes are not returned.
+      description: |
+        Get an entrance by id. If the entrance is sensitive (i.e. not public):
+        - if you are an unauthenticated visitor, you will not be able to get it.
+        - if you are an authenticated Grottocenter user, you will be able to get the entrance information but the fields "longitude", "latitude" and "locations" will be hidden.
+        - if you are an authenticated Grottocenter administrator, you will be able to get all the information.
       parameters:
       - name: id
         in: path
@@ -1235,6 +1239,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Entrance'
+        '403':
+          description: You are not authorized to view the entrance.
         '404':
           description: Entrance not found.
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -68,7 +68,7 @@ module.exports.policies = {
     count: true,
     create: 'tokenAuth',
     delete: ['tokenAuth', 'moderatorAuth'],
-    find: 'apiKeyAuth',
+    find: 'facultativeTokenAuth',
     findAll: ['apiKeyAuth', 'paginate'],
     findRandom: true,
     publicCount: true,


### PR DESCRIPTION
1. Client is a visitor => hide the entrance => return a "forbidden" response
2. Client is an authenticated user => show the entrance without longitude, latitude & locations
3. Client is an authenticated administrator => show the whole entrance

I have added a new policy called *facultativeTokenAuth*. It parses the auth token if present. If it is not present, it keeps going.