### PR TITLE
fix(newDoc): store null publication date

### DIFF
--- a/api/controllers/DocumentController.js
+++ b/api/controllers/DocumentController.js
@@ -32,7 +32,7 @@ const getConvertedDataFromClient = (req) => {
     ...reqBodyWithoutId,
     author: req.token.id,
     authors: req.body.authors ? req.body.authors.map((a) => a.id) : undefined,
-    datePublication: req.body.publicationDate,
+    datePublication: req.body.publicationDate === "" ? null : req.body.publicationDate,
     editor: ramda.pathOr(undefined, ['editor', 'id'], req.body),
     identifierType: ramda.pathOr(undefined, ['identifierType', 'id'], req.body),
     library: ramda.pathOr(undefined, ['library', 'id'], req.body),


### PR DESCRIPTION
Fix the issue that prevents a new document to be searchable if the publication date is not provided.