### PR TITLE
[CHILD DOC] Improve document children performance

### DIFF
--- a/api/controllers/DocumentController.js
+++ b/api/controllers/DocumentController.js
@@ -940,7 +940,6 @@ module.exports = {
         .populate('authorizationDocument')
         .populate('authors')
         .populate('cave')
-        .populate('children')
         .populate('descriptions')
         .populate('editor')
         .populate('entrance')
@@ -972,14 +971,7 @@ module.exports = {
       found.mainLanguage = await DocumentService.getMainLanguage(found.id);
       await setNamesOfPopulatedDocument(found);
       await DescriptionService.setDocumentDescriptions(found);
-      if (found.children.length > 0) {
-        found.children = await Promise.all(
-          found.children.map(
-            async (childDoc) =>
-              await DocumentService.deepPopulateChildren(childDoc),
-          ),
-        );
-      }
+      await DocumentService.deepPopulateChildren(found);
     }
 
     const params = {

--- a/api/controllers/v1/DocumentController.js
+++ b/api/controllers/v1/DocumentController.js
@@ -10,6 +10,7 @@ module.exports = {
   findByCaverId: (req, res, next) =>
     documentController.findByCaverId(req, res, next),
   find: (req, res, next) => documentController.find(req, res, next),
+  findChildren: (req, res) => documentController.findChildren(req, res),
   update: (req, res, next) => documentController.update(req, res, next),
   validate: (req, res, next) => documentController.validate(req, res, next),
   multipleValidate: (req, res, next) =>

--- a/api/services/DescriptionService.js
+++ b/api/services/DescriptionService.js
@@ -3,14 +3,15 @@ const ramda = require('ramda');
 module.exports = {
   /**
    * @param {string} document to document to set names including its parent if present
+   * @param {Boolean} [setParent=true] specify if the document parent description must be set (recursive and cost a lot of resources)
    */
-  setDocumentDescriptions: async (document) => {
+  setDocumentDescriptions: async (document, setParent = true) => {
     document.descriptions = await TDescription.find()
       .where({
         document: document.id,
       })
       .populate('language');
-    if (ramda.pathOr(null, ['parent', 'id'], document)) {
+    if (setParent && ramda.pathOr(null, ['parent', 'id'], document)) {
       await module.exports.setDocumentDescriptions(document.parent);
     }
   },

--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -966,6 +966,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Count'
+  
+  '/documents/{id}/children':
+    get:
+      tags:
+      - documents
+      description: Get a document children.
+      parameters:
+      - name: id
+        in: path
+        description: Document id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+        '400':
+          description: Document not found.
 
   '/documents/{id}/validate':
     put:
@@ -3050,7 +3072,3 @@ components:
           type: string
         'dct:creator':
           type: string
-        
-        
-        
-        

--- a/config/routes.js
+++ b/config/routes.js
@@ -174,6 +174,7 @@ module.exports.routes = {
   /* Document controller */
   'GET /api/v1/documents': 'v1/Document.findAll',
   'GET /api/v1/documents/:id': 'v1/Document.find',
+  'GET /api/v1/documents/:id/children': 'v1/Document.findChildren',
   'GET /api/v1/documents/count': 'v1/Document.count',
   'POST /api/v1/documents': 'v1/Document.create',
   'POST /api/v1/documents/check-rows': 'v1/Document.checkRows',


### PR DESCRIPTION
Fix #644

Feature is not recursive anymore : just find children and grandchildren. This is enough for the main use case which is "When an user is viewing a Collection, he needs to view the issues and the articles (children and grandchildren)".

`GET /documents/:id` does not return children anymore. You need to call `GET /documents/:id/children` to get them.