### PR TITLE
[GEOLOC] Return networks instead of caves

### DIFF
--- a/api/controllers/FileFormatController.js
+++ b/api/controllers/FileFormatController.js
@@ -1,7 +1,7 @@
 /**
- * EntranceController
+ * FileFormatController
  *
- * @description :: Server-side logic for managing entrances
+ * @description :: Server-side logic for managing file formats
  * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 

--- a/api/controllers/GeoLocController.js
+++ b/api/controllers/GeoLocController.js
@@ -1,0 +1,203 @@
+/**
+ * GeolocController
+ *
+ * @description :: Server-side logic for managing geolocalization of Grottocenter entities
+ * @help        :: See http://links.sailsjs.org/docs/controllers
+ */
+
+const GeoLocService = require('../services/GeoLocService');
+
+const checkAndGetCoordinatesParams = (req) => {
+  let errorMessage = '';
+  const errors = [];
+  const neededParams = [
+    { key: 'sw_lat', name: 'South west latitude', value: null },
+    { key: 'sw_lng', name: 'South west longitude', value: null },
+    { key: 'ne_lat', name: 'North east latitude', value: null },
+    { key: 'ne_lng', name: 'North east longitude', value: null },
+  ];
+
+  const result = neededParams.map((param) => {
+    return {
+      ...param,
+      value: req.param(param.key, null),
+    };
+  });
+
+  // Check null values
+  const missingParams = result.filter((p) => p.value === null);
+  if (missingParams.length > 0) {
+    errorMessage = 'You must provide the following parameter(s): ';
+    for (const missingParam of missingParams) {
+      errors.push(missingParam.name + ' value on key ' + missingParam.key);
+    }
+  } else {
+    // Check valid values
+    for (const param of result) {
+      if (
+        param.key.endsWith('lat') &&
+        (param.value < -90 || param.value > 90)
+      ) {
+        errors.push(
+          param.name +
+            ' value must be between -90 & 90 (value found: ' +
+            param.value +
+            ')',
+        );
+      }
+      if (
+        param.key.endsWith('lng') &&
+        (param.value < -180 || param.value > 80)
+      ) {
+        errors.push(
+          param.name +
+            ' value must be between -180 & 80 (value found: ' +
+            param.value +
+            ')',
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) errorMessage += errors.join(', ') + '.';
+
+  return {
+    errorMessage,
+    southWestBound: {
+      lat: result.find((p) => p.key === 'sw_lat').value,
+      lng: result.find((p) => p.key === 'sw_lng').value,
+    },
+    northEastBound: {
+      lat: result.find((p) => p.key === 'ne_lat').value,
+      lng: result.find((p) => p.key === 'ne_lng').value,
+    },
+  };
+};
+
+module.exports = {
+  countEntrances: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.countEntrances(
+        southWestBound,
+        northEastBound,
+      );
+      if (!result) {
+        return res.json({ count: 0 });
+      }
+      return res.json({ count: result });
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+
+  findEntrancesCoordinates: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.getEntrancesCoordinates(
+        southWestBound,
+        northEastBound,
+        100000,
+      );
+      return res.json(result);
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+
+  findEntrances: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.getEntrancesMap(
+        southWestBound,
+        northEastBound,
+        100000,
+      );
+      return res.json(result);
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+
+  findGrottos: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.getGrottosMap(
+        southWestBound,
+        northEastBound,
+      );
+      return res.json(result);
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+
+  findNetworksCoordinates: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.getCavesCoordinates(
+        southWestBound,
+        northEastBound,
+        100000,
+      );
+      return res.json(result);
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+
+  findNetworks: async (req, res) => {
+    const {
+      southWestBound,
+      northEastBound,
+      errorMessage,
+    } = checkAndGetCoordinatesParams(req);
+
+    if (errorMessage !== '') return res.badRequest(errorMessage);
+
+    try {
+      const result = await GeoLocService.getCavesMap(
+        southWestBound,
+        northEastBound,
+      );
+      return res.json(result);
+    } catch (e) {
+      ErrorService.getDefaultErrorHandler(res)(e);
+    }
+  },
+};

--- a/api/controllers/GeoLocController.js
+++ b/api/controllers/GeoLocController.js
@@ -170,7 +170,7 @@ module.exports = {
     if (errorMessage !== '') return res.badRequest(errorMessage);
 
     try {
-      const result = await GeoLocService.getCavesCoordinates(
+      const result = await GeoLocService.getNetworksCoordinates(
         southWestBound,
         northEastBound,
         100000,
@@ -191,7 +191,7 @@ module.exports = {
     if (errorMessage !== '') return res.badRequest(errorMessage);
 
     try {
-      const result = await GeoLocService.getCavesMap(
+      const result = await GeoLocService.getNetworksMap(
         southWestBound,
         northEastBound,
       );

--- a/api/controllers/v1/GeoLocController.js
+++ b/api/controllers/v1/GeoLocController.js
@@ -1,150 +1,19 @@
 /**
  */
 
-const GeoLocService = require('../../services/GeoLocService');
+const GeolocController = require('../GeoLocController');
 module.exports = {
-  countEntries: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
+  countEntrances: (req, res) => GeolocController.countEntrances(req, res),
 
-    GeoLocService.countEntrances(southWestBound, northEastBound)
-      .then((result) => {
-        if (!result) {
-          return res.json({ count: 0 });
-        }
-        return res.json({ count: result });
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(`Call to countEntries raised an error : ${err}`);
-      });
-  },
+  findEntrancesCoordinates: (req, res) =>
+    GeolocController.findEntrancesCoordinates(req, res),
 
-  findEntrancesCoordinates: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
+  findEntrances: (req, res) => GeolocController.findEntrances(req, res),
 
-    GeoLocService.getEntrancesCoordinates(
-      southWestBound,
-      northEastBound,
-      100000,
-    )
-      .then((result) => {
-        sails.log.debug('entrances coord sent');
-        sails.log.debug(result.length);
-        return res.json(result);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(
-          `Call to getEntrancesCoordinates raised an error : ${err}`,
-        );
-      });
-  },
+  findGrottos: (req, res) => GeolocController.findGrottos(req, res),
 
-  findEntrances: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
+  findNetworksCoordinates: (req, res) =>
+    GeolocController.findNetworksCoordinates(req, res),
 
-    GeoLocService.getEntrancesMap(southWestBound, northEastBound, 100000)
-      .then((result) => {
-        sails.log.debug('entrances sent');
-        sails.log.debug(result.length);
-        return res.json(result);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(
-          `Call to getEntrancesMap raised an error : ${err}`,
-        );
-      });
-  },
-
-  findGrottos: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
-
-    GeoLocService.getGrottosMap(southWestBound, northEastBound)
-      .then((result) => {
-        sails.log.debug('grottos sent');
-        sails.log.debug(result.length);
-        return res.json(result);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(
-          `Call to getGrottosMap raised an error : ${err}`,
-        );
-      });
-  },
-
-  findCavesCoordinates: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
-
-    GeoLocService.getCavesCoordinates(southWestBound, northEastBound, 100000)
-      .then((result) => {
-        sails.log.debug('Caves coord sent');
-        sails.log.debug(result.length);
-        return res.json(result);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(
-          `Call to getCavesCoordinatesInExtend raised an error : ${err}`,
-        );
-      });
-  },
-
-  findCaves: (req, res) => {
-    const southWestBound = {
-      lat: req.param('sw_lat'),
-      lng: req.param('sw_lng'),
-    };
-    const northEastBound = {
-      lat: req.param('ne_lat'),
-      lng: req.param('ne_lng'),
-    };
-
-    GeoLocService.getCavesMap(southWestBound, northEastBound)
-      .then((result) => {
-        sails.log.debug('grottos sent');
-        sails.log.debug(result.length);
-        return res.json(result);
-      })
-      .catch((err) => {
-        sails.log.error(err);
-        return res.serverError(`Call to getCavesMap raised an error : ${err}`);
-      });
-  },
+  findNetworks: (req, res) => GeolocController.findNetworks(req, res),
 };

--- a/api/services/GeoLocService.js
+++ b/api/services/GeoLocService.js
@@ -1,6 +1,3 @@
-/**
- */
-
 const PUBLIC_ENTRANCES_IN_BOUNDS = `
   SELECT e.id as id, ne.name as name, e.city as city,
   e.region as region, e.longitude as longitude, e.latitude as latitude,
@@ -11,7 +8,8 @@ const PUBLIC_ENTRANCES_IN_BOUNDS = `
   LEFT JOIN t_name as nc ON nc.id_cave = e.id
   LEFT JOIN t_cave as c ON c.Id = e.Id_cave
   WHERE e.latitude > $1 AND e.latitude < $2 AND e.longitude > $3 AND e.longitude < $4
-  AND e.is_sensitive=false
+  AND e.is_sensitive = false
+  AND e.is_deleted = false
   ORDER BY size_coef DESC
   LIMIT $5;
 `;
@@ -19,169 +17,49 @@ const PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS = `
   SELECT e.longitude as longitude, e.latitude as latitude
   FROM t_entrance as e
   WHERE e.latitude > $1 AND e.latitude < $2 AND e.longitude > $3 AND e.longitude < $4
-  AND e.is_sensitive=false
+  AND e.is_sensitive = false
+  AND e.is_deleted = false
   LIMIT $5;
 `;
 
-const CAVES_IN_BOUNDS = `
+const NETWORKS_IN_BOUNDS = `
   SELECT c.id as id, COALESCE(nc.name, ne.name) as name, avg(en.longitude) as longitude, avg(en.latitude) as latitude
   FROM t_entrance as en
   INNER JOIN t_cave c ON c.id = en.id_cave
   LEFT JOIN t_name AS nc ON nc.id_cave = c.id
   LEFT JOIN t_name as ne ON ne.id_entrance = en.id
-  WHERE en.latitude > $1 AND en.latitude < $2 AND en.longitude > $3 AND en.longitude < $4 AND en.is_sensitive=false
-  GROUP BY c.id, nc.name, ne.name
+  WHERE en.latitude > $1 AND en.latitude < $2 AND en.longitude > $3 AND en.longitude < $4 
+  AND en.is_sensitive = false
+  AND en.is_deleted = false
+  AND c.is_deleted = false
+  GROUP BY c.id, COALESCE(nc.name, ne.name)
+  HAVING count(en.id_cave) > 1
 `;
 
-const PUBLIC_CAVES_COORDINATES_IN_BOUNDS = `
+const PUBLIC_NETWORKS_COORDINATES_IN_BOUNDS = `
   SELECT avg(en.longitude) as longitude, avg(en.latitude) as latitude
-  FROM t_entrance as en
-  INNER JOIN t_cave c ON c.id = en.id_cave
-  WHERE en.latitude > $1 AND en.latitude < $2 AND en.longitude > $3 AND en.longitude < $4 AND en.is_sensitive=false
+  FROM t_cave AS c
+  LEFT JOIN t_entrance en ON c.id = en.id_cave
+  WHERE en.latitude > $1 AND en.latitude < $2 AND en.longitude > $3 AND en.longitude < $4 
+  AND en.is_sensitive = false
+  AND en.is_deleted = false
+  AND c.is_deleted = false
   GROUP BY c.id
+  HAVING count(en.id_cave) > 1
   LIMIT $5;
 `;
 
 /**
- * Return the cave in the bounds
- * @param southWestBound
- * @param northEastBound
- * @returns {Promise<any>}
+ * return a light version of the networks
+ * @param networks
  */
-const getCaves = (southWestBound, northEastBound) =>
-  new Promise((resolve, reject) => {
-    CommonService.query(CAVES_IN_BOUNDS, [
-      southWestBound.lat,
-      northEastBound.lat,
-      southWestBound.lng,
-      northEastBound.lng,
-    ]).then(
-      (results) => {
-        if (
-          !results ||
-          results.rows.length <= 0 ||
-          results.rows[0].count === 0
-        ) {
-          resolve([]);
-        }
-        resolve(results.rows);
-      },
-      (err) => {
-        reject(err);
-      },
-    );
-  });
-
-/**
- * Return all the entrances coordinates in the bounds
- * @param southWestBound
- * @param northEastBound
- * @returns {Promise<any>}
- */
-const getCavesCoordinatesInExtend = (southWestBound, northEastBound, limit) =>
-  new Promise((resolve, reject) => {
-    CommonService.query(PUBLIC_CAVES_COORDINATES_IN_BOUNDS, [
-      southWestBound.lat,
-      northEastBound.lat,
-      southWestBound.lng,
-      northEastBound.lng,
-      limit,
-    ]).then(
-      (results) => {
-        if (
-          !results ||
-          results.rows.length <= 0 ||
-          results.rows[0].count === 0
-        ) {
-          resolve([]);
-        }
-        resolve(results.rows);
-      },
-      (err) => {
-        reject(err);
-      },
-    );
-  });
-
-/**
- * Return all the entrances coordinates in the bounds
- * @param southWestBound
- * @param northEastBound
- * @param limit
- * @returns {Promise<any>}
- */
-const getEntrancesCoordinatesInExtend = (
-  southWestBound,
-  northEastBound,
-  limit,
-) =>
-  new Promise((resolve, reject) => {
-    CommonService.query(PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS, [
-      southWestBound.lat,
-      northEastBound.lat,
-      southWestBound.lng,
-      northEastBound.lng,
-      limit,
-    ]).then(
-      (results) => {
-        if (
-          !results ||
-          results.rows.length <= 0 ||
-          results.rows[0].count === 0
-        ) {
-          resolve([]);
-        }
-        resolve(results.rows);
-      },
-      (err) => {
-        reject(err);
-      },
-    );
-  });
-
-/**
- * Return all the entrances in the bounds
- * @param southWestBound
- * @param northEastBound
- * @param limit
- * @returns {Promise<any>}
- */
-const getEntrancesBetweenCoords = (southWestBound, northEastBound, limit) =>
-  new Promise((resolve, reject) => {
-    CommonService.query(PUBLIC_ENTRANCES_IN_BOUNDS, [
-      southWestBound.lat,
-      northEastBound.lat,
-      southWestBound.lng,
-      northEastBound.lng,
-      limit,
-    ]).then(
-      (results) => {
-        if (
-          !results ||
-          results.rows.length <= 0 ||
-          results.rows[0].count === 0
-        ) {
-          resolve([]);
-        }
-        resolve(results.rows);
-      },
-      (err) => {
-        reject(err);
-      },
-    );
-  });
-
-/**
- * return a light version of the caves
- * @param caves
- */
-const formatCaves = (caves) => {
-  return caves.map((cave) => {
+const formatNetworks = (networks) => {
+  return networks.map((network) => {
     return {
-      id: cave.id,
-      name: cave.name,
-      longitude: Number(cave.longitude),
-      latitude: Number(cave.latitude),
+      id: network.id,
+      name: network.name,
+      longitude: Number(network.longitude),
+      latitude: Number(network.latitude),
     };
   });
 };
@@ -190,7 +68,6 @@ const formatCaves = (caves) => {
  * Format the quality entrances in a lighter version
  * Quality entrance stand for an entrance that won't be clustered
  * @param entrances
- * @returns {Promise<any>}
  */
 const formatEntrances = (entrances) =>
   entrances.map((entrance) => {
@@ -235,14 +112,97 @@ const formatGrottos = (grottos) =>
     latitude: parseFloat(grotto.latitude),
   }));
 
-/**
- * Return the speleological group in the bounds
- * @param southWestBound
- * @param northEastBound
- * @returns {Promise<any>}
- */
-const getGrottoBetweenCoords = (southWestBound, northEastBound) =>
-  new Promise((resolve, reject) => {
+// ====================================
+
+module.exports = {
+  countEntrances: async (southWestBound, northEastBound) => {
+    const parameters = {
+      isDeleted: false,
+      latitude: {
+        '>': southWestBound.lat,
+        '<': northEastBound.lat,
+      },
+      longitude: {
+        '>': southWestBound.lng,
+        '<': northEastBound.lng,
+      },
+    };
+
+    // TODO : to adapt when authentication will be implemented
+    parameters.isSensitive = false;
+    return await TEntrance.count(parameters);
+  },
+
+  getEntrancesCoordinates: async (
+    southWestBound,
+    northEastBound,
+    limitEntrances,
+  ) => {
+    const results = await CommonService.query(
+      PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS,
+      [
+        southWestBound.lat,
+        northEastBound.lat,
+        southWestBound.lng,
+        northEastBound.lng,
+        limitEntrances,
+      ],
+    );
+    if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
+      return [];
+    }
+    const coordinates = results.rows;
+
+    return coordinates.map((coord) => {
+      return [Number(coord.longitude), Number(coord.latitude)];
+    });
+  },
+
+  getNetworksCoordinates: async (
+    southWestBound,
+    northEastBound,
+    limitNetworks,
+  ) => {
+    const results = await CommonService.query(
+      PUBLIC_NETWORKS_COORDINATES_IN_BOUNDS,
+      [
+        southWestBound.lat,
+        northEastBound.lat,
+        southWestBound.lng,
+        northEastBound.lng,
+        limitNetworks,
+      ],
+    );
+    if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
+      return [];
+    }
+    const coordinates = results.rows;
+    return coordinates.map((coord) => {
+      return [Number(coord.longitude), Number(coord.latitude)];
+    });
+  },
+
+  /**
+   * @param southWestBound
+   * @param northEastBound
+   * @param limitEntrances Max number of entrances that will be showed at a certain level of zoom
+   * @returns {Promise<any>}
+   */
+  getEntrancesMap: async (southWestBound, northEastBound, limitEntrances) => {
+    const results = await CommonService.query(PUBLIC_ENTRANCES_IN_BOUNDS, [
+      southWestBound.lat,
+      northEastBound.lat,
+      southWestBound.lng,
+      northEastBound.lng,
+      limitEntrances,
+    ]);
+    if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
+      return [];
+    }
+    return formatEntrances(results.rows);
+  },
+
+  getGrottosMap: async (southWestBound, northEastBound) => {
     const parameters = {
       latitude: {
         '>': southWestBound.lat,
@@ -252,127 +212,22 @@ const getGrottoBetweenCoords = (southWestBound, northEastBound) =>
         '>': southWestBound.lng,
         '<': northEastBound.lng,
       },
-    }; // TODO add controls on parameters
+    };
+    const grottos = await TGrotto.find(parameters);
+    await NameService.setNames(grottos, 'grotto');
+    return formatGrottos(grottos);
+  },
 
-    TGrotto.find(parameters).exec(async (err, result) => {
-      if (err) {
-        reject(err);
-      }
-      await NameService.setNames(result, 'grotto');
-      resolve(result);
-    });
-  });
-
-// ====================================
-
-module.exports = {
-  /**
-   * @returns {Promise} which resolves to the succesfully countEntrances
-   */
-  countEntrances: (southWestBound, northEastBound) =>
-    new Promise((resolve, reject) => {
-      const parameters = {
-        latitude: {
-          '>': southWestBound.lat,
-          '<': northEastBound.lat,
-        },
-        longitude: {
-          '>': southWestBound.lng,
-          '<': northEastBound.lng,
-        },
-      }; // TODO add controls on parameters
-
-      // TODO : to adapt when authentication will be implemented
-      parameters.isSensitive = false;
-
-      TEntrance.count(parameters).exec((err, result) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(result);
-      });
-    }),
-
-  getEntrancesCoordinates: (southWestBound, northEastBound, limitEntrances) =>
-    new Promise((resolve, reject) => {
-      getEntrancesCoordinatesInExtend(
-        southWestBound,
-        northEastBound,
-        limitEntrances,
-      )
-        .then((coordinates) => {
-          resolve(
-            coordinates.map((coord) => {
-              return [Number(coord.longitude), Number(coord.latitude)];
-            }),
-          );
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }),
-
-  getCavesCoordinates: (southWestBound, northEastBound, limitCaves) =>
-    new Promise((resolve, reject) => {
-      getCavesCoordinatesInExtend(southWestBound, northEastBound, limitCaves)
-        .then((coordinates) => {
-          resolve(
-            coordinates.map((coord) => {
-              return [Number(coord.longitude), Number(coord.latitude)];
-            }),
-          );
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }),
-
-  /**
-   * @param southWestBound
-   * @param northEastBound
-   * @param limitEntrances Max number of entrances that will be showed at a certain level of zoom
-   * @returns {Promise<any>}
-   */
-  getEntrancesMap: (southWestBound, northEastBound, limitEntrances) =>
-    new Promise((resolve, reject) => {
-      getEntrancesBetweenCoords(southWestBound, northEastBound, limitEntrances)
-        .then((entrances) => {
-          resolve(formatEntrances(entrances));
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }),
-
-  /**
-   * @param southWestBound
-   * @param northEastBound
-   * @returns {Promise<any>}
-   */
-  getGrottosMap: (southWestBound, northEastBound) =>
-    new Promise((resolve, reject) => {
-      getGrottoBetweenCoords(southWestBound, northEastBound)
-        .then((grottos) => {
-          resolve(formatGrottos(grottos));
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }),
-
-  /**
-   * @param southWestBound
-   * @param northEastBound
-   * @returns {Promise<any>}
-   */
-  getCavesMap: (southWestBound, northEastBound) =>
-    new Promise((resolve, reject) => {
-      getCaves(southWestBound, northEastBound)
-        .then((caves) => {
-          resolve(formatCaves(caves));
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    }),
+  getNetworksMap: async (southWestBound, northEastBound) => {
+    const results = await CommonService.query(NETWORKS_IN_BOUNDS, [
+      southWestBound.lat,
+      northEastBound.lat,
+      southWestBound.lng,
+      northEastBound.lng,
+    ]);
+    if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
+      return [];
+    }
+    return formatNetworks(results.rows);
+  },
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -172,12 +172,12 @@ module.exports.policies = {
   },
 
   'v1/GeoLocController': {
-    countEntries: true,
-    findCaves: true,
-    findCavesCoordinates: true,
-    findGrottos: true,
+    countEntrances: true,
     findEntrances: true,
     findEntrancesCoordinates: true,
+    findGrottos: true,
+    findNetworks: true,
+    findNetworksCoordinates: true,
   },
 
   'v1/AccountController': {

--- a/config/routes.js
+++ b/config/routes.js
@@ -91,20 +91,8 @@ module.exports.routes = {
     'v1/Entrance.unlinkDocument',
   'GET /api/v1/entrances/count': 'v1/Entrance.count',
   'GET /api/v1/entrances/findRandom': 'v1/Entrance.findRandom',
-  'GET /api/v1/entrances/publicCount': {
-    controller: 'v1/Entrance',
-    action: 'publicCount',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/entrances/:id': {
-    controller: 'v1/Entrance',
-    action: 'find',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
+  'GET /api/v1/entrances/publicCount': 'v1/Entrance.publicCount',
+  'GET /api/v1/entrances/:id': 'v1/Entrance.find',
   'POST /api/v1/entrances': 'v1/Entrance.create',
   'POST /api/v1/entrances/check-rows': 'v1/Entrance.checkRows',
   'POST /api/v1/entrances/import-rows': 'v1/Entrance.importRows',
@@ -150,9 +138,6 @@ module.exports.routes = {
     api: {
       entity: 'grotto',
     },
-    cors: {
-      allowOrigins: '*',
-    },
   },
   'POST /api/v1/organizations': 'v1/Grotto.create',
   'PUT /api/v1/organizations/:id': 'v1/Grotto.update',
@@ -164,9 +149,6 @@ module.exports.routes = {
     action: 'find',
     api: {
       entity: 'massif',
-    },
-    cors: {
-      allowOrigins: '*',
     },
   },
   'POST /api/v1/massifs': 'v1/Massif.create',
@@ -206,9 +188,6 @@ module.exports.routes = {
     api: {
       entity: 'subject',
     },
-    cors: {
-      allowOrigins: '*',
-    },
   },
   'GET /api/v1/documents/subjects/:code': {
     controller: 'v1/Subject',
@@ -217,18 +196,12 @@ module.exports.routes = {
     api: {
       entity: 'subject',
     },
-    cors: {
-      allowOrigins: '*',
-    },
   },
   'POST /api/v1/documents/subjects/search/logical/or': {
     controller: 'v1/Subject',
     action: 'search',
     api: {
       entity: 'subject',
-    },
-    cors: {
-      allowOrigins: '*',
     },
   },
 
@@ -239,9 +212,6 @@ module.exports.routes = {
     api: {
       entity: 'identifierType',
     },
-    cors: {
-      allowOrigins: '*',
-    },
   },
 
   /* Region controller */
@@ -250,9 +220,6 @@ module.exports.routes = {
     action: 'search',
     api: {
       entity: 'region',
-    },
-    cors: {
-      allowOrigins: '*',
     },
   },
 
@@ -264,65 +231,17 @@ module.exports.routes = {
   'GET /api/rss/:language': 'Rss.getFeed',
 
   /* Geo localisation controller */
-  'GET /api/v1/geoloc/countEntries': {
-    controller: 'v1/GeoLoc',
-    action: 'countEntries',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/geoloc/caves': {
-    controller: 'v1/GeoLoc',
-    action: 'findCaves',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/geoloc/cavesCoordinates': {
-    controller: 'v1/GeoLoc',
-    action: 'findCavesCoordinates',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/geoloc/grottos': {
-    controller: 'v1/GeoLoc',
-    action: 'findGrottos',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/geoloc/entrances': {
-    controller: 'v1/GeoLoc',
-    action: 'findEntrances',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-  'GET /api/v1/geoloc/entrancesCoordinates': {
-    controller: 'v1/GeoLoc',
-    action: 'findEntrancesCoordinates',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
+  'GET /api/v1/geoloc/countEntries': 'v1/GeoLoc.countEntries',
+  'GET /api/v1/geoloc/caves': 'v1/GeoLoc.findCaves',
+  'GET /api/v1/geoloc/cavesCoordinates': 'v1/GeoLoc.findCavesCoordinates',
+  'GET /api/v1/geoloc/grottos': 'v1/GeoLoc.findGrottos',
+  'GET /api/v1/geoloc/entrances': 'v1/GeoLoc.findEntrances',
+  'GET /api/v1/geoloc/entrancesCoordinates':
+    'v1/GeoLoc.findEntrancesCoordinates',
 
   /* Search controller*/
-  'POST /api/v1/search': {
-    controller: 'v1/Search',
-    action: 'search',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
-
-  'POST /api/v1/advanced-search': {
-    controller: 'v1/Search',
-    action: 'advancedSearch',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
+  'POST /api/v1/search': 'v1/Search.search',
+  'POST /api/v1/advanced-search': 'v1/Search.advancedSearch',
 
   /* Language controller */
   'GET /api/v1/languages/:id': {
@@ -330,9 +249,6 @@ module.exports.routes = {
     action: 'find',
     api: {
       entity: 'language',
-    },
-    cors: {
-      allowOrigins: '*',
     },
   },
 
@@ -342,22 +258,13 @@ module.exports.routes = {
     api: {
       entity: 'language',
     },
-    cors: {
-      allowOrigins: '*',
-    },
   },
 
   /* Users controller */
   'GET /api/v1/cavers/:caverId/documents': 'v1/Document.findByCaverId',
 
   /* Convert controller */
-  'GET /api/convert': {
-    controller: 'ConvertController',
-    action: 'convert',
-    cors: {
-      allowOrigins: '*',
-    },
-  },
+  'GET /api/convert': 'ConvertController.convert',
 
   /* License controller */
   'GET /api/v1/licenses': 'v1/License.findAll',

--- a/config/routes.js
+++ b/config/routes.js
@@ -231,13 +231,30 @@ module.exports.routes = {
   'GET /api/rss/:language': 'Rss.getFeed',
 
   /* Geo localisation controller */
-  'GET /api/v1/geoloc/countEntries': 'v1/GeoLoc.countEntries',
-  'GET /api/v1/geoloc/caves': 'v1/GeoLoc.findCaves',
-  'GET /api/v1/geoloc/cavesCoordinates': 'v1/GeoLoc.findCavesCoordinates',
-  'GET /api/v1/geoloc/grottos': 'v1/GeoLoc.findGrottos',
+  'GET /api/v1/geoloc/countEntrances': 'v1/GeoLoc.countEntrances',
   'GET /api/v1/geoloc/entrances': 'v1/GeoLoc.findEntrances',
   'GET /api/v1/geoloc/entrancesCoordinates':
     'v1/GeoLoc.findEntrancesCoordinates',
+  'GET /api/v1/geoloc/networks': 'v1/GeoLoc.findNetworks',
+  'GET /api/v1/geoloc/networksCoordinates': 'v1/GeoLoc.findNetworksCoordinates',
+  'GET /api/v1/geoloc/organizations': 'v1/GeoLoc.findGrottos',
+
+  /**
+   * @deprecated use geoloc/countEntrances instead
+   */
+  'GET /api/v1/geoloc/countEntries': 'v1/GeoLoc.countEntrances',
+  /**
+   * @deprecated use geoloc/organizations instead
+   */
+  'GET /api/v1/geoloc/grottos': 'v1/GeoLoc.findGrottos',
+  /**
+   * @deprecated use geoloc/networks instead
+   */
+  'GET /api/v1/geoloc/caves': 'v1/GeoLoc.findNetworks',
+  /**
+   * @deprecated use geoloc/networksCoordinates instead
+   */
+  'GET /api/v1/geoloc/cavesCoordinates': 'v1/GeoLoc.findNetworksCoordinates',
 
   /* Search controller*/
   'POST /api/v1/search': 'v1/Search.search',


### PR DESCRIPTION
Fix #690

Networks = cave with nb of entrances > 1

Le fichier `routes.js` a été nettoyé. J'ai marqué des routes comme "deprecated" en indiquant quelle route utiliser à la place. Il faudra voir quand est-ce qu'on les supprimera. Il serait judicieux d'envoyer un email aux personnes utilisant notre API pour les prévenir avant la suppression (cf #647).

J'ai totalement refactorisé tous les fichiers de Geoloc, il y en avait bien besoin : beaucoup de Promise().then().error() alors que le await devient la norme dans toute l'API.

![Peek 2021-12-21 17-20](https://user-images.githubusercontent.com/20704943/146964107-c9d32c02-9ff5-4930-a894-a6566dc58488.gif)