### PR TITLE
fix(search): add special char to ignore

### DIFF
--- a/api/services/ElasticsearchService.js
+++ b/api/services/ElasticsearchService.js
@@ -282,10 +282,8 @@ const self = (module.exports = {
    */
    sanitizeQuery: (sourceString) => {
     // eslint-disable-next-line no-useless-escape
-    sourceString.replace(/[`~!@#$%^&*()_|+\-=?;:",<>«»\{\}\[\]\/\\]/gi, ' ')
-    if(sourceString[sourceString.length-1] === '.'){
-      sourceString = sourceString.slice(0, -1);
-    }
+    sourceString.replace(/[`~!@#$%^&*()_|+\-=?;:",<>«»\{\}\[\]\/\\]/gi, ' ');
+    sourceString = sourceString[sourceString.length-1] === '.' ? sourceString.slice(0, -1) : sourceString;
     return sourceString;
    },
 });

--- a/api/services/ElasticsearchService.js
+++ b/api/services/ElasticsearchService.js
@@ -280,7 +280,12 @@ const self = (module.exports = {
    * Replace all special characters from a source string by a space.
    * @param {*} sourceString
    */
-  sanitizeQuery: (sourceString) =>
+   sanitizeQuery: (sourceString) => {
     // eslint-disable-next-line no-useless-escape
-    sourceString.replace(/[`~!@#$%^&*()_|+\-=?;:",<>\{\}\[\]\/]/gi, ' '),
+    sourceString.replace(/[`~!@#$%^&*()_|+\-=?;:",<>«»\{\}\[\]\/\\]/gi, ' ')
+    if(sourceString[sourceString.length-1] === '.'){
+      sourceString = sourceString.slice(0, -1);
+    }
+    return sourceString;
+   },
 });


### PR DESCRIPTION
- Add french quote mark and backslash to the special characters we must ignore
- Remove the last dot of a search query, if there is any. If you add it, even if the field (title or description) possesses such dot at the end, it couldn't be found.