### PR TITLE
fix(cors): allow authorization header

### DIFF
--- a/config/security.js
+++ b/config/security.js
@@ -30,6 +30,7 @@ module.exports.security = {
     allRoutes: true,
     allowOrigins: '*',
     allowCredentials: false,
+    allowRequestHeaders: 'content-type, authorization',
   },
   /****************************************************************************
    *                                                                           *


### PR DESCRIPTION
Autorise la présence du header authorization pour les requêtes venant du nouveau front (ou autres). Nécessaire pour pouvoir effectuer des actions qui nécessitent d'être connecté.