### PR TITLE
[ELASTICSEARCH LOGS] Reduce log level from "trace" to "debug"

### DIFF
--- a/config/elasticsearch.js
+++ b/config/elasticsearch.js
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === 'production') {
 } else {
   client = new elasticsearch.Client({
     host: process.env.ES_HOST,
-    log: 'trace',
+    log: 'debug',
   });
 }
 


### PR DESCRIPTION
The trace debug is way too verbose and force us to scroll a lot to spot the Sails errors.