### PR TITLE
[DELETE] Fix elasticsearch deletions

### DIFF
--- a/api/controllers/v1/cave/delete-one.js
+++ b/api/controllers/v1/cave/delete-one.js
@@ -1,4 +1,5 @@
 const CaveService = require('../../../services/CaveService');
+const ElasticsearchService = require('../../../services/ElasticsearchService');
 const ErrorService = require('../../../services/ErrorService');
 const RightService = require('../../../services/RightService');
 
@@ -73,6 +74,7 @@ module.exports = async (req, res) => {
   try {
     sails.log.info(`Deleting cave with id ${caveId}`);
     await TCave.destroyOne(caveId);
+    await ElasticsearchService.deleteResource('caves', caveId);
     return res.sendStatus(204);
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/entrance/delete-one.js
+++ b/api/controllers/v1/entrance/delete-one.js
@@ -41,7 +41,7 @@ module.exports = async (req, res) => {
     )
   );
 
-  ElasticsearchService.deleteResource('entrances', entranceId);
+  await ElasticsearchService.deleteResource('entrances', entranceId);
 
   return res.sendStatus(204);
 };

--- a/api/controllers/v1/massif/delete-one.js
+++ b/api/controllers/v1/massif/delete-one.js
@@ -1,4 +1,5 @@
 const RightService = require('../../../services/RightService');
+const ElasticsearchService = require('../../../services/ElasticsearchService');
 
 module.exports = async (req, res) => {
   const hasRight = await sails.helpers.checkRight
@@ -36,5 +37,7 @@ module.exports = async (req, res) => {
       `An unexpected error occured when trying to delete massif with id ${massifId}.`
     )
   );
+  await ElasticsearchService.deleteResource('massifs', massifId);
+
   return res.sendStatus(204);
 };

--- a/api/controllers/v1/organization/delete-one.js
+++ b/api/controllers/v1/organization/delete-one.js
@@ -41,6 +41,6 @@ module.exports = async (req, res) => {
     )
   );
 
-  ElasticsearchService.deleteResource('grottos', organizationId);
+  await ElasticsearchService.deleteResource('grottos', organizationId);
   return res.sendStatus(204);
 };


### PR DESCRIPTION
Les massifs et entrées de cavité n'étaient pas automatiquement supprimées d'Elasticsearch à leur suppression : c'est désormais le cas avec cette PR.