### PR TITLE
[ELASTICSEARCH REFACTOR]  remove unused esClient

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -6,7 +6,6 @@
  */
 
 const passport = require('passport');
-const esClient = require('../../config/elasticsearch').elasticsearchCli;
 const { tokenSalt } = AuthService;
 const PASSWORD_MIN_LENGTH = 8;
 

--- a/api/controllers/CaverController.js
+++ b/api/controllers/CaverController.js
@@ -426,7 +426,6 @@ module.exports = {
     const newCaver = await CaverService.createNonUserCaver(
       paramsCaver,
       handleError,
-      esClient,
     );
 
     const params = {};

--- a/api/controllers/DocumentController.js
+++ b/api/controllers/DocumentController.js
@@ -5,7 +5,6 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
-const esClient = require('../../config/elasticsearch').elasticsearchCli;
 const ramda = require('ramda');
 const getCountryISO3 = require('country-iso-2-to-3');
 
@@ -225,7 +224,6 @@ const getConvertedDocumentFromCsv = async (rawData, authorId) => {
             paramsGrotto,
             nameGrotto,
             (err) => err,
-            esClient,
           );
           editorId = editorGrotto.id;
           break;

--- a/api/controllers/EntranceController.js
+++ b/api/controllers/EntranceController.js
@@ -5,7 +5,6 @@
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 const ramda = require('ramda');
-const esClient = require('../../config/elasticsearch').elasticsearchCli;
 const getCountryISO3 = require('country-iso-2-to-3');
 
 // Extract everything from the request body except id
@@ -547,7 +546,6 @@ module.exports = {
       cleanedData,
       nameDescLocData,
       handleError(res),
-      esClient,
     );
 
     const params = {};
@@ -903,7 +901,6 @@ module.exports = {
             dataEntrance,
             dataNameDescLoc,
             handleError,
-            esClient,
           );
           if (
             doubleCheck({

--- a/api/controllers/GrottoController.js
+++ b/api/controllers/GrottoController.js
@@ -5,7 +5,6 @@
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 
-const esClient = require('../../config/elasticsearch').elasticsearchCli;
 const ramda = require('ramda');
 
 // Extract everything from the request body except id
@@ -165,7 +164,6 @@ module.exports = {
       cleanedData,
       nameData,
       handleError,
-      esClient,
     );
 
     const params = {};

--- a/api/controllers/MassifController.js
+++ b/api/controllers/MassifController.js
@@ -5,7 +5,6 @@
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 const ramda = require('ramda');
-const esClient = require('../../config/elasticsearch').elasticsearchCli;
 
 module.exports = {
   find: (req, res, next, converter = MappingV1Service.convertToMassifModel) => {

--- a/api/helpers/CsvHelpers/get-author.js
+++ b/api/helpers/CsvHelpers/get-author.js
@@ -1,5 +1,3 @@
-const esClient = require('../../../config/elasticsearch').elasticsearchCli;
-
 module.exports = {
   friendlyName: 'Author getter',
 
@@ -59,7 +57,6 @@ module.exports = {
       const newCaver = await CaverService.createNonUserCaver(
         caverParams,
         (error) => error,
-        esClient,
       );
       authorId = newCaver.id;
     } else {

--- a/api/helpers/CsvHelpers/get-creator.js
+++ b/api/helpers/CsvHelpers/get-creator.js
@@ -1,5 +1,3 @@
-const esClient = require('../../../config/elasticsearch').elasticsearchCli;
-
 module.exports = {
   friendlyName: 'Creator getter',
 
@@ -47,7 +45,6 @@ module.exports = {
         caver = await CaverService.createNonUserCaver(
           paramsCaver,
           (error) => error,
-          esClient,
         );
         break;
       default:

--- a/api/services/CaverService.js
+++ b/api/services/CaverService.js
@@ -19,7 +19,7 @@ module.exports = {
     return Number(result.rows[0]['?column?']);
   },
 
-  createNonUserCaver: async (caverData, errorHandler, esClient) => {
+  createNonUserCaver: async (caverData, errorHandler) => {
     let nickname = ramda.propOr('', 'nickname', caverData);
     const name = ramda.propOr(undefined, 'name', caverData);
     const surname = ramda.propOr(undefined, 'surname', caverData);

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -63,12 +63,7 @@ module.exports = {
     return allEntrances;
   },
 
-  createEntrance: async (
-    entranceData,
-    nameDescLocData,
-    errorHandler,
-    esClient,
-  ) => {
+  createEntrance: async (entranceData, nameDescLocData, errorHandler) => {
     const newEntrancePopulated = await sails
       .getDatastore()
       .transaction(async (db) => {

--- a/api/services/GrottoService.js
+++ b/api/services/GrottoService.js
@@ -1,7 +1,7 @@
 const ramda = require('ramda');
 
 module.exports = {
-  createGrotto: async (cleanedData, nameData, errorHandler, esClient) => {
+  createGrotto: async (cleanedData, nameData, errorHandler) => {
     const newOrganizationPopulated = await sails
       .getDatastore()
       .transaction(async (db) => {


### PR DESCRIPTION
A previous commit removed esClient usage when calling services but I forgot to remove it from the controllers.