### PR TITLE
[NAME API] Set as main api route

### DIFF
--- a/api/controllers/NameController.js
+++ b/api/controllers/NameController.js
@@ -86,10 +86,119 @@ module.exports = {
       .populate('grotto')
       .populate('language')
       .populate('massif')
+      .populate('point')
       .populate('reviewer');
 
     const params = {};
     params.controllerMethod = 'NameController.update';
+    return ControllerService.treatAndConvert(
+      req,
+      null,
+      newName,
+      params,
+      res,
+      converter,
+    );
+  },
+
+  updateIsMain: async (req, res, converter) => {
+    // Check right
+    const hasRightOnAny = await sails.helpers.checkRight
+      .with({
+        groups: req.token.groups,
+        rightEntity: RightService.RightEntities.NAME,
+        rightAction: RightService.RightActions.EDIT_ANY,
+      })
+      .intercept('rightNotFound', (err) => {
+        return res.serverError(
+          'A server error occured when checking your right to update any name.',
+        );
+      });
+
+    // Check if name exists
+    const nameId = req.param('id');
+    const currentName = await TName.findOne(nameId);
+    if (!currentName) {
+      return res.status(404).send({
+        message: `Name of id ${nameId} not found.`,
+      });
+    }
+
+    const newIsMainValue = req.param('isMain');
+    if (newIsMainValue !== true && newIsMainValue !== false) {
+      return res.badRequest(
+        `You must provide an isMain value ('true' or 'false').`,
+      );
+    }
+
+    // Launch update request
+    const updatedName = await TName.updateOne({
+      id: nameId,
+    })
+      .set({ isMain: newIsMainValue })
+      .intercept('E_UNIQUE', (e) => {
+        sails.log.error(e.message);
+        return res.status(409).send(e.message);
+      })
+      .intercept({ name: 'UsageError' }, (e) => {
+        sails.log.error(e.message);
+        return res.badRequest(e.message);
+      })
+      .intercept({ name: 'AdapterError' }, (e) => {
+        sails.log.error(e.message);
+        return res.badRequest(e.message);
+      })
+      .intercept((e) => {
+        sails.log.error(e.message);
+        return res.serverError(e.message);
+      });
+
+    // If it's true, update other names of the entity to isMain = false
+    if (newIsMainValue === true) {
+      const possibleEntites = [
+        { id: updatedName.cave, type: 'cave' },
+        { id: updatedName.entrance, type: 'entrance' },
+        { id: updatedName.grotto, type: 'grotto' },
+        { id: updatedName.massif, type: 'massif' },
+        { id: updatedName.point, type: 'point' },
+      ];
+      const entity = possibleEntites.find((e) => e.id !== null);
+      await TName.update({
+        [entity.type]: entity.id,
+        id: { '!=': updatedName.id },
+      })
+        .set({ isMain: false })
+        .intercept('E_UNIQUE', (e) => {
+          sails.log.error(e.message);
+          return res.status(409).send(e.message);
+        })
+        .intercept({ name: 'UsageError' }, (e) => {
+          sails.log.error(e.message);
+          return res.badRequest(e.message);
+        })
+        .intercept({ name: 'AdapterError' }, (e) => {
+          sails.log.error(e.message);
+          return res.badRequest(e.message);
+        })
+        .intercept((e) => {
+          sails.log.error(e.message);
+          return res.serverError(e.message);
+        });
+    }
+
+    // Return name updated and populated
+    const newName = await TName.findOne(nameId)
+      .populate('author')
+      .populate('cave')
+      .populate('entrance')
+      .populate('grotto')
+      .populate('language')
+      .populate('massif')
+      .populate('point')
+      .populate('reviewer');
+
+    const params = {};
+    params.controllerMethod = 'NameController.updateIsMain';
     return ControllerService.treatAndConvert(
       req,
       null,

--- a/api/controllers/NameController.js
+++ b/api/controllers/NameController.js
@@ -8,7 +8,7 @@
 module.exports = {
   update: async (req, res, converter) => {
     // Check right
-    const hasRightOnAny = await sails.helpers.checkRight
+    const hasRight = await sails.helpers.checkRight
       .with({
         groups: req.token.groups,
         rightEntity: RightService.RightEntities.NAME,
@@ -20,17 +20,9 @@ module.exports = {
         );
       });
 
-    const hasRightOnOwn = await sails.helpers.checkRight
-      .with({
-        groups: req.token.groups,
-        rightEntity: RightService.RightEntities.NAME,
-        rightAction: RightService.RightActions.EDIT_OWN,
-      })
-      .intercept('rightNotFound', (err) => {
-        return res.serverError(
-          'A server error occured when checking your right to update your names.',
-        );
-      });
+    if (!hasRight) {
+      return res.forbidden('You are not authorized to update any name.');
+    }
 
     // Check if name exists
     const nameId = req.param('id');
@@ -43,19 +35,7 @@ module.exports = {
 
     const cleanedData = {
       name: req.param('name'),
-      isMain: req.param('isMain'),
     };
-
-    // Check right on this particular name
-    if (!hasRightOnAny) {
-      if (hasRightOnOwn) {
-        if (req.token.id !== currentName.author) {
-          return res.forbidden("You can not update a name you didn't created.");
-        }
-      } else {
-        return res.forbidden('You can not update a name.');
-      }
-    }
 
     // Launch update request
     const updatedName = await TName.updateOne({
@@ -101,9 +81,9 @@ module.exports = {
     );
   },
 
-  updateIsMain: async (req, res, converter) => {
+  setAsMain: async (req, res, converter) => {
     // Check right
-    const hasRightOnAny = await sails.helpers.checkRight
+    const hasRight = await sails.helpers.checkRight
       .with({
         groups: req.token.groups,
         rightEntity: RightService.RightEntities.NAME,
@@ -114,6 +94,9 @@ module.exports = {
           'A server error occured when checking your right to update any name.',
         );
       });
+    if (!hasRight) {
+      return res.forbidden('You are not authorized to update any name.');
+    }
 
     // Check if name exists
     const nameId = req.param('id');
@@ -124,10 +107,17 @@ module.exports = {
       });
     }
 
-    const newIsMainValue = req.param('isMain');
-    if (newIsMainValue !== true && newIsMainValue !== false) {
-      return res.badRequest(
-        `You must provide an isMain value ('true' or 'false').`,
+    // Do nothing if already main
+    if (currentName.isMain) {
+      const params = {};
+      params.controllerMethod = 'NameController.setAsMain';
+      return ControllerService.treatAndConvert(
+        req,
+        null,
+        currentName,
+        params,
+        res,
+        converter,
       );
     }
 
@@ -135,7 +125,7 @@ module.exports = {
     const updatedName = await TName.updateOne({
       id: nameId,
     })
-      .set({ isMain: newIsMainValue })
+      .set({ isMain: true })
       .intercept('E_UNIQUE', (e) => {
         sails.log.error(e.message);
         return res.status(409).send(e.message);
@@ -153,38 +143,36 @@ module.exports = {
         return res.serverError(e.message);
       });
 
-    // If it's true, update other names of the entity to isMain = false
-    if (newIsMainValue === true) {
-      const possibleEntites = [
-        { id: updatedName.cave, type: 'cave' },
-        { id: updatedName.entrance, type: 'entrance' },
-        { id: updatedName.grotto, type: 'grotto' },
-        { id: updatedName.massif, type: 'massif' },
-        { id: updatedName.point, type: 'point' },
-      ];
-      const entity = possibleEntites.find((e) => e.id !== null);
-      await TName.update({
-        [entity.type]: entity.id,
-        id: { '!=': updatedName.id },
+    // Update other names of the entity to isMain = false
+    const possibleEntites = [
+      { id: updatedName.cave, type: 'cave' },
+      { id: updatedName.entrance, type: 'entrance' },
+      { id: updatedName.grotto, type: 'grotto' },
+      { id: updatedName.massif, type: 'massif' },
+      { id: updatedName.point, type: 'point' },
+    ];
+    const entity = possibleEntites.find((e) => e.id !== null);
+    await TName.update({
+      [entity.type]: entity.id,
+      id: { '!=': updatedName.id },
+    })
+      .set({ isMain: false })
+      .intercept('E_UNIQUE', (e) => {
+        sails.log.error(e.message);
+        return res.status(409).send(e.message);
       })
-        .set({ isMain: false })
-        .intercept('E_UNIQUE', (e) => {
-          sails.log.error(e.message);
-          return res.status(409).send(e.message);
-        })
-        .intercept({ name: 'UsageError' }, (e) => {
-          sails.log.error(e.message);
-          return res.badRequest(e.message);
-        })
-        .intercept({ name: 'AdapterError' }, (e) => {
-          sails.log.error(e.message);
-          return res.badRequest(e.message);
-        })
-        .intercept((e) => {
-          sails.log.error(e.message);
-          return res.serverError(e.message);
-        });
-    }
+      .intercept({ name: 'UsageError' }, (e) => {
+        sails.log.error(e.message);
+        return res.badRequest(e.message);
+      })
+      .intercept({ name: 'AdapterError' }, (e) => {
+        sails.log.error(e.message);
+        return res.badRequest(e.message);
+      })
+      .intercept((e) => {
+        sails.log.error(e.message);
+        return res.serverError(e.message);
+      });
 
     // Return name updated and populated
     const newName = await TName.findOne(nameId)
@@ -198,7 +186,7 @@ module.exports = {
       .populate('reviewer');
 
     const params = {};
-    params.controllerMethod = 'NameController.updateIsMain';
+    params.controllerMethod = 'NameController.setAsMain';
     return ControllerService.treatAndConvert(
       req,
       null,

--- a/api/controllers/v1/NameController.js
+++ b/api/controllers/v1/NameController.js
@@ -6,4 +6,6 @@ const nameController = require('../NameController');
 module.exports = {
   update: (req, res) =>
     nameController.update(req, res, MappingV1Service.convertToNameModel),
+  updateIsMain: (req, res) =>
+    nameController.updateIsMain(req, res, MappingV1Service.convertToNameModel),
 };

--- a/api/controllers/v1/NameController.js
+++ b/api/controllers/v1/NameController.js
@@ -6,6 +6,6 @@ const nameController = require('../NameController');
 module.exports = {
   update: (req, res) =>
     nameController.update(req, res, MappingV1Service.convertToNameModel),
-  updateIsMain: (req, res) =>
-    nameController.updateIsMain(req, res, MappingV1Service.convertToNameModel),
+  setAsMain: (req, res) =>
+    nameController.setAsMain(req, res, MappingV1Service.convertToNameModel),
 };

--- a/api/models/TEntrance.js
+++ b/api/models/TEntrance.js
@@ -164,6 +164,7 @@ module.exports = {
 
     precision: {
       type: 'number',
+      allowNull: true,
       columnName: 'precision',
       columnType: 'int2',
     },

--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -73,6 +73,7 @@ module.exports = {
     result.dateInscription = source.dateInscription;
     result.dateReviewed = source.dateReviewed;
     result.id = source.id;
+    result.isMain = source.isMain;
     result.language = source.language;
     result.name = source.name;
     result.point = source.point;

--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -986,7 +986,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Name'
-    
+  
+  '/names/{id}/isMain':
+    patch:
+      tags:
+        - names
+      description: Update a name isMain property. An entity can have multiples names, in different languages for example. But only one of them is the main one. If you set a name isMain attribute to true, all the other names of the entity isMain will be set to false.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: isMain
+          in: query
+          required: true
+          schema:
+            type: boolean
+      
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Name'
+                
   '/account/email':
     patch:
       tags:

--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -961,7 +961,7 @@ paths:
     patch:
       tags:
         - names
-      description: Update a name. You must provide a name and isMain values even if you are changing only one of the two. If you are an user, you can only update a name you previously created.
+      description: Update a name.
       parameters:
         - name: id
           in: path
@@ -973,11 +973,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: isMain
-          in: query
-          required: true
-          schema:
-            type: boolean
       
       responses:
         '200':
@@ -987,22 +982,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Name'
   
-  '/names/{id}/isMain':
-    patch:
+  '/names/{id}/setAsMain':
+    post:
       tags:
         - names
-      description: Update a name isMain property. An entity can have multiples names, in different languages for example. But only one of them is the main one. If you set a name isMain attribute to true, all the other names of the entity isMain will be set to false.
+      description: Set a name to the main one. An entity can have multiples names, in different languages for example. But only one of them is the main one. If you set a name to main, all the other names of the entity isMain will be set to false.
       parameters:
         - name: id
           in: path
           required: true
           schema:
             type: string
-        - name: isMain
-          in: query
-          required: true
-          schema:
-            type: boolean
       
       responses:
         '200':

--- a/config/policies.js
+++ b/config/policies.js
@@ -86,8 +86,8 @@ module.exports.policies = {
   },
 
   'v1/NameController': {
+    setAsMain: 'tokenAuth',
     update: 'tokenAuth',
-    updateIsMain: 'tokenAuth',
   },
 
   SearchController: {

--- a/config/policies.js
+++ b/config/policies.js
@@ -87,6 +87,7 @@ module.exports.policies = {
 
   'v1/NameController': {
     update: 'tokenAuth',
+    updateIsMain: 'tokenAuth',
   },
 
   SearchController: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -221,7 +221,7 @@ module.exports.routes = {
 
   /* Name controller */
   'PATCH /api/v1/names/:id': 'v1/Name.update',
-  'PUT /api/v1/names/:id/isMain': 'v1/Name.updateIsMain',
+  'POST /api/v1/names/:id/setAsMain': 'v1/Name.setAsMain',
 
   /* Document Subject controller */
   'GET /api/v1/documents/subjects': {

--- a/config/routes.js
+++ b/config/routes.js
@@ -221,6 +221,7 @@ module.exports.routes = {
 
   /* Name controller */
   'PATCH /api/v1/names/:id': 'v1/Name.update',
+  'PUT /api/v1/names/:id/isMain': 'v1/Name.updateIsMain',
 
   /* Document Subject controller */
   'GET /api/v1/documents/subjects': {


### PR DESCRIPTION
- N'importe qui peut rendre un name "main".
- Tous les autres names se référant à la même entité (cave, entrance, massif, grotto, point) voient leur isMain passer à `false`. Cela permet de préserver l'unicité du isMain pour une entité donnée.