### PR TITLE
[CAVE] Fix & improve createCave route

### DIFF
--- a/api/controllers/v1/CaveController.js
+++ b/api/controllers/v1/CaveController.js
@@ -13,7 +13,8 @@ module.exports = {
 
   findAll: (req, res) =>
     caveController.findAll(req, res, MappingV1Service.convertToCaveList),
-  create: (req, res) => caveController.create(req, res),
+  create: (req, res) =>
+    caveController.create(req, res, MappingV1Service.convertToCaveModel),
   delete: (req, res, next) => caveController.delete(req, res, next),
   addDocument: async (req, res) => caveController.addDocument(req, res),
   update: (req, res) =>

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3,7 +3,7 @@ openapi: '3.0.0'
 info:
   description: "This page documents the available Grottocenter's API."
   title: 'Grottocenter 3 - REST API'
-  version: 'v.1'
+  version: 'v1 - 21.1.4'
   termsOfService: 'https://wiki.grottocenter.org/wiki/GrottoCenter:En/API'
   contact:
     name: 'Slack space'
@@ -76,47 +76,37 @@ paths:
       description: "Create a Cave. When submitting a new cave, you must provide an authentification token (from the /login route) in the Authorization header. This token will be used to set the author of the submission."
       parameters:
 
-      - name: name
-        in: query
-        description: Main name of the cave, using the local language
-        required: true
-        schema:
-          type: string
-
-      - name: description
-        in: query
-        description: Your description of the cave
-        schema:
-          type: string
-
-      - name: descriptionTitle
-        in: query
-        description: Title of your description
-        schema:
-          type: string
-
-      - name: descriptionAndNameLanguage
-        in: query
-        description: Language used for the description and the name. List of languages supported by Grottocenter is available using the /languages route.
-        required: true
-        schema:
-          type: object
-          properties:
-            id:
-              type: string
-
       - name: depth
         in: query
         description: Depth of the cave
         schema:
           type: integer
-
-      - name: length
+  
+      - name: descriptions
         in: query
-        description: Length of the cave
+        description: Description objects array
+        required: true
         schema:
-          type: integer
-
+          type: array
+          items:
+            type: object
+            properties:
+              body:
+                type: string
+              language: 
+                type: string
+                description: Language used for the description. The list of languages supported by Grottocenter is available using the /languages route.
+              title:
+                type: string
+      
+      - name: documents
+        in: query
+        description: Document ids related to the cave
+        schema:
+          type: array
+          items:
+            type: integer
+      
       - name: isDiving
         in: query
         description: If the cave is flooded or not
@@ -124,42 +114,48 @@ paths:
           type: boolean
           default: false
 
-      - name: temperature
-        in: query
-        description: Average temperature in the cave
-        schema:
-          type: number
-          format: double
-
-      - name: longitude
-        in: query
-        schema:
-          type: number
-
       - name: latitude
+        in: query
+        schema:
+          type: number
+      
+      - name: length
+        in: query
+        description: Length of the cave
+        schema:
+          type: integer
+          
+      - name: longitude
         in: query
         schema:
           type: number
 
       - name: massif
         in: query
-        description: Massif in which the cave is located.
+        description: Massif id in which the cave is located.
+        schema:
+          type: integer
+
+      - name: name
+        in: query
+        description: Name object
+        required: true
         schema:
           type: object
           properties:
-            id:
+            text:
               type: string
-
-      - name: documents
+              description: Main name of the cave, using the local language.
+            language: 
+              type: string
+              description: Language used for the name. The list of languages supported by Grottocenter is available using the /languages route.
+      
+      - name: temperature
         in: query
-        description: Documents related to the cave
+        description: Average temperature in the cave
         schema:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: string
+          type: number
+          format: double
 
       responses:
         200:


### PR DESCRIPTION
- multiple descriptions are now allowed (you must always send an array, even for one description)
- name and descriptions improved. Now using full objects.
- "id" key must be omitted: just put the id of the data.

JSON used: 

```json
{
  "depth": 42,
  "descriptions": [
    {
      "body": "There are many rocks.",
      "language": "eng",
      "title": "Geology"
    },
    {
      "body": "It's wet",
      "language": "eng",
      "title": "Hydrology"
    },
    {
      "body": "Very beautiful",
      "language": "eng",
      "title": "First gallery"
    }
  ],
  "documents": [
    109,
    161,
    191
  ],
  "isDiving": true,
  "latitude": 22.440979208779,
  "length": 530,
  "longitude": -83.980479240417,
  "massif": 4,
  "name": {
    "text": "La Cavité XYZ",
    "language": "eng"
  },
  "temperature": 8.36
}
```