### PR TITLE
[CI / GH ACTIONS] Use npm ci instead of npm install + add Prettier and ESLINT in GH actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - run: npm install
+      - run: npm ci
 
       # ===== Test
       - run: npm test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,10 @@ jobs:
             ${{ runner.os }}-
 
       - run: npm ci
+      - name: Prettier
+        run: npm run prettier
+      - name: Lint
+        run: npm run lint
 
       # ===== Test
       - run: npm test


### PR DESCRIPTION
## `npm ci` VS `npm i`

**TL,DR**
Unlike npm install, npm ci will look in your package-lock.json to install all the dependencies with the exact version.
npm ci will never modify your package-lock.json. It does however expect a package-lock.json file in your project.

https://docs.npmjs.com/cli/v8/commands/npm-ci

https://betterprogramming.pub/npm-ci-vs-npm-install-which-should-you-use-in-your-node-js-projects-51e07cb71e26

https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci

## Prettier / Eslint

Github action now runs eslint and prettier to reject pull request not correctly formatted. It does NOT fix the issues, it just shows them: it's the developer responsibility to check them and fix them.