### PR TITLE
feat(api): add marc record services and controller

### DIFF
--- a/api/controllers/v1/bibliographic-metadata/get-record-format.js
+++ b/api/controllers/v1/bibliographic-metadata/get-record-format.js
@@ -1,0 +1,49 @@
+const BibliographicMetadataService = require('../../../services/BibliographicMetadataService');
+const ControllerService = require('../../../services/ControllerService');
+const MarcConvertorService = require('../../../services/MarcConvertorService');
+
+/**
+ * Get Bibliographic metadata by ID and format
+ * GET /bibliographic-metadata/:id/format/:format
+ */
+module.exports = async (req, res) => {
+  const { id, format } = req.params;
+
+  if (!id || !format) {
+    return res.badRequest({
+      message: 'ID and format parameters are required',
+    });
+  }
+
+  const bibliographicMetadata =
+    await BibliographicMetadataService.getMetadata(id);
+
+  if (!bibliographicMetadata) {
+    return res.notFound({
+      message: `Record with ID ${id} not found`,
+    });
+  }
+  // Transform by the format selected
+  const [marcFormat, country] = format.split('-');
+  const [marcRecord, countrySelected] =
+    await MarcConvertorService.documentToMarc(
+      bibliographicMetadata,
+      marcFormat,
+      country
+    );
+
+  const response = {
+    metadata: marcRecord,
+    format: marcFormat,
+    country: countrySelected,
+  };
+
+  const params = {
+    controllerMethod: 'RecordController.getRecordByFormat',
+    searchedItem: `Record ${id} in format ${format}`,
+    notFoundMessage: `Record ${id} not found in format ${format}`,
+  };
+
+  // Use ControllerService to handle the response
+  return ControllerService.treat(req, null, response, params, res);
+};

--- a/api/services/BibliographicMetadataService.js
+++ b/api/services/BibliographicMetadataService.js
@@ -1,0 +1,27 @@
+const METADATA_STATUS = {
+  REGISTERED: 'registered',
+  DELETED: 'deleted',
+};
+
+module.exports = {
+  /**
+   * Get a bibliographic record by its ID
+   * @param {string} id - the ID of the record to retrieve
+   * @param {boolean} registeredOnly - if true, only return registered records; if false, return all records
+   */
+  async getMetadata(id, registeredOnly = true) {
+    const criteria = { id };
+
+    if (registeredOnly) {
+      criteria.metadataStatus = METADATA_STATUS.REGISTERED;
+    }
+
+    const Record = await sails.models.tbibliographicmetadata.findOne(criteria);
+
+    if (!Record) {
+      return null;
+    }
+
+    return Record;
+  },
+};

--- a/api/services/MarcConvertorService.js
+++ b/api/services/MarcConvertorService.js
@@ -1,0 +1,60 @@
+const defaultConvertor = require('./marcConvertor/country/Default');
+const ItConvertor = require('./marcConvertor/country/It');
+const Marc21Convertor = require('./marcConvertor/format/Marc21');
+const UnimarcConvertor = require('./marcConvertor/format/Unimarc');
+
+const MarcCountryTransformers = {
+  default: defaultConvertor,
+  it: ItConvertor,
+};
+
+const MarcFormatTransformers = {
+  marc21: Marc21Convertor,
+  unimarc: UnimarcConvertor,
+};
+
+module.exports = {
+  /**
+   * Converts a document to MARC format based on the specified format and country.
+   * @param {Object} document - The document to convert (OAI Metadata).
+   * @param {string} format - The MARC format to convert to (e.g., 'marc21', 'unimarc').
+   * @param {string} country - The country code for the MARC transformation (e.g., 'it', 'default').
+   * @return {Promise<string>} - A promise that resolves to the MARC record in ISO 2709 format.
+   */
+  documentToMarc: async (document, format, country) => {
+    if (!MarcFormatTransformers[format]) {
+      throw new Error(`Unsupported format: ${format}`);
+    }
+
+    // verify if country exist, if not exist take the default controller
+    let selectedCountry = country || 'default';
+    if (!MarcCountryTransformers[selectedCountry]) {
+      selectedCountry = 'default';
+    }
+
+    const marcCountryModule = MarcCountryTransformers[selectedCountry];
+    const marcFormatModule = MarcFormatTransformers[format];
+
+    // Normalize the document using the country-specific transformer
+    const normalizedData = await marcCountryModule.normalizeMarc(document);
+
+    // Convert the normalized data to MARC using the specified format transformer
+    const marcData = await marcFormatModule.transform(normalizedData);
+
+    // Convert the data to ISO 2709 format
+    const record = await marcData.transformDocumentToIso2709();
+    return [record, selectedCountry];
+  },
+
+  /**
+   * Returns the list of supported countries for MARC transformations.
+   * @return {Array<string>} - An array of country codes supported for MARC transformations
+   */
+  getSupportedCountries: () => Object.keys(MarcCountryTransformers),
+
+  /**
+   * Returns the list of supported formats for MARC transformations.
+   * @return {Array<string>} - An array of format names supported for MARC transformations
+   */
+  getSupportedFormats: () => Object.keys(MarcFormatTransformers),
+};

--- a/api/services/marcConvertor/MarcRecord.js
+++ b/api/services/marcConvertor/MarcRecord.js
@@ -1,0 +1,145 @@
+const { MarcRecord } = require('@natlibfi/marc-record');
+const { ISO2709 } = require('@natlibfi/marc-record-serializers');
+
+/**
+ * Class representing a MARC record.
+ * This class provides methods to create and manipulate MARC records using @natlibfi/marc-record
+ */
+class Marc {
+  constructor() {
+    this.record = new MarcRecord();
+  }
+
+  /**
+   * Adds a data field to the MARC record.
+   * @param {string} tag - The tag of the data field.
+   * @param {string} ind1 - The first indicator of the data field.
+   * @param {string} ind2 - The second indicator of the data field.
+   * @param {Array} subfields - An array of subfields, where each subfield is an array containing the subfield code and value.
+   */
+  addDataField(tag, ind1, ind2, subfields) {
+    const subfieldObjects = subfields.map((sf) => ({
+      code: sf[0],
+      value: sf[1],
+    }));
+
+    const field = {
+      tag,
+      ind1,
+      ind2,
+      subfields: subfieldObjects,
+    };
+
+    this.record.insertField(field);
+    return this;
+  }
+
+  /**
+   * Adds a control field to the MARC record.
+   * @param {string} tag - The tag of the control field.
+   * @param {string} value - The value of the control field.
+   */
+  addControlField(tag, value) {
+    const field = {
+      tag,
+      value: value.toString(),
+    };
+
+    this.record.insertField(field);
+    return this;
+  }
+
+  /**
+   * Sets the leader of the MARC record.
+   * @param {string} leader - The leader string to be set.
+   */
+  addLeader(leader) {
+    this.record.leader = leader;
+    return this;
+  }
+
+  /**
+   * Gets the MARC record.
+   * @returns {MarcRecord} The MARC record object.
+   */
+  getRecord() {
+    return this.record;
+  }
+
+  /**
+   * Clears the current MARC record, resetting it to a new empty record.
+   */
+  clear() {
+    this.record = new MarcRecord();
+    return this;
+  }
+
+  /**
+   * Returns a string representation of the MARC record.
+   * @return {string} The string representation of the MARC record.
+   */
+  toString() {
+    return this.record.toString();
+  }
+
+  /**
+   * Calculates the current length of the MARC record.
+   * @returns {number} The total length of the MARC record when serialized
+   */
+  getCurrentLength() {
+    try {
+      const iso2709String = ISO2709.to(this.record);
+      return iso2709String.length;
+    } catch (error) {
+      return 0;
+    }
+  }
+
+  /**
+   * Transforms the MARC record to ISO2709 format.
+   * @returns {Promise<string>} A promise that resolves to the ISO2709 formatted string.
+   */
+  transformDocumentToIso2709() {
+    return new Promise((resolve, reject) => {
+      try {
+        const iso2709String = ISO2709.to(this.record);
+        resolve(iso2709String);
+      } catch (error) {
+        reject(new Error(`Failed to convert to ISO2709: ${error.message}`));
+      }
+    });
+  }
+
+  /**
+   * Transforms the MARC record to ISO2709 format (synchronous version).
+   * @returns {string} The ISO2709 formatted string.
+   */
+  toIso2709() {
+    return ISO2709.to(this.record);
+  }
+
+  /**
+   * Finds fields by tag.
+   * @param {string} tag - The tag to search for.
+   * @returns {Array} Array of fields matching the tag.
+   */
+  getFieldsByTag(tag) {
+    return this.record.get(tag);
+  }
+
+  /**
+   * Validates the MARC record.
+   * @returns {boolean} True if the record is valid, false otherwise.
+   */
+  isValid() {
+    try {
+      // Try to serialize to check validity
+      ISO2709.to(this.record);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+}
+
+module.exports = Marc;

--- a/api/services/marcConvertor/Utils.js
+++ b/api/services/marcConvertor/Utils.js
@@ -1,0 +1,80 @@
+/**
+ * Extract specific identifier from identifiers array
+ * @param {Array} identifiers - Array of identifiers, each in the format "type:value"
+ * @param {string} type - The type of identifier to extract (e.g., isbn, issn, url, ...)
+ * @return {string|null} - The extracted identifier value or null if not found
+ */
+function extractIdentifier(identifiers, type) {
+  if (!identifiers || !Array.isArray(identifiers)) return null;
+
+  const identifier = identifiers.find((id) => id.startsWith(`${type}:`));
+  return identifier ? identifier.replace(`${type}:`, '') : null;
+}
+
+/**
+ * Format date for MARC
+ * @param {string|Date} date - The date to format, can be a string or Date object
+ * @returns {string} - The formatted date string in the format YYYYMMDDHHMM
+ */
+function formatDateForMarc(date) {
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const hours = String(d.getHours()).padStart(2, '0');
+  const minutes = String(d.getMinutes()).padStart(2, '0');
+  const seconds = String(d.getSeconds()).padStart(2, '0');
+
+  return `${year}${month}${day}${hours}${minutes}${seconds}.0`;
+}
+
+/**
+ * Get file format from URL
+ * @param {string} url - The URL to extract the file format from
+ */
+function getFileFormat(url) {
+  const extension = url.split('.').pop().toLowerCase();
+  const formatMap = {
+    pdf: 'application/pdf',
+    xml: 'application/xml',
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  };
+
+  return formatMap[extension] || null;
+}
+
+/**
+ * Get current date in YYYYMMDD format
+ */
+function getCurrentDateYYYYMMDD() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+
+  return `${year}${month}${day}`;
+}
+
+/** * Determine ISO 3166 country code format
+ * @param {string} countryCode - The country code to check
+ * @returns {number} - Returns 1 for 3-letter codes, 2 for longer codes, and 0 for shorter codes
+ */
+function determineIsoCode3166(countryCode) {
+  if (countryCode.length === 3) {
+    return 1;
+  }
+  if (countryCode.length > 3) {
+    return 2;
+  }
+
+  return 0;
+}
+
+module.exports = {
+  extractIdentifier,
+  formatDateForMarc,
+  getFileFormat,
+  getCurrentDateYYYYMMDD,
+  determineIsoCode3166,
+};

--- a/api/services/marcConvertor/country/Default.js
+++ b/api/services/marcConvertor/country/Default.js
@@ -1,0 +1,8 @@
+module.exports = {
+  /**
+   * Transform normalized document data to MARC format for everyone (default)
+   * @param {Object} document - Document data from your notice format
+   * @returns {Object} Normalized document data for MARC conversion
+   */
+  normalizeMarc: async (document) => document,
+};

--- a/api/services/marcConvertor/country/It.js
+++ b/api/services/marcConvertor/country/It.js
@@ -1,0 +1,22 @@
+module.exports = {
+  /**
+   * Transform normalized document data to MARC format for Italy
+   * @param {Object} document - Document data from your notice format
+   * @returns {Object} Normalized document data for MARC conversion
+   */
+  normalizeMarc: async (document) => {
+    const newBibliographicMetadata = document;
+
+    if (
+      document.dcCreators &&
+      document.dcCreators.length > 0 &&
+      document.dcCreators[0] !== 'Unknown'
+    ) {
+      newBibliographicMetadata.Responsability = document.dcCreators[0];
+    } else if (document.dcPublisher && document.dcPublisher !== 'Unknown') {
+      newBibliographicMetadata.Responsability = `edited by ${document.dcPublisher}`;
+    }
+
+    return newBibliographicMetadata;
+  },
+};

--- a/api/services/marcConvertor/format/Marc21.js
+++ b/api/services/marcConvertor/format/Marc21.js
@@ -1,0 +1,198 @@
+const Marc = require('../MarcRecord');
+const {
+  determineIsoCode3166,
+  formatDateForMarc,
+  extractIdentifier,
+} = require('../Utils');
+
+/**
+ * Generate MARC21 leader
+ * link : https://www.loc.gov/marc/bibliographic/bdleader.html
+ * @param {string} type - The type of document (e.g., 'article', 'book')
+ * @returns {string} - The MARC-21 leader string
+ */
+function generateLeader(type) {
+  let leader = '00000';
+  leader += 'n';
+
+  switch (type) {
+    case 'article':
+      leader += 'a';
+      break;
+    case 'book':
+      leader += 'a';
+      break;
+    case 'issue':
+      leader += 'a';
+      break;
+    default:
+      leader += 'a';
+  }
+
+  leader += 'm'; // monographic
+  leader += ' '; // position 08
+  leader += 'a'; // position 09
+  leader += '2'; // 10
+  leader += '2'; // 11
+  leader += '00000'; // base address placeholder
+  leader += ' '; // 17
+  leader += 'i'; // 18
+  leader += ' '; // 19
+  leader += '4'; // 20
+  leader += '5'; // 21
+  leader += '0'; // 22
+  leader += '0'; // 23
+
+  return leader;
+}
+
+module.exports = {
+  /**
+   * Transform normalized document data to MARC 21 format
+   * link : https://www.loc.gov/marc/bibliographic/
+   * @param {Object} document - Document data from your notice format
+   * @returns {Object} MARC 21 formatted data
+   */
+  transform: (document) => {
+    const marcRecord = new Marc();
+
+    const docType =
+      document.dcTypes && document.dcTypes.length > 0
+        ? document.dcTypes[0]
+        : 'unknown';
+    marcRecord.addLeader(generateLeader(docType));
+
+    marcRecord
+      .addControlField('001', document.id)
+      .addControlField('005', formatDateForMarc(document.lastUpdate));
+
+    if (document.dcTitle) {
+      const titleField = [['a', document.dcTitle]];
+      if (document.Responsability) {
+        titleField.push(['f', document.Responsability]);
+      }
+      marcRecord.addDataField('245', '0', '0', titleField);
+    }
+
+    if (
+      document.dcCreators &&
+      document.dcCreators.length > 0 &&
+      document.dcCreators[0] !== 'Unknown'
+    ) {
+      marcRecord.addDataField('100', ' ', ' ', [['a', document.dcCreators[0]]]);
+
+      if (document.dcCreators.length > 1) {
+        document.dcCreators.slice(1).forEach((creator) => {
+          marcRecord.addDataField('700', ' ', ' ', [['a', creator]]);
+        });
+      }
+    } else {
+      marcRecord.addDataField('100', ' ', ' ', [['a', 'Unknown Author']]);
+    }
+
+    if (document.dcContributor && document.dcContributor !== 'Unknown') {
+      marcRecord.addDataField('700', ' ', ' ', [['a', document.dcContributor]]);
+    }
+
+    if (document.dcPublisher && document.dcPublisher !== 'Unknown') {
+      const publisherField = [['b', document.dcPublisher]];
+
+      if (document.dcDate) {
+        publisherField.push(['c', document.dcDate.getFullYear().toString()]);
+      }
+
+      marcRecord.addDataField('260', ' ', ' ', publisherField);
+    }
+
+    if (document.dcLanguages && document.dcLanguages.length > 0) {
+      marcRecord.addDataField('041', '0', ' ', [
+        ['a', document.dcLanguages[0]],
+      ]);
+
+      if (document.dcLanguages.length > 1) {
+        document.dcLanguages.slice(1).forEach((lang) => {
+          marcRecord.addDataField('041', '0', ' ', [['a', lang]]);
+        });
+      }
+    }
+
+    if (document.dcDescriptions && document.dcDescriptions.length > 0) {
+      document.dcDescriptions.forEach((description) => {
+        marcRecord.addDataField('520', ' ', ' ', [['a', description]]);
+      });
+    }
+
+    if (document.dcCoverages && document.dcCoverages.length > 0) {
+      document.dcCoverages.forEach((coverage) => {
+        const isoCode = determineIsoCode3166(coverage);
+        if (isoCode === 1) {
+          marcRecord.addDataField('043', ' ', ' ', [['c', coverage]]);
+        } else {
+          marcRecord.addDataField('500', ' ', ' ', [['a', coverage]]);
+        }
+      });
+    }
+
+    if (document.dcSubjects && document.dcSubjects.length > 0) {
+      document.dcSubjects.forEach((subject) => {
+        marcRecord.addDataField('653', ' ', ' ', [['a', subject]]);
+      });
+    }
+
+    if (document.dcFormats && document.dcFormats.length > 0) {
+      document.dcFormats.forEach((format) => {
+        if (format) {
+          marcRecord.addDataField('856', ' ', ' ', [['q', format]]);
+        }
+      });
+    }
+
+    if (document.dcIdentifiers && document.dcIdentifiers.length > 0) {
+      document.dcIdentifiers.forEach((identifier) => {
+        const type = identifier.split(':')[0];
+        const value = extractIdentifier(identifier, type);
+        if (value) {
+          switch (type) {
+            case 'isbn':
+              marcRecord.addDataField('020', ' ', ' ', [['a', value]]);
+              break;
+            case 'issn':
+              marcRecord.addDataField('022', ' ', ' ', [['a', value]]);
+              break;
+            case 'ean':
+              marcRecord.addDataField('024', '3', ' ', [['a', value]]);
+              break;
+            case 'url':
+              marcRecord.addDataField('856', '4', '0', [['u', value]]);
+              break;
+            default:
+              break;
+          }
+        }
+      });
+    }
+
+    if (document.dcRelations && document.dcRelations.length > 0) {
+      document.dcRelations.forEach((relation) => {
+        marcRecord.addDataField('787', '0', ' ', [['n', relation]]);
+      });
+    }
+
+    if (document.dcRights && document.dcRights.length > 0) {
+      marcRecord.addDataField('540', ' ', ' ', [
+        ['a', `Licence: ${document.dcRights.join(', ')}`],
+      ]);
+    }
+
+    if (document.dcTypes && document.dcTypes.length > 0) {
+      document.dcTypes.forEach((type) => {
+        marcRecord.addDataField('655', ' ', '7', [['a', type]]);
+      });
+    }
+
+    marcRecord.addDataField('040', ' ', ' ', [['a', 'GrottoCenterAgencyCode']]);
+    marcRecord.addDataField('042', ' ', ' ', [['a', 'dc']]); // derivate of the dublin core format
+
+    return marcRecord;
+  },
+};

--- a/api/services/marcConvertor/format/Unimarc.js
+++ b/api/services/marcConvertor/format/Unimarc.js
@@ -1,0 +1,198 @@
+const Marc = require('../MarcRecord');
+const {
+  determineIsoCode3166,
+  getCurrentDateYYYYMMDD,
+  formatDateForMarc,
+  extractIdentifier,
+} = require('../Utils');
+
+/**
+ * Generate UNIMARC leader
+ * link : https://repository.ifla.org/server/api/core/bitstreams/f1aeb085-852e-4c1e-9683-7b08d5f1cde1/content
+ * @param {string} type - The type of document (e.g., 'article', 'book')
+ * @returns {string} - The UNIMARC leader string
+ */
+function generateLeader(type) {
+  let leader = '00000'; // size of the document
+  leader += 'n'; // status : new document
+
+  switch (
+    type // type of document (more need to be implemente)
+  ) {
+    case 'article':
+      leader += 'a';
+      break;
+    case 'book':
+      leader += 'a';
+      break;
+    default:
+      leader += 'a';
+  }
+
+  leader += 'm'; // bibliographic level
+  leader += ' ';
+  leader += 'a';
+  leader += '2'; // Unimarc code
+  leader += '2'; // Unimarc code
+  leader += '00000';
+  leader += '   ';
+  leader += '4';
+  leader += '5';
+  leader += '0';
+  leader += '0';
+
+  return leader;
+}
+
+module.exports = {
+  /**
+   * Transform normalized document data to UNIMARC format
+   * link : https://repository.ifla.org/server/api/core/bitstreams/f1aeb085-852e-4c1e-9683-7b08d5f1cde1/content
+   * @param {Object} document - Document data from your notice format
+   * @returns {Object} UNIMARC formatted data
+   */
+  transform: (document) => {
+    const marcRecord = new Marc();
+
+    sails.log.info(document);
+
+    marcRecord.addLeader(generateLeader(document.dcTypes));
+
+    marcRecord
+      .addControlField('001', document.id)
+      .addControlField('005', formatDateForMarc(document.lastUpdate));
+
+    if (document.dcTitle) {
+      const titleField = [['a', document.dcTitle]];
+      if (document.Responsability) {
+        titleField.push(['f', document.Responsability]);
+      }
+      marcRecord.addDataField('200', ' ', ' ', titleField);
+    }
+
+    if (
+      document.dcCreators &&
+      document.dcCreators.length > 0 &&
+      document.dcCreators[0] !== 'Unknown'
+    ) {
+      marcRecord.addDataField('700', ' ', ' ', [['a', document.dcCreators[0]]]); // Assuming first creator is the main author
+      if (document.dcCreators.length > 1) {
+        document.dcCreators.slice(1).forEach((creator) => {
+          marcRecord.addDataField('701', ' ', ' ', [['a', creator]]); // Additional authors
+        });
+      }
+    } else {
+      marcRecord.addDataField('700', ' ', ' ', [['a', 'Unknown Author']]);
+    }
+
+    if (document.dcContibutor) {
+      marcRecord.addDataField('800', ' ', ' ', [['a', document.dcContibutor]]);
+    }
+
+    if (document.dcPublisher && document.dcPublisher !== 'Unknown') {
+      marcRecord.addDataField('210', ' ', ' ', [['c', document.dcPublisher]]);
+    }
+
+    let field100 = getCurrentDateYYYYMMDD(); // Character 0-7
+    field100 += document.dcDate
+      ? `a${document.dcDate.getFullYear()}`
+      : '         '; // Character 8-16
+    field100 += '    a'; // Character 17-21
+    field100 +=
+      document.dcLanguages && document.dcLanguages > 0
+        ? document.dcLanguages[0]
+        : 'fre'; // Character 22-24
+    field100 += 'y'; // Character 25
+    field100 += '50      ba'; // Character 26-35
+    marcRecord.addDataField('100', ' ', ' ', [['a', field100]]);
+
+    if (document.dcLanguages && document.dcLanguages.length > 0) {
+      document.dcLanguages.forEach((lang) => {
+        marcRecord.addDataField('101', ' ', ' ', [['a', lang]]);
+      });
+    }
+
+    if (document.dcDescriptions) {
+      document.dcDescriptions.forEach((description) => {
+        marcRecord.addDataField('330', ' ', ' ', [['a', description]]);
+      });
+    }
+
+    if (document.dcCoverages && document.dcCoverages.length > 0) {
+      document.dcCoverages.forEach((coverage) => {
+        const isoCode = determineIsoCode3166(coverage);
+        if (isoCode === 1) {
+          marcRecord.addDataField('102', ' ', ' ', [['a', coverage]]); // ISO 3166-1
+        } else if (isoCode === 2) {
+          marcRecord.addDataField('102', ' ', ' ', [['c', coverage]]); // ISO 3166-2
+        }
+      });
+    }
+
+    if (document.dcSubjects && document.dcSubjects.length > 0) {
+      document.dcSubjects.forEach((subject) => {
+        marcRecord.addDataField('606', ' ', ' ', [['a', subject]]);
+      });
+    }
+
+    if (document.dcFormats && document.dcFormats.length > 0) {
+      document.dcFormats.forEach((format) => {
+        if (format) {
+          marcRecord.addDataField('856', ' ', ' ', [['q', format]]);
+        }
+      });
+    }
+
+    if (document.dcIdientifiers && document.dcIdentifiers.length > 0) {
+      document.dcIdentifiers.forEach((identifier) => {
+        const type = identifier.split(':')[0];
+        const value = extractIdentifier(identifier, type);
+        if (value) {
+          switch (type) {
+            case 'isbn':
+              marcRecord.addDataField('010', ' ', ' ', [['a', value]]);
+              break;
+            case 'issn':
+              marcRecord.addDataField('011', ' ', ' ', [['a', value]]);
+              break;
+            case 'ean':
+              marcRecord.addDataField('073', ' ', ' ', [['a', value]]);
+              break;
+            case 'url':
+              marcRecord.addDataField('856', ' ', ' ', [['u', value]]);
+              break;
+            default:
+              break;
+          }
+        }
+      });
+    }
+
+    if (document.dcRelations && document.dcRelations.length > 0) {
+      document.dcRelations.forEach((relation) => {
+        marcRecord.addDataField('461', ' ', ' ', [['t', relation]]);
+      });
+    }
+
+    if (document.dcRights) {
+      marcRecord.addDataField('540', ' ', ' ', [
+        ['a', `Licence :${document.dcRights}`],
+      ]);
+    }
+
+    if (document.dcTypes) {
+      const types = [];
+      document.dcTypes.forEach((type) => {
+        types.push(['a', type]);
+      });
+      marcRecord.addDataField('183', ' ', ' ', types);
+    }
+
+    marcRecord.addDataField('801', ' ', ' ', [
+      ['a', 'FR-740335301'],
+      ['b', 'BERNEX-BBS/SA'],
+    ]); // agency code
+
+    return marcRecord;
+  },
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -102,6 +102,9 @@ module.exports.policies = {
   'v1/document-type/find': true,
   'v1/document-type/find-all': true,
 
+  // Bibliographic Metadata (Record)
+  'v1/bibliographic-metadata/get-record-format': true,
+
   // Entrance
   'v1/entrance/count': true,
   'v1/entrance/public-count': true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -221,6 +221,10 @@ module.exports.routes = {
   'GET /api/v1/documents/types': 'v1/document-type/find-all',
   'GET /api/v1/documents/types/:id': 'v1/document-type/find',
 
+  // Bibliographic Metadata (Record)
+  'GET /api/v1/bibliographic-metadata/:id/format/:format':
+    'v1/bibliographic-metadata/get-record-format',
+
   // Description
   'PATCH /api/v1/descriptions/:id': 'v1/description/update',
   'POST /api/v1/descriptions': 'v1/description/create',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.664.0",
         "@azure/storage-blob": "^12.25.0",
+        "@babel/runtime": "^7.27.6",
+        "@natlibfi/marc-record": "^9.1.6",
+        "@natlibfi/marc-record-serializers": "^10.1.7-alpha.1",
         "archiver": "^7.0.1",
         "argon2": "^0.41.1",
         "ejs": "^3.1.10",
@@ -1276,6 +1279,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
@@ -2083,6 +2095,123 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@natlibfi/marc-record": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.6.tgz",
+      "integrity": "sha512-ceYJMRK3BHx3FpaRo7x8kMcC3iEj7CVgn8YFvqDyJJ7RdvKlSnfi8D15wrOjZPJxhi+R1UAmBXMWZzAMnWnORw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "jsonschema": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers": {
+      "version": "10.1.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.7-alpha.1.tgz",
+      "integrity": "sha512-J+T7WMXgXqn2XYPKEFxqEYTacXnFg4CTYuOMYLVtU01Nmv7S91aG8mmM6FgIrD7f7haSAL2jxeidR9Yw6+A80Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@natlibfi/marc-record": "^9.1.6",
+        "@xmldom/xmldom": "^0.9.8",
+        "stream-json": "^1.9.1",
+        "xml2js": "^0.6.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "marc-record-serializers": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@natlibfi/marc-record-serializers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@natlibfi/marc-record/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@natlibfi/marc-record/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2811,6 +2940,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -6334,7 +6472,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7600,6 +7737,15 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -10321,7 +10467,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11503,6 +11648,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/streamifier": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
@@ -12601,7 +12761,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12654,7 +12813,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12663,7 +12821,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12688,6 +12845,34 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12700,7 +12885,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -13843,6 +14027,11 @@
         "@babel/types": "^7.25.7"
       }
     },
+    "@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="
+    },
     "@babel/template": {
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
@@ -14442,6 +14631,86 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@natlibfi/marc-record": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.6.tgz",
+      "integrity": "sha512-ceYJMRK3BHx3FpaRo7x8kMcC3iEj7CVgn8YFvqDyJJ7RdvKlSnfi8D15wrOjZPJxhi+R1UAmBXMWZzAMnWnORw==",
+      "requires": {
+        "debug": "^4.4.1",
+        "jsonschema": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "@natlibfi/marc-record-serializers": {
+      "version": "10.1.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.7-alpha.1.tgz",
+      "integrity": "sha512-J+T7WMXgXqn2XYPKEFxqEYTacXnFg4CTYuOMYLVtU01Nmv7S91aG8mmM6FgIrD7f7haSAL2jxeidR9Yw6+A80Q==",
+      "requires": {
+        "@natlibfi/marc-record": "^9.1.6",
+        "@xmldom/xmldom": "^0.9.8",
+        "stream-json": "^1.9.1",
+        "xml2js": "^0.6.2",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -15037,6 +15306,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -17681,8 +17955,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-east-asian-width": {
       "version": "1.2.0",
@@ -18570,6 +18843,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
+    },
+    "jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -20594,8 +20872,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -21556,6 +21833,19 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+    },
+    "stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "requires": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "streamifier": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
@@ -22396,7 +22686,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -22406,14 +22695,12 @@
         "ansi-regex": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "strip-ansi": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -22462,6 +22749,27 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+          "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+        },
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        }
+      }
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -22470,8 +22778,7 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.664.0",
     "@azure/storage-blob": "^12.25.0",
+    "@babel/runtime": "^7.27.6",
+    "@natlibfi/marc-record": "^9.1.6",
+    "@natlibfi/marc-record-serializers": "^10.1.7-alpha.1",
     "archiver": "^7.0.1",
     "argon2": "^0.41.1",
     "ejs": "^3.1.10",


### PR DESCRIPTION
## 🤔 What

new routes to access to bibliographic metadata of documents (in marc format)

## 🤷‍♂️ Why

Give access to marc file for the server z3950

## 🔍 How

  - add GET /api/v1/bibliographicMetadata/:id/format/:format
    - :format -> marcFormat-country
    - marcFormat can be 'unimarc' or 'marc21'
    - country can be 'it' or 'default' (if not specify, set to'default')
  - add policies in policies.js
  - add services in services/BibliographicMetadataService.js (getMetadata)
  - add services in services/MarcConvertorServices.js
  - add convertors format and country specification
  - Marc class to handle MARC records fields and subfields

## 🧪 Testing

GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/unimarc-it -> work with marc record in unimarc and it specification
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/unimarc-i -> work with marc record in unimarc and default specification
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/unimarc -> work with marc record in unimarc and default specification
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/marc21-it -> work with marc record in marc21 and it specification
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/marc21-default -> work with marc record in marc21 and default specifiation
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/marc -> doesn't work
GET http://localhost:1337/api/v1/bibliographicMetadata/25030/format/-it -> doesn't work