### PR TITLE
chore(docker): use the same postgre version as production

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ name: grottocenter
 services:
   dbserver:
     container_name: ${POSTGRES_CONTAINER_NAME}
-    image: postgis/postgis
+    image: postgis/postgis:16-3.4
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -23,7 +23,7 @@ services:
 
   testdbserver:
     container_name: ${POSTGRES_TEST_CONTAINER_NAME}
-    image: postgis/postgis
+    image: postgis/postgis:16-3.4
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER}


### PR DESCRIPTION
## 🤔 What

We are using an old version of postgreSQL in production. To make sure our dev is align with this version we should force docker to use the same version.
Also fixing the sql file which is using some query which are not compatible with production.