### PR TITLE
[ERROR RESPONSES] Convert to json when user wants json

### DIFF
--- a/api/responses/badRequest.js
+++ b/api/responses/badRequest.js
@@ -38,7 +38,12 @@ module.exports = function badRequest(data, options) {
 
   // If the user-agent wants JSON, always respond with JSON
   if (req.wantsJSON) {
-    return res.json(data);
+    // If data is a plain string, cast it to json with a message key
+    if (typeof data === 'string') {
+      return res.json({ message: data });
+    } else {
+      return res.json(data);
+    }
   }
 
   // If second argument is a string, we take that to mean it refers to a view.

--- a/api/responses/forbidden.js
+++ b/api/responses/forbidden.js
@@ -35,7 +35,12 @@ module.exports = function forbidden(data, options) {
 
   // If the user-agent wants JSON, always respond with JSON
   if (req.wantsJSON) {
-    return res.json(data);
+    // If data is a plain string, cast it to json with a message key
+    if (typeof data === 'string') {
+      return res.json({ message: data });
+    } else {
+      return res.json(data);
+    }
   }
 
   // If second argument is a string, we take that to mean it refers to a view.

--- a/api/responses/ok.js
+++ b/api/responses/ok.js
@@ -24,7 +24,12 @@ module.exports = function sendOK(data, options) {
 
   // If appropriate, serve data as JSON(P)
   if (req.wantsJSON) {
-    return res.json(data);
+    // If data is a plain string, cast it to json with a message key
+    if (typeof data === 'string') {
+      return res.json({ message: data });
+    } else {
+      return res.json(data);
+    }
   }
 
   // If second argument is a string, we take that to mean it refers to a view.

--- a/api/responses/serverError.js
+++ b/api/responses/serverError.js
@@ -35,7 +35,12 @@ module.exports = function serverError(data, options) {
 
   // If the user-agent wants JSON, always respond with JSON
   if (req.wantsJSON) {
-    return res.json(data);
+    // If data is a plain string, cast it to json with a message key
+    if (typeof data === 'string') {
+      return res.json({ message: data });
+    } else {
+      return res.json(data);
+    }
   }
 
   // If second argument is a string, we take that to mean it refers to a view.

--- a/api/responses/unauthorized.js
+++ b/api/responses/unauthorized.js
@@ -35,7 +35,12 @@ module.exports = function unauthorized(data, options) {
 
   // If the user-agent wants JSON, always respond with JSON
   if (req.wantsJSON) {
-    return res.json(data);
+    // If data is a plain string, cast it to json with a message key
+    if (typeof data === 'string') {
+      return res.json({ message: data });
+    } else {
+      return res.json(data);
+    }
   }
 
   // If second argument is a string, we take that to mean it refers to a view.


### PR DESCRIPTION
**Issue**
When an error response was sent, the API send the `data` variable always "as is". But, in most of the cases, `data` is a plain string and thus, this caused a JSON parse error.

**Solution**
The error response check if `data` is a string or not. If it's a string, it converts it to a JSON object, with a "message" key.