### PR TITLE
[ENTRANCE API] Populate all authors for child data

### DIFF
--- a/api/services/ErrorService.js
+++ b/api/services/ErrorService.js
@@ -1,0 +1,21 @@
+module.exports = {
+  /**
+   * @returns {Function} default Grottocenter ORM error handler
+   */
+  getDefaultOrmErrorHandler: () => {
+    return (error) => {
+      if (error.code && error.code === 'E_UNIQUE') {
+        return res.sendStatus(409);
+      } else {
+        switch (error.name) {
+          case 'UsageError':
+            return res.badRequest(error.message);
+          case 'AdapterError':
+            return res.badRequest(error.message);
+          default:
+            return res.serverError(error.message);
+        }
+      }
+    };
+  },
+};

--- a/api/services/MappingV1Service.js
+++ b/api/services/MappingV1Service.js
@@ -296,8 +296,8 @@ module.exports = {
     result.names = source.names;
     result.temperature = source.temperature;
 
-    if (source.author instanceof Object) {
-      result.author = MappingV1Service.convertToCaverModel(source.author);
+    if (source.id_author instanceof Object) {
+      result.author = MappingV1Service.convertToCaverModel(source.id_author);
     }
     if (source.reviewer instanceof Object) {
       result.reviewer = MappingV1Service.convertToCaverModel(source.reviewer);


### PR DESCRIPTION
I think it will be a good idea to refactor a lot of code similar to `CaverService.getCaver()` new function. 

The use of the `defaultOrmHandler()` is very convenient (thanks to Axel for inspiring me !)  + we will be able to deep populate a lot of things easily.