### PR TITLE
fix(nameService): fix retrieve cave name

### DIFF
--- a/api/services/NameService.js
+++ b/api/services/NameService.js
@@ -16,9 +16,14 @@ module.exports = {
         //    the name of the cave is the same as its entrance.
         if (Array.isArray(entity.names) && entity.names.length === 0) {
           if (entitiesType === 'cave') {
-            entity.names = await TName.find().where({
-              entrance: entity.entrances[0].id,
-            });
+            const relatedEntrance = await TEntrance.find({
+              cave: entity.id,
+            }).limit(1);
+            entity.names = relatedEntrance[0]
+              ? await TName.find().where({
+                  entrance: relatedEntrance[0].id,
+                })
+              : [];
           }
         }
         const mainName = entity.names.find((n) => n.isMain);


### PR DESCRIPTION
Si la cave n'a pas de noms, on ne pouvait pas récupérer celle de l'entrée, car entrance n'est pas un attribut de cave à moins de populate cave (mais c'est pas toujours le cas, notamment dans find de DocumentController)