### PR TITLE
[ENTRANCE] Improve create entrance method

### DIFF
--- a/apiV1.yaml
+++ b/apiV1.yaml
@@ -1541,11 +1541,8 @@ paths:
         required: true
         description: Cave related to the entrance
         schema:
-            type: object
-            properties:
-              id:
-                type: number
-                description: Id of the cave
+          type: number
+          description: Id of the cave
       - name: city
         in: query
         description: City where the entrance is located
@@ -1561,11 +1558,8 @@ paths:
         in: query
         description: Country where the entrance is located
         schema:
-            type: object
-            properties:
-              id:
-                type: string
-                description: Id of the country
+          type: string
+          description: ISO 3166-1 alpha-2 code of the country where the entrance is located
       - name: county
         in: query
         description: County where the entrance is located
@@ -1573,7 +1567,6 @@ paths:
           type: string
       - name: description
         in: query
-        required: true
         schema:
             type: object
             properties:
@@ -2902,6 +2895,14 @@ components:
         reviewer:
           $ref: '#/components/schemas/Caver'
 
+    Option:
+      type: object
+      properties:
+        id:
+          type: 'number'
+        name:
+          type: 'string'
+      
     Organization:
       type: object
       properties:


### PR DESCRIPTION
- Check required parameters
- Simplify parameters when only an id is needed. For example:
```json
{
  "cave": {
    "id": 5
  }
}
```
becomes
```json
{
  "cave": 5
}
```

Here is a full example I used during testing: 
```json
{
  "name": {
    "language": "fra",
    "text": "L'entrée XYZ"
  },
  "cave": 5,
  "country": "FR",
  "description": {
    "body": "Ceci est une description de cette incroyable entrée.",
    "language": "fra",
    "title": "Titre de la description de l'entrée"
  },  
  "location": {
    "body": "Prenez à droite après le premier virage sur la D10 direction Dupond. Contournez le grand chêne par la gauche et baissez les yeux : vous y êtes!",
    "language": "fra"
  },
  "depth": 42,
  "geology": "Q35758",
  "isDiving": true,
  "length": 530,
  "longitude": -83.980479240417,
  "latitude": 22.440979208779,
  "temperature": 8.36
}
```