### PR TITLE
fix(deps): add npmrc to rebuild native modules for deployment compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+rebuild-bundle=true


### PR DESCRIPTION
## 🤔 What

_Fix GLIBC compatibility issue for argon2 native module deployment._

- Add `.npmrc` configuration to force rebuilding native modules
- Resolve `GLIBC_2.34 not found` error on Azure App Service

## 🤷♂️ Why

_After upgrading argon2 to v0.44.0, the deployment started failing with a GLIBC version mismatch error. The prebuilt binaries included with argon2 were compiled against GLIBC 2.34, but the Azure App Service environment has an older GLIBC version._

## 🔍 How

_Added `.npmrc` file with `rebuild-bundle=true` setting. This forces npm to rebuild all native modules (including argon2) during installation on the target environment instead of using prebuilt binaries, ensuring compatibility with the server's GLIBC version._

## 🧪 Testing

_Deploy to Azure App Service and verify the API starts without GLIBC errors. Test authentication endpoints that use argon2 for password hashing._

## 📸 Previews

_No UI changes - this is a deployment configuration fix._