### PR TITLE
Allow admin to view coordinate of sensitive entrances

### DIFF
--- a/api/controllers/v1/document/find-all.js
+++ b/api/controllers/v1/document/find-all.js
@@ -61,6 +61,7 @@ module.exports = async (req, res) => {
     documents,
     params,
     res,
-    (data) => toListFromController('documents', data, toDocument)
+    (data, meta) =>
+      toListFromController('documents', data, toDocument, { meta })
   );
 };

--- a/api/controllers/v1/document/find-by-caver-id.js
+++ b/api/controllers/v1/document/find-by-caver-id.js
@@ -46,6 +46,6 @@ module.exports = async (req, res) => {
     documents,
     params,
     res,
-    (data) => toListFromController('documents', data, toDocument)
+    (data, meta) => toListFromController('documents', data, toDocument, meta)
   );
 };

--- a/api/controllers/v1/document/get-snapshots.js
+++ b/api/controllers/v1/document/get-snapshots.js
@@ -26,7 +26,8 @@ module.exports = async (req, res) => {
       documentWithDescription,
       params,
       res,
-      (data) => toListFromController('documents', data, toDocument)
+      (data, meta) =>
+        toListFromController('documents', data, toDocument, { meta })
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/entrance-duplicate/find-all.js
+++ b/api/controllers/v1/entrance-duplicate/find-all.js
@@ -33,7 +33,8 @@ module.exports = async (req, res) => {
       duplicates,
       params,
       res,
-      (data) => toListFromController('duplicates', data, toEntranceDuplicate)
+      (data, meta) =>
+        toListFromController('duplicates', data, toEntranceDuplicate, { meta })
     );
   } catch (err) {
     ErrorService.getDefaultErrorHandler(res)(err);

--- a/api/controllers/v1/entrance/get-all-snapshots.js
+++ b/api/controllers/v1/entrance/get-all-snapshots.js
@@ -14,6 +14,7 @@ const {
   toSimpleRigging,
   toSimpleHistory,
 } = require('../../../services/mapping/converters');
+const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
   try {
@@ -98,7 +99,9 @@ module.exports = async (req, res) => {
       {
         descriptions: hDescriptions.flat().map((d) => toSimpleDescription(d)),
         documents: hDocuments.flat().map((d) => toDocument(d)),
-        entrances: hEntrances.flat().map((e) => toEntrance(e)),
+        entrances: hEntrances
+          .flat()
+          .map((e) => toEntrance(e, getMetaFromRequest(req))),
         locations: filteredLocations.flat().map((l) => toSimpleLocation(l)),
         riggings: hRiggings.flat().map((r) => toSimpleRigging(r)),
         histories: hHistories.flat().map((h) => toSimpleHistory(h)),

--- a/api/controllers/v1/entrance/get-snapshots.js
+++ b/api/controllers/v1/entrance/get-snapshots.js
@@ -25,7 +25,8 @@ module.exports = async (req, res) => {
       entrancesH,
       params,
       res,
-      (data) => toListFromController('entrances', data, toEntrance)
+      (data, meta) =>
+        toListFromController('entrances', data, toEntrance, { meta })
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/notification/find-all.js
+++ b/api/controllers/v1/notification/find-all.js
@@ -63,6 +63,7 @@ module.exports = async (req, res) => {
     populatedNotifications,
     params,
     res,
-    (data) => toListFromController('notifications', data, toNotification)
+    (data, meta) =>
+      toListFromController('notifications', data, toNotification, { meta })
   );
 };

--- a/api/controllers/v1/partner/find-for-carousel.js
+++ b/api/controllers/v1/partner/find-for-carousel.js
@@ -36,7 +36,8 @@ module.exports = (req, res) => {
         found,
         params,
         res,
-        (data) => toListFromController('organization', data, toOrganization)
+        (data, meta) =>
+          toListFromController('organization', data, toOrganization, { meta })
       );
     });
 };

--- a/api/services/ControllerService.js
+++ b/api/services/ControllerService.js
@@ -1,4 +1,6 @@
-const treatRange = (parameters, res, converter, found) => {
+const { getMetaFromRequest } = require('./mapping/utils');
+
+const treatRange = (parameters, req, res, converter, found) => {
   res.set('Accept-Range', `${parameters.searchedItem} ${parameters.maxRange}`);
 
   const rangeTo = Math.min(
@@ -44,7 +46,8 @@ const treatRange = (parameters, res, converter, found) => {
   );
 
   res.set('Access-Control-Expose-Headers', 'Content-Range');
-  return res.partialContent(converter(found));
+  const meta = getMetaFromRequest(req);
+  return res.partialContent(converter(found, meta));
 };
 
 module.exports = {
@@ -73,8 +76,9 @@ module.exports = {
       return res.notFound(`${parameters.searchedItem} not found`);
     }
     if (parameters.total > found.length) {
-      return treatRange(parameters, res, converter, found);
+      return treatRange(parameters, req, res, converter, found);
     }
-    return res.ok(converter(found));
+    const meta = getMetaFromRequest(req);
+    return res.ok(converter(found, meta));
   },
 };

--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -409,7 +409,7 @@ CREATE TABLE t_entrance (
 	altitude int2 NULL,
 	is_of_interest bool NULL,
 	id_cave int4 NULL,
-	id_country bpchar(2) NOT NULL,
+	id_country bpchar(2) NOT NULL DEFAULT '00'::bpchar,
 	id_geology bpchar(10) NOT NULL DEFAULT 'Q35758'::bpchar,
 	is_deleted bool NOT NULL DEFAULT false,
 	redirect_to int4 NULL,


### PR DESCRIPTION
Allows users with admin rights to view the coordinate of sensitive entrances.

This feature was present from a long time but was inadvertently removed in a recent change.

Also
- Prevent editing sensitive entrance coordinate when not an admin
- Adds a default value in the database for the entrance country
- Adds more fields in the converter for organization to fix edition in front
