### PR TITLE
Feat/oai optimization

### DIFF
--- a/api/controllers/v1/bibliographic-metadata/count.js
+++ b/api/controllers/v1/bibliographic-metadata/count.js
@@ -25,7 +25,6 @@ module.exports = async (req, res) => {
       until: req.query.until,
     };
 
-    // Configure metadata status filter
     const filter = {};
     if (req.query.includeDeleted !== 'true') {
       filter.metadataStatus = 'registered';
@@ -43,7 +42,6 @@ module.exports = async (req, res) => {
       parameters,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod: 'BibliographicMetadataController.getCount',
       searchedItem: 'count of bibliographic records',

--- a/api/controllers/v1/bibliographic-metadata/get-identifiers-paginated.js
+++ b/api/controllers/v1/bibliographic-metadata/get-identifiers-paginated.js
@@ -27,7 +27,6 @@ module.exports = async (req, res) => {
       offset: parseInt(req.query.offset, 10) || 0,
     };
 
-    // Configure metadata status filter (exclude deleted records by default)
     const filter = {};
     if (req.query.includeDeleted !== 'true') {
       filter.metadataStatus = 'registered';
@@ -52,7 +51,6 @@ module.exports = async (req, res) => {
       parameters,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod:
         'BibliographicMetadataController.getIdentifiersPaginated',

--- a/api/controllers/v1/bibliographic-metadata/get-identifiers.js
+++ b/api/controllers/v1/bibliographic-metadata/get-identifiers.js
@@ -27,7 +27,6 @@ module.exports = async (req, res) => {
       until: req.query.until,
     };
 
-    // Configure metadata status filter (exclude deleted records by default)
     const filter = {};
     if (req.query.includeDeleted !== 'true') {
       filter.metadataStatus = 'registered';
@@ -46,7 +45,6 @@ module.exports = async (req, res) => {
       parameters,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod: 'BibliographicMetadataController.getIdentifiers',
       searchedItem: 'bibliographic identifiers',

--- a/api/controllers/v1/bibliographic-metadata/get-record.js
+++ b/api/controllers/v1/bibliographic-metadata/get-record.js
@@ -23,9 +23,13 @@ module.exports = async (req, res) => {
 
     // Retrieve the specific bibliographic metadata record by its ID
     // Note: No status filter - returns both registered and deleted records
-    const record = await BibliographicMetadataService.getRecordById(id);
+    let record = await BibliographicMetadataService.getRecordById(id);
 
-    // Configure controller service parameters for standardized response handling
+    // Localize parent descriptions if record has parents
+    if (record) {
+      record = await sails.helpers.localizeParentDescriptions(record, req);
+    }
+
     const params = {
       controllerMethod: 'BibliographicMetadataController.getRecord',
       notFoundMessage: `Record with ID ${id} not found.`,

--- a/api/controllers/v1/bibliographic-metadata/get-records-paginated.js
+++ b/api/controllers/v1/bibliographic-metadata/get-records-paginated.js
@@ -27,7 +27,6 @@ module.exports = async (req, res) => {
       offset: parseInt(req.query.offset, 10) || 0,
     };
 
-    // Configure metadata status filter (exclude deleted records by default)
     const filter = {};
     if (req.query.includeDeleted !== 'true') {
       filter.metadataStatus = 'registered';
@@ -39,9 +38,16 @@ module.exports = async (req, res) => {
       filter
     );
 
+    // Localize parent descriptions for each record
+    const localizedRecords = await Promise.all(
+      result.records.map((record) =>
+        sails.helpers.localizeParentDescriptions(record, req)
+      )
+    );
+
     // Structure response with records, pagination metadata, and applied parameters
     const response = {
-      records: result.records,
+      records: localizedRecords,
       pagination: {
         total: result.total,
         limit: result.limit,
@@ -51,7 +57,6 @@ module.exports = async (req, res) => {
       parameters,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod: 'BibliographicMetadataController.getRecordsPaginated',
       searchedItem: 'bibliographic records',

--- a/api/controllers/v1/bibliographic-metadata/get-records.js
+++ b/api/controllers/v1/bibliographic-metadata/get-records.js
@@ -27,7 +27,6 @@ module.exports = async (req, res) => {
       until: req.query.until,
     };
 
-    // Configure metadata status filter (exclude deleted records by default)
     const filter = {};
     if (req.query.includeDeleted !== 'true') {
       filter.metadataStatus = 'registered';
@@ -39,14 +38,20 @@ module.exports = async (req, res) => {
       filter
     );
 
+    // Localize parent descriptions for each record
+    const localizedRecords = await Promise.all(
+      records.map((record) =>
+        sails.helpers.localizeParentDescriptions(record, req)
+      )
+    );
+
     // Structure response with records, count, and applied parameters
     const response = {
-      records,
-      count: records.length,
+      records: localizedRecords,
+      count: localizedRecords.length,
       parameters,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod: 'BibliographicMetadataController.getRecords',
       searchedItem: 'bibliographic records',

--- a/api/controllers/v1/bibliographic-metadata/get-sets.js
+++ b/api/controllers/v1/bibliographic-metadata/get-sets.js
@@ -24,7 +24,6 @@ module.exports = async (req, res) => {
       count: sets.length,
     };
 
-    // Configure controller service parameters for standardized response handling
     const params = {
       controllerMethod: 'BibliographicMetadataController.getSets',
       searchedItem: 'distinct sets',

--- a/api/helpers/localize-parent-descriptions.js
+++ b/api/helpers/localize-parent-descriptions.js
@@ -1,0 +1,85 @@
+/**
+ * Helper for localizing parent descriptions in bibliographic metadata records
+ *
+ * This helper adds localized parent information to dcDescriptions based on the
+ * client's language preference. It processes parent records and adds appropriate
+ * localized messages for collection and issue parents.
+ */
+
+module.exports = {
+  friendlyName: 'Localize parent descriptions',
+
+  description:
+    'Add localized parent information to dcDescriptions based on client language',
+
+  inputs: {
+    record: {
+      type: 'ref',
+      description: 'The bibliographic metadata record to process',
+      required: true,
+    },
+
+    req: {
+      type: 'ref',
+      description: 'The request object for i18n access',
+      required: true,
+    },
+  },
+
+  exits: {
+    success: {
+      description: 'Record with localized parent descriptions',
+      outputType: 'ref',
+    },
+  },
+
+  async fn(inputs) {
+    const { record, req } = inputs;
+
+    // If record doesn't exist or has no parents, return as-is
+    if (!record || !record.parents || record.parents.length === 0) {
+      return record;
+    }
+
+    const localizedDescriptions = [];
+
+    // Add existing descriptions first
+    if (record.dcDescriptions && record.dcDescriptions.length > 0) {
+      localizedDescriptions.push(...record.dcDescriptions);
+    }
+
+    // Process each parent to add localized description
+    record.parents.forEach((parent) => {
+      if (parent.dcTitle && parent.dcTypeGrottocenter) {
+        let localizedKey = '';
+
+        // Determine the appropriate localization key based on parent type
+        if (parent.dcTypeGrottocenter.includes('issue')) {
+          localizedKey = 'Parent issue title';
+        } else if (parent.dcTypeGrottocenter.includes('collection')) {
+          localizedKey = 'Parent collection title';
+        }
+
+        // Add localized parent description if we found a matching type
+        if (localizedKey) {
+          // Try to get localized prefix using req.i18n
+          let localizedPrefix = localizedKey; // fallback
+
+          // eslint-disable-next-line no-underscore-dangle
+          if (req.i18n && typeof req.i18n.__ === 'function') {
+            // eslint-disable-next-line no-underscore-dangle
+            localizedPrefix = req.i18n.__(localizedKey);
+          }
+
+          const finalMessage = `${localizedPrefix}: ${parent.dcTitle}`;
+          localizedDescriptions.push(finalMessage);
+        }
+      }
+    });
+
+    // Update the record's dcDescriptions
+    record.dcDescriptions = localizedDescriptions;
+
+    return record;
+  },
+};

--- a/api/helpers/localize-parent-descriptions.js
+++ b/api/helpers/localize-parent-descriptions.js
@@ -50,7 +50,7 @@ module.exports = {
 
     // Process each parent to add localized description
     record.parents.forEach((parent) => {
-      if (parent.dcTitle && parent.dcTypeGrottocenter) {
+      if (parent.dcTypeGrottocenter) {
         let localizedKey = '';
 
         // Determine the appropriate localization key based on parent type
@@ -71,7 +71,19 @@ module.exports = {
             localizedPrefix = req.i18n.__(localizedKey);
           }
 
-          const finalMessage = `${localizedPrefix}: ${parent.dcTitle}`;
+          // Handle missing or "Sans titre" titles - localize appropriately
+          let title = parent.dcTitle;
+          if (!title || title === 'Sans titre') {
+            // eslint-disable-next-line no-underscore-dangle
+            if (req.i18n && typeof req.i18n.__ === 'function') {
+              // eslint-disable-next-line no-underscore-dangle
+              title = req.i18n.__('Untitled');
+            } else {
+              title = 'Untitled';
+            }
+          }
+
+          const finalMessage = `${localizedPrefix}: ${title}`;
           localizedDescriptions.push(finalMessage);
         }
       }

--- a/api/services/BibliographicMetadataService.js
+++ b/api/services/BibliographicMetadataService.js
@@ -110,25 +110,24 @@ async function getOAIRecordsPaginatedWithoutSet(
     const { where } = buildOaiCriteria(parameters, filter);
 
     // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
-    const records = await sails.models.vbibliographicmetadata.find({
+    const rows = await sails.models.vbibliographicmetadata.find({
       where,
-      limit,
+      limit: limit + 1,
       skip: offset,
       sort: 'id ASC', // Pour assurer un ordre consistant
     });
 
-    // Requête pour le total (sans pagination)
-    const total = await module.exports.countRecords(parameters, filter);
+    const hasNext = rows.length > limit;
+    const records = hasNext ? rows.slice(0, limit) : rows;
 
     return {
       records,
-      total,
       limit,
       offset,
-      hasNext: offset + limit < total,
+      hasNext,
     };
   } catch (error) {
-    sails.log.error('Error in getOAIRecordsPaginated:', error);
+    sails.log.error('Error in getOAIRecordsPaginatedWithoutSet:', error);
     throw error;
   }
 }
@@ -182,36 +181,27 @@ async function getOAIRecordsPaginatedWithSet(
     LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
   `;
 
-    const recordsParams = [...sqlParams, limit, offset];
+    const recordsParams = [...sqlParams, limit + 1, offset];
     const { rows: ids } = await sails.sendNativeQuery(
       recordsQuery,
       recordsParams
     );
 
-    // Requête pour le total
-    const countQuery = `
-    SELECT COUNT(*) as total
-    FROM v_bibliographic_metadata
-    ${whereSQL} ${setCondition}
-  `;
-
-    const {
-      rows: [{ total }],
-    } = await sails.sendNativeQuery(countQuery, sqlParams);
+    const hasNext = ids.length > limit;
+    const idList = hasNext ? ids.slice(0, limit) : ids;
 
     const records = await sails.models.vbibliographicmetadata.find({
-      where: { id: ids.map((r) => r.id) },
+      where: { id: idList.map((r) => r.id) },
     });
 
     return {
       records,
-      total: parseInt(total, 10),
       limit,
       offset,
-      hasNext: offset + limit < parseInt(total, 10),
+      hasNext,
     };
   } catch (error) {
-    sails.log.error('Error in getOAIRecordsPaginated:', error);
+    sails.log.error('Error in getOAIRecordsPaginatedWithSet:', error);
     throw error;
   }
 }
@@ -221,30 +211,27 @@ async function getOAIIdentifiersPaginatedWithoutSet(
   filter = { metadataStatus: METADATA_STATUS.REGISTERED }
 ) {
   try {
-    // Validate and sanitize pagination parameters
     const limit = Math.max(0, parseInt(parameters.limit, 10) || 50);
     const offset = Math.max(0, parseInt(parameters.offset, 10) || 0);
 
     const { where } = buildOaiCriteria(parameters, filter);
 
-    // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
-    const identifiers = await sails.models.vbibliographicmetadata.find({
+    const rows = await sails.models.vbibliographicmetadata.find({
       where,
       select: ['oaiIdentifier', 'lastUpdate', 'listSets'],
-      limit,
+      limit: limit + 1,
       skip: offset,
-      sort: 'id ASC', // Pour assurer un ordre consistant
+      sort: 'id ASC',
     });
 
-    // Requête pour le total (sans pagination)
-    const total = await module.exports.countRecords(parameters, filter);
+    const hasNext = rows.length > limit;
+    const identifiers = hasNext ? rows.slice(0, limit) : rows;
 
     return {
       identifiers,
-      total,
       limit,
       offset,
-      hasNext: offset + limit < total,
+      hasNext,
     };
   } catch (error) {
     sails.log.error('Error in getOAIIdentifiersPaginatedWithoutSet:', error);
@@ -260,13 +247,11 @@ async function getOAIIdentifiersPaginatedWithSet(
     const limit = parseInt(parameters.limit, 10) || 50;
     const offset = parseInt(parameters.offset, 10) || 0;
 
-    // Si filtre par set, utiliser une requête SQL native pour les performances
     const setCondition = parameters.set ? `AND $1 = ANY(list_sets)` : '';
     const setParams = parameters.set ? [parameters.set] : [];
 
     const whereConditions = [];
 
-    // Only add metadata status filter if explicitly provided
     if (filter.metadataStatus) {
       whereConditions.push(`metadata_status = '${filter.metadataStatus}'`);
     }
@@ -274,7 +259,6 @@ async function getOAIIdentifiersPaginatedWithSet(
     const sqlParams = [...setParams];
     let paramIndex = setParams.length + 1;
 
-    // Ajouter les conditions de date
     if (parameters.from) {
       whereConditions.push(`last_update >= $${paramIndex}::timestamp`);
       sqlParams.push(parameters.from);
@@ -299,29 +283,20 @@ async function getOAIIdentifiersPaginatedWithSet(
       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
     `;
 
-    const identifiersParams = [...sqlParams, limit, offset];
-    const { rows: identifiers } = await sails.sendNativeQuery(
+    const identifiersParams = [...sqlParams, limit + 1, offset];
+    const { rows } = await sails.sendNativeQuery(
       identifiersQuery,
       identifiersParams
     );
 
-    // Requête pour le total
-    const countQuery = `
-      SELECT COUNT(*) as total
-      FROM v_bibliographic_metadata
-      ${whereSQL} ${setCondition}
-    `;
-
-    const {
-      rows: [{ total }],
-    } = await sails.sendNativeQuery(countQuery, sqlParams);
+    const hasNext = rows.length > limit;
+    const identifiers = hasNext ? rows.slice(0, limit) : rows;
 
     return {
       identifiers,
-      total: parseInt(total, 10),
       limit,
       offset,
-      hasNext: offset + limit < parseInt(total, 10),
+      hasNext,
     };
   } catch (error) {
     sails.log.error('Error in getOAIIdentifiersPaginatedWithSet:', error);

--- a/api/services/BibliographicMetadataService.js
+++ b/api/services/BibliographicMetadataService.js
@@ -109,12 +109,12 @@ async function getOAIRecordsPaginatedWithoutSet(
 
     const { where } = buildOaiCriteria(parameters, filter);
 
-    // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
+    // No set filter - use Waterline with pagination directly
     const rows = await sails.models.vbibliographicmetadata.find({
       where,
-      limit: limit + 1,
+      limit: limit + 1, // Fetch one extra record to determine if there are more pages (hasNext)
       skip: offset,
-      sort: 'id ASC', // Pour assurer un ordre consistant
+      sort: 'id ASC', // Ensure consistent ordering
     });
 
     const hasNext = rows.length > limit;
@@ -141,8 +141,8 @@ async function getOAIRecordsPaginatedWithSet(
     const limit = Math.max(0, parseInt(parameters.limit, 10) || 50);
     const offset = Math.max(0, parseInt(parameters.offset, 10) || 0);
 
-    // Si filtre par set, on doit utiliser une approche différente car array filtering
-    // Pour les performances, on utilise une requête SQL native
+    // Set filtering requires different approach due to array filtering
+    // Use native SQL query for performance
     const setCondition = parameters.set ? `AND $1 = ANY(list_sets)` : '';
     const setParams = parameters.set ? [parameters.set] : [];
 
@@ -156,7 +156,7 @@ async function getOAIRecordsPaginatedWithSet(
     const sqlParams = [...setParams];
     let paramIndex = setParams.length + 1;
 
-    // Ajouter les conditions de date
+    // Add date conditions
     if (parameters.from) {
       whereConditions.push(`last_update >= $${paramIndex}::timestamp`);
       sqlParams.push(parameters.from);
@@ -172,7 +172,7 @@ async function getOAIRecordsPaginatedWithSet(
       whereConditions.length > 0 ? whereConditions.join(' AND ') : '';
     const whereSQL = whereClause ? `WHERE ${whereClause}` : 'WHERE 1=1';
 
-    // Requête pour récupérer les records paginés
+    // Query to fetch paginated records
     const recordsQuery = `
     SELECT id_document as id
     FROM v_bibliographic_metadata
@@ -181,7 +181,7 @@ async function getOAIRecordsPaginatedWithSet(
     LIMIT $${paramIndex} OFFSET $${paramIndex + 1} 
   `;
 
-    const recordsParams = [...sqlParams, limit + 1, offset];
+    const recordsParams = [...sqlParams, limit + 1, offset]; // Fetch one extra record to check if there are more pages
     const { rows: ids } = await sails.sendNativeQuery(
       recordsQuery,
       recordsParams
@@ -219,7 +219,7 @@ async function getOAIIdentifiersPaginatedWithoutSet(
     const rows = await sails.models.vbibliographicmetadata.find({
       where,
       select: ['oaiIdentifier', 'lastUpdate', 'listSets'],
-      limit: limit + 1,
+      limit: limit + 1, // Fetch one extra identifier to determine if there are more pages (hasNext)
       skip: offset,
       sort: 'id ASC',
     });
@@ -274,7 +274,7 @@ async function getOAIIdentifiersPaginatedWithSet(
       whereConditions.length > 0 ? whereConditions.join(' AND ') : '';
     const whereSQL = whereClause ? `WHERE ${whereClause}` : 'WHERE 1=1';
 
-    // Requête pour récupérer les identifiers paginés (seulement les champs nécessaires)
+    // Query to fetch paginated identifiers (only necessary fields)
     const identifiersQuery = `
       SELECT oai_identifier as "oaiIdentifier", last_update as "lastUpdate", list_sets as "listSets"
       FROM v_bibliographic_metadata
@@ -283,7 +283,7 @@ async function getOAIIdentifiersPaginatedWithSet(
       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
     `;
 
-    const identifiersParams = [...sqlParams, limit + 1, offset];
+    const identifiersParams = [...sqlParams, limit + 1, offset]; // Fetch one extra identifier to check if there are more pages
     const { rows } = await sails.sendNativeQuery(
       identifiersQuery,
       identifiersParams
@@ -951,7 +951,7 @@ module.exports = {
     filter = { metadataStatus: METADATA_STATUS.REGISTERED }
   ) {
     try {
-      // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
+      // No set filter - use Waterline with pagination directly
       if (!parameters.set) {
         return getOAIRecordsPaginatedWithoutSet(parameters, filter);
       }
@@ -987,7 +987,7 @@ module.exports = {
     filter = { metadataStatus: METADATA_STATUS.REGISTERED }
   ) {
     try {
-      // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
+      // No set filter - use Waterline with pagination directly
       if (!parameters.set) {
         return getOAIIdentifiersPaginatedWithoutSet(parameters, filter);
       }

--- a/api/services/BibliographicMetadataService.js
+++ b/api/services/BibliographicMetadataService.js
@@ -178,7 +178,7 @@ async function getOAIRecordsPaginatedWithSet(
     FROM v_bibliographic_metadata
     ${whereSQL} ${setCondition}
     ORDER BY id_document ASC
-    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1} 
   `;
 
     const recordsParams = [...sqlParams, limit + 1, offset];
@@ -953,10 +953,10 @@ module.exports = {
     try {
       // Si pas de filtre set, on peut utiliser directement Waterline avec pagination
       if (!parameters.set) {
-        return this.getOAIRecordsPaginatedWithoutSet(parameters, filter);
+        return getOAIRecordsPaginatedWithoutSet(parameters, filter);
       }
 
-      return this.getOAIRecordsPaginatedWithSet(parameters, filter);
+      return getOAIRecordsPaginatedWithSet(parameters, filter);
     } catch (error) {
       sails.log.error('Error in getOAIRecordsPaginated:', error);
       throw error;

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -33,6 +33,7 @@ module.exports.i18n = {
     'fr',
     'he',
     'id',
+    'it',
     'nl',
     'pt',
     'ro',

--- a/config/locales/ar.json
+++ b/config/locales/ar.json
@@ -1,4 +1,5 @@
 {
 	"Parent collection title": "Parent collection title",
-	"Parent issue title": "Parent issue title"
+	"Parent issue title": "Parent issue title",
+	"Untitled": "Untitled"
 }

--- a/config/locales/ar.json
+++ b/config/locales/ar.json
@@ -1,1 +1,4 @@
-{}
+{
+	"Parent collection title": "Parent collection title",
+	"Parent issue title": "Parent issue title"
+}

--- a/config/locales/de.json
+++ b/config/locales/de.json
@@ -1,4 +1,5 @@
 {
   "Parent collection title": "Titel Übergeordnete Sammlung",
-  "Parent issue title": "Titel Übergeordnete Ausgabe"
+  "Parent issue title": "Titel Übergeordnete Ausgabe",
+  "Untitled": "Ohne Titel"
 }

--- a/config/locales/de.json
+++ b/config/locales/de.json
@@ -1,1 +1,4 @@
-{}
+{
+  "Parent collection title": "Titel Übergeordnete Sammlung",
+  "Parent issue title": "Titel Übergeordnete Ausgabe"
+}

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -26,5 +26,7 @@
   "validated": "validated",
   "We received a request to reset the password for your account.": "We received a request to reset the password for your account.",
   "You are receiving this email because of your subscription to the country %s.": "You are receiving this email because of your subscription to the country %s.",
-  "You are receiving this email because of your subscription to the massif %s.": "You are receiving this email because of your subscription to the massif %s."
+  "You are receiving this email because of your subscription to the massif %s.": "You are receiving this email because of your subscription to the massif %s.",
+  "Parent collection title": "Parent collection title",
+  "Parent issue title": "Parent issue title"
 }

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -28,5 +28,6 @@
   "You are receiving this email because of your subscription to the country %s.": "You are receiving this email because of your subscription to the country %s.",
   "You are receiving this email because of your subscription to the massif %s.": "You are receiving this email because of your subscription to the massif %s.",
   "Parent collection title": "Parent collection title",
-  "Parent issue title": "Parent issue title"
+  "Parent issue title": "Parent issue title",
+  "Untitled": "Untitled"
 }

--- a/config/locales/es.json
+++ b/config/locales/es.json
@@ -1,1 +1,4 @@
-{}
+{
+  "Parent collection title": "Título colección padre",
+  "Parent issue title": "Título revista padre"
+}

--- a/config/locales/es.json
+++ b/config/locales/es.json
@@ -1,4 +1,5 @@
 {
   "Parent collection title": "Título colección padre",
-  "Parent issue title": "Título revista padre"
+  "Parent issue title": "Título revista padre",
+  "Untitled": "Sin título"
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -29,5 +29,6 @@
   "You are receiving this email because of your subscription to the massif %s.": "Vous recevez cet email car vous êtes abonné au massif %s.",
   "Password Reset": "Password Reset",
   "Parent collection title": "Titre collection parente",
-  "Parent issue title": "Titre revue parente"
+  "Parent issue title": "Titre revue parente",
+  "Untitled": "Sans titre"
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -27,5 +27,7 @@
   "We received a request to reset the password for your account.": "Nous avons reçu une demande de réinitialisation du mot de passe de votre compte.",
   "You are receiving this email because of your subscription to the country %s.": "Vous recevez cet email car vous êtes abonné au pays %s.",
   "You are receiving this email because of your subscription to the massif %s.": "Vous recevez cet email car vous êtes abonné au massif %s.",
-  "Password Reset": "Password Reset"
+  "Password Reset": "Password Reset",
+  "Parent collection title": "Titre collection parente",
+  "Parent issue title": "Titre revue parente"
 }

--- a/config/locales/it.json
+++ b/config/locales/it.json
@@ -1,4 +1,6 @@
 {
   "Parent collection title": "Titolo collezione genitore",
-  "Parent issue title": "Titolo rivista genitore"
+  "Parent issue title": "Titolo rivista genitore",
+  "Untitled": "Senza titolo"
 }
+ 

--- a/config/locales/it.json
+++ b/config/locales/it.json
@@ -1,1 +1,4 @@
-{}
+{
+  "Parent collection title": "Titolo collezione genitore",
+  "Parent issue title": "Titolo rivista genitore"
+}

--- a/sql/4_materialized_views.sql
+++ b/sql/4_materialized_views.sql
@@ -191,43 +191,7 @@ SELECT
     ) as dc_languages,
     COALESCE(
       ARRAY_REMOVE(
-        ARRAY_CAT(
-          ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(btrim(td.body), '')), NULL),
-          ARRAY[
-            -- For an ARTICLE: add the parent issue name
-            CASE
-              WHEN tt.name ILIKE 'Article%' THEN
-                CASE
-                  WHEN d.id_parent IS NOT NULL THEN
-                    'Revue parente : ' || (
-                      SELECT COALESCE(NULLIF(btrim(tdp.title), ''), 'Sans titre')
-                      FROM t_document p
-                      LEFT JOIN t_description tdp ON tdp.id_document = p.id
-                      WHERE p.id = d.id_parent
-                      LIMIT 1
-                    )
-                  ELSE NULL
-                END
-              ELSE NULL
-            END,
-            -- For an ISSUE: add the parent collection name
-            CASE
-              WHEN tt.name ILIKE 'Issue%' THEN
-                (
-                  SELECT 'Collection parente : ' || COALESCE(NULLIF(btrim(tdc.title), ''), 'Sans titre')
-                  FROM doc_parents dp2
-                  JOIN t_document p2 ON p2.id = dp2.parent
-                  JOIN t_type tt2 ON tt2.id = p2.id_type
-                  LEFT JOIN t_description tdc ON tdc.id_document = p2.id
-                  WHERE dp2.child = d.id
-                    AND tt2.name ILIKE 'Collection'
-                  ORDER BY dp2.level ASC, dp2.parent
-                  LIMIT 1
-                )
-              ELSE NULL
-            END
-          ]
-        ),
+        ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(btrim(td.body), '')), NULL),
         NULL
       ),
       ARRAY[]::text[]

--- a/sql/4_materialized_views.sql
+++ b/sql/4_materialized_views.sql
@@ -96,7 +96,7 @@ WITH RECURSIVE doc_children(root, child, level) AS (
     SELECT 
         id_parent as root,
         id as child,
-        1 as level
+        1 as level 
     FROM t_document 
     WHERE id_parent IS NOT NULL
     
@@ -190,7 +190,46 @@ SELECT
       ARRAY[]::text[]
     ) as dc_languages,
     COALESCE(
-      ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(btrim(td.body), '')), NULL),
+      ARRAY_REMOVE(
+        ARRAY_CAT(
+          ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(btrim(td.body), '')), NULL),
+          ARRAY[
+            -- For an ARTICLE: add the parent issue name
+            CASE
+              WHEN tt.name ILIKE 'Article%' THEN
+                CASE
+                  WHEN d.id_parent IS NOT NULL THEN
+                    'Revue parente : ' || (
+                      SELECT COALESCE(NULLIF(btrim(tdp.title), ''), 'Sans titre')
+                      FROM t_document p
+                      LEFT JOIN t_description tdp ON tdp.id_document = p.id
+                      WHERE p.id = d.id_parent
+                      LIMIT 1
+                    )
+                  ELSE NULL
+                END
+              ELSE NULL
+            END,
+            -- For an ISSUE: add the parent collection name
+            CASE
+              WHEN tt.name ILIKE 'Issue%' THEN
+                (
+                  SELECT 'Collection parente : ' || COALESCE(NULLIF(btrim(tdc.title), ''), 'Sans titre')
+                  FROM doc_parents dp2
+                  JOIN t_document p2 ON p2.id = dp2.parent
+                  JOIN t_type tt2 ON tt2.id = p2.id_type
+                  LEFT JOIN t_description tdc ON tdc.id_document = p2.id
+                  WHERE dp2.child = d.id
+                    AND tt2.name ILIKE 'Collection'
+                  ORDER BY dp2.level ASC, dp2.parent
+                  LIMIT 1
+                )
+              ELSE NULL
+            END
+          ]
+        ),
+        NULL
+      ),
       ARRAY[]::text[]
     ) as dc_descriptions,
     COALESCE(

--- a/sql/4_materialized_views.sql
+++ b/sql/4_materialized_views.sql
@@ -137,7 +137,7 @@ children_agg AS (
         ARRAY_AGG(
             jsonb_build_object(
                 'id', dc.child,
-                'dcTitle', COALESCE(NULLIF(btrim(td_child.title), ''), 'Sans titre'),
+                'dcTitle', NULLIF(btrim(td_child.title), ''),
                 'dcTypeGrottocenter', lower(regexp_replace(tt_child.name, '\s+', '_', 'g'))
             ) ORDER BY dc.level, dc.child
         ) AS children
@@ -153,7 +153,7 @@ parents_agg AS (
         ARRAY_AGG(
             jsonb_build_object(
                 'id', dp.parent,
-                'dcTitle', COALESCE(NULLIF(btrim(td_parent.title), ''), 'Sans titre'),
+                'dcTitle', NULLIF(btrim(td_parent.title), ''),
                 'dcTypeGrottocenter', lower(regexp_replace(tt_parent.name, '\s+', '_', 'g'))
             ) ORDER BY dp.level, dp.parent
         ) AS parents

--- a/test/integration/1_services/BibliographicMetadataService.test.js
+++ b/test/integration/1_services/BibliographicMetadataService.test.js
@@ -114,7 +114,6 @@ describe('BibliographicMetadataService', () => {
       });
       result.records.should.be.an.Array();
       result.records.length.should.be.belowOrEqual(10);
-      result.total.should.be.a.Number();
       result.limit.should.equal(10);
       result.offset.should.equal(0);
       result.should.have.property('hasNext');
@@ -140,7 +139,6 @@ describe('BibliographicMetadataService', () => {
         {}
       );
       result.records.should.be.an.Array();
-      result.total.should.equal(21); // Includes deleted record
     });
 
     it('should filter by set in paginated results', async () => {
@@ -150,7 +148,6 @@ describe('BibliographicMetadataService', () => {
         offset: 0,
       });
       result.records.should.be.an.Array();
-      result.total.should.equal(4); // ids: 2, 8, 9, 18
       result.records.forEach((record) => {
         record.listSets.should.containEql('grottocenter:image');
       });
@@ -262,7 +259,6 @@ describe('BibliographicMetadataService', () => {
       });
       result.identifiers.should.be.an.Array();
       result.identifiers.length.should.be.belowOrEqual(5);
-      result.total.should.be.a.Number();
       result.limit.should.equal(5);
       result.offset.should.equal(0);
       result.should.have.property('hasNext');
@@ -288,7 +284,6 @@ describe('BibliographicMetadataService', () => {
         {}
       );
       result.identifiers.should.be.an.Array();
-      result.total.should.equal(21); // Includes deleted record
     });
 
     it('should filter by set in paginated results', async () => {
@@ -298,7 +293,6 @@ describe('BibliographicMetadataService', () => {
         offset: 0,
       });
       result.identifiers.should.be.an.Array();
-      result.total.should.equal(1); // Only id 7 is registered (id 13 is deleted)
       result.identifiers.forEach((identifier) => {
         identifier.listSets.should.containEql('grottocenter:collection');
       });
@@ -314,7 +308,6 @@ describe('BibliographicMetadataService', () => {
         {}
       );
       result.identifiers.should.be.an.Array();
-      result.total.should.equal(2); // ids 7 and 13
     });
 
     it('should handle pagination beyond available identifiers', async () => {
@@ -660,7 +653,6 @@ describe('BibliographicMetadataService', () => {
       result.records.should.be.an.Array();
       result.should.have.property('limit');
       result.should.have.property('offset');
-      result.should.have.property('total');
       result.should.have.property('hasNext');
     });
 
@@ -1181,7 +1173,6 @@ describe('BibliographicMetadataService', () => {
       });
       result.should.be.an.Object();
       result.records.length.should.equal(0);
-      result.total.should.equal(0);
     });
 
     it('should handle pagination with malformed set names', async () => {
@@ -1234,7 +1225,6 @@ describe('BibliographicMetadataService', () => {
         offset: 0,
       });
       result.should.be.an.Object();
-      result.total.should.equal(0);
       result.hasNext.should.be.false();
     });
   });

--- a/test/integration/4_routes/BibliographicMetadata/get-identifiers-paginated.test.js
+++ b/test/integration/4_routes/BibliographicMetadata/get-identifiers-paginated.test.js
@@ -32,7 +32,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
         res.body.should.have.property('parameters');
 
         // Check pagination metadata
-        res.body.pagination.should.have.property('total', 20); // Excludes id 13 (deleted)
         res.body.pagination.should.have.property('limit', 50);
         res.body.pagination.should.have.property('offset', 0);
         res.body.pagination.should.have.property('hasNext', false);
@@ -62,7 +61,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
 
         res.body.identifiers.length.should.equal(5);
         res.body.pagination.should.have.property('limit', 5);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', true);
 
         return done();
@@ -82,7 +80,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
         res.body.identifiers.length.should.equal(5);
         res.body.pagination.should.have.property('limit', 5);
         res.body.pagination.should.have.property('offset', 5);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', true);
 
         return done();
@@ -99,7 +96,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 21);
         res.body.identifiers.length.should.equal(21);
 
         // Should include the deleted record (id 13)
@@ -122,7 +118,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 5); // ids: 1, 4, 14, 15, 17
         res.body.identifiers.length.should.equal(5);
 
         // All returned identifiers should have the 'grottocenter:sound' set
@@ -144,7 +139,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 12); // actual count from CI
         res.body.identifiers.length.should.equal(12);
 
         // All returned identifiers should have lastUpdate >= 2025-01-10
@@ -169,7 +163,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 4); // actual count from CI
         res.body.identifiers.length.should.equal(4);
 
         // All returned identifiers should have lastUpdate <= 2025-01-05 23:59:59.999
@@ -194,7 +187,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 3); // ids: 2, 3, 4
         res.body.identifiers.length.should.equal(3);
 
         // All returned identifiers should be within the date range
@@ -223,7 +215,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 5); // Total sound records
         res.body.pagination.should.have.property('limit', 3);
         res.body.pagination.should.have.property('offset', 1);
         res.body.pagination.should.have.property('hasNext', true);
@@ -247,7 +238,6 @@ describe('Bibliographic Metadata Get Identifiers Paginated Controller', () => {
         if (err) return done(err);
 
         res.body.identifiers.length.should.equal(0);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', false);
 
         return done();

--- a/test/integration/4_routes/BibliographicMetadata/get-records-paginated.test.js
+++ b/test/integration/4_routes/BibliographicMetadata/get-records-paginated.test.js
@@ -32,7 +32,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
         res.body.should.have.property('parameters');
 
         // Check pagination metadata
-        res.body.pagination.should.have.property('total', 20); // Excludes id 13 (deleted)
         res.body.pagination.should.have.property('limit', 50);
         res.body.pagination.should.have.property('offset', 0);
         res.body.pagination.should.have.property('hasNext', false);
@@ -80,7 +79,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
 
         res.body.records.length.should.equal(5);
         res.body.pagination.should.have.property('limit', 5);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', true);
 
         return done();
@@ -98,7 +96,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
         res.body.records.length.should.equal(5);
         res.body.pagination.should.have.property('limit', 5);
         res.body.pagination.should.have.property('offset', 5);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', true);
 
         return done();
@@ -115,7 +112,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 21);
         res.body.records.length.should.equal(21);
 
         // Should include the deleted record (id 13)
@@ -139,7 +135,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 5); // ids: 1, 4, 14, 15, 17
         res.body.records.length.should.equal(5);
 
         // All returned records should have the 'grottocenter:sound' set
@@ -160,7 +155,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 12); // actual count from CI
         res.body.records.length.should.equal(12);
 
         // All returned records should have lastUpdate >= 2025-01-10
@@ -183,7 +177,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 4); // actual count from CI
         res.body.records.length.should.equal(4);
 
         // All returned records should have lastUpdate <= 2025-01-05 23:59:59.999
@@ -208,7 +201,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 3); // ids: 2, 3, 4
         res.body.records.length.should.equal(3);
 
         // All returned records should be within the date range
@@ -237,7 +229,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 5); // Total sound records
         res.body.pagination.should.have.property('limit', 3);
         res.body.pagination.should.have.property('offset', 1);
         res.body.pagination.should.have.property('hasNext', true);
@@ -262,7 +253,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
         if (err) return done(err);
 
         res.body.records.length.should.equal(0);
-        res.body.pagination.should.have.property('total', 20);
         res.body.pagination.should.have.property('hasNext', false);
 
         return done();
@@ -368,7 +358,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 4); // ids: 2, 8, 9, 18
         res.body.records.length.should.equal(2);
 
         // Validate each record has image set and correct type
@@ -393,7 +382,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 1); // Only id 7 is registered (id 13 is deleted)
         res.body.records.length.should.equal(1);
 
         const record = res.body.records[0];
@@ -416,7 +404,6 @@ describe('Bibliographic Metadata Get Records Paginated Controller', () => {
       .end((err, res) => {
         if (err) return done(err);
 
-        res.body.pagination.should.have.property('total', 2); // ids 7 and 13
         res.body.records.length.should.equal(2);
 
         // Find both records


### PR DESCRIPTION
🤔 What
Remove COUNT(*) from pagination in OAI endpoints (records / identifiers).

Switch to a lighter pagination strategy with a clear “next page” indicator.

Enrich metadata by adding the parent title into descriptions:

Article → shows the parent issue title.

Journal/issue → shows the parent collection title.

🤷‍♂️ Why
Reduce database load and improve response times.

Make it easier for PMB to reconstruct the hierarchy (collection → journal → article).

🔍 How
Pagination now fetches slightly more than the requested page size to determine if a next page exists, then returns exactly the requested size plus a boolean hasNext.

The materialized view computes the titles of the immediate parent and the nearest ancestor , and injects them into the description depending on the document type.