### PR TITLE
feat(subscription): allows admins to unsubscribe anyone. Documents permission and ES index

### DIFF
--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -1,0 +1,324 @@
+# Permission Management System
+
+## Overview
+
+Grottocenter API implements a **Role-Based Access Control (RBAC) Level 1** system where users are assigned to roles and permissions are checked based on role membership. The system uses a combination of route-level policies and controller-level permission checks.
+
+## User Roles
+
+Roles are **not hierarchical**; for instance, an Administrator does not automatically inherit all permissions of a Moderator, nevertheless, **a user can be assigned multiple roles** cumulating their permissions.
+
+### 1. **Visitor** (Anonymous Users)
+- **Description**: Non-authenticated users
+- **Permissions**:
+  - View public cave/entrance/document/organisation/massif/person data
+  - Search through cave/entrance/document/organisation/massif/person data
+  - View complete entity history
+  - View statistics
+  - View all organization details
+  - Access API documentation
+  - Access API within the rate limits
+
+### 2. **User** (Authenticated Users)
+- **Description**: Default authenticated users role
+- **Permissions**: All Visitor permissions plus:
+  - **Content Management**:
+    - Create caves, entrances, documents, Massifs, Organisations, comments, descriptions, locations, riggings, histories
+    - Edit caves, entrances, documents, Massifs, Organisations, descriptions, locations, riggings, histories
+    - Edit own comments
+    - Unlink documents from entities
+    - Rollback to a previous version of any content
+    - Add/remove own explored entrances
+  - **Personal Management**:
+    - Manage personal profile and settings
+    - Join/leave organizations (own membership only)
+  - **Organization Membership**:
+    - Manage own organization memberships
+    - Manage explored caves for organizations they belong to
+
+### 3. **Leader** (Regional Leaders)
+- **Description**: Contributors that others can refer to for questions
+- **Permissions**: All User permissions plus:
+  - **Regional Management**:
+    - Subscribe/unsubscribe to country notifications
+    - Subscribe/unsubscribe to massif notifications
+    - Subscribe/unsubscribe to region notifications
+  - **Data Export**:
+    - Download full database export
+
+### 4. **Moderator** (Content Reviewers)
+- **Description**: Content reviewers and validators
+- **Permissions**: All User permissions plus:
+  - **Content Moderation**:
+    - Delete/restore any caves, entrances, documents, comments, descriptions, locations, riggings, histories, organisations, massifs, documents
+    - Update any user's comments
+    - Validate documents
+    - Manage duplicates (documents and entrances)
+  - **Advanced Access**:
+    - View deleted content
+    - Access moderation tools and interfaces
+  - **Explored Cave Management**:
+    - Add/remove explored caves for any organization
+
+### 5. **Administrator** (System Administrators)
+- **Description**: Technical responsible for the application
+- **Permissions**: All User permissions plus:
+  - **User Management**:
+    - Assign/remove user roles
+    - Manage any user accounts
+    - Delete user accounts
+    - View user lists (authors, contributors, users)
+    - View complete user information
+    - Cancel any user's subscriptions
+  - **System Operations**:
+    - Import data from CSV files (documents and entrances)
+    - System configuration and maintenance
+  - **Sensitive Data Management**:
+    - Remove sensitive flag from entrances
+    - Modify coordinates of sensitive entrances
+    - Access all sensitive entrance data
+  - **Advanced Organization Management**:
+    - Add/remove explored caves for any organization
+    - Manage organization memberships for any user
+
+## Comprehensive Permission Matrix
+
+| Action                                                        | Visitor | User | Leader | Moderator | Administrator |
+|---------------------------------------------------------------|---------|------|--------|-----------|---------------|
+| **Public Data Access**                                        |
+| View public cave/entrance/document/organisation/massif/person | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View non-sensitive coordinates                                | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Search content                                                | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View statistics                                               | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View history                                                  | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Content Creation**                                          |
+| Create caves/entrances/document/organisation/massif/person    | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Create comments/descriptions/locations/riggings/histories     | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Content Modification**                                      |
+| Update caves/entrances/document/organisation/massif/person    | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update descriptions/locations/riggings/histories              | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update own comments                                           | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update any comment                                            | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Soft delete any content                                       | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **Soft-deleted Content Management**                           |
+| View soft-deleted content                                     | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Restore soft-deleted content                                  | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Permanent delete                                              | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Document Management**                                       |
+| Validate documents                                            | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Manage document duplicates                                    | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Unlink documents from entities                                | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Organization Management**                                   |
+| Join/leave own organizations                                  | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Revoke any user's organization membership                     | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Explored Cave Management**                                  |
+| Add/remove explored caves (own orgs)                          | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Add/remove explored caves (any org)                           | ❌ | ❌ | ❌ | ✅ | ✅ |
+| **Subscriptions & Notifications**                             |
+| Manage own subscriptions                                      | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Cancel any user's subscriptions                               | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Sensitive Data Access**                                     |
+| View sensitive entrance coordinates                           | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Modify sensitive entrance coordinates                         | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Remove sensitive flag                                         | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **User Management**                                           |
+| View user lists                                               | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Manage user roles                                             | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Delete user accounts                                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **System Operations**                                         |
+| Import data from CSV                                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Download full database export                                 | ❌ | ❌ | ✅ | ❌ | ❌ |
+
+## Special Permission Cases
+
+### Sensitive Entrance Data
+- **Coordinates**: Only Moderators and Administrators can view coordinates of sensitive entrances
+- **Locations**: Sensitive entrance location descriptions are hidden from non-privileged users
+- **Modification**: Only Administrators can remove the sensitive flag or modify coordinates of sensitive entrances
+- **Creation**: Any authenticated user can mark an entrance as sensitive, but coordinates are then hidden from their own
+  view
+- **Restriction**: Once marked as sensitive, only Administrators can unmark an entrance (remove the sensitive flag)
+
+### Organization-Based Permissions
+- **Membership Management**: Users can only manage their own organization memberships
+- **Explored Cave Management**: Organization members can add/remove explored caves for organizations they belong to
+- **Administrative Override**: Moderators and Administrators can manage any organization's explored caves and
+  memberships
+
+### Owner-Based Access Control
+- **Content Ownership**: Users can modify any content except other's comments
+- **Moderator Override**: Moderators and Administrators can modify any content regardless of ownership
+- **Comment Updates**: Users can update their own comments; Moderators can update any comments
+
+### Snapshot and History Access
+- **Public History**: Available to all users for non-sensitive content
+- **Sensitive History**: Historical data for sensitive entrances requires Administrator privileges
+
+## Security Features
+
+### JWT Token Authentication
+- All authenticated endpoints require valid JWT tokens
+- Tokens contain user ID and role memberships
+- Tokens are validated by the `tokenAuth` policy
+
+### Ownership-Based Access
+- Users can modify their own content
+- Moderators and Administrators can override ownership
+- Organization members can manage their organization's explored caves
+
+### Sensitive Data Protection
+- Sensitive entrance coordinates are hidden from everyone except Administrators
+- Only Administrators can modify sensitive entrance coordinates
+
+### Soft Deletes
+- Content is soft-deleted (marked as deleted, not removed)
+- Only Moderators+ can restore deleted content
+- Administrators can perform permanent deletions
+
+## Architecture
+
+### Three-Layer Permission Model
+
+1. **Route Level** (`config/policies.js`)
+- `false` - Blocked (default)
+- `true` - Public access (no authentication required)
+- `'tokenAuth'` - Requires valid JWT token
+
+2. **Controller Level** (`RightService.hasGroup()`)
+- Role-based permission checks
+- Owner-based access control
+
+3. **Business Logic Level**
+- Resource-specific permissions
+- Contextual access control
+
+## Implementation Details
+
+### Database Schema
+
+```sql
+-- User groups/roles
+CREATE TABLE t_group (
+  id smallserial PRIMARY KEY,
+  name varchar(200) NOT NULL,
+  comments varchar(1000)
+);
+
+-- User-to-group assignments
+CREATE TABLE j_caver_group (
+  id_caver int4 NOT NULL,
+  id_group int2 NOT NULL,
+  PRIMARY KEY (id_caver, id_group)
+);
+```
+
+### Code Examples
+
+#### Route-Level Policy
+```javascript
+// config/policies.js
+module.exports.policies = {
+  '*': false, // Deny all by default
+  'v1/entrance/find': true, // Public access
+  'v1/entrance/create': 'tokenAuth', // Requires authentication
+};
+```
+
+#### Role-Based Permission Check
+```javascript
+// In controllers
+const hasRight = RightService.hasGroup(
+  req.token.groups,
+  RightService.G.MODERATOR
+);
+if (!hasRight) {
+  return res.forbidden('You are not authorized to perform this action.');
+}
+```
+
+#### Owner-Based Access Control
+```javascript
+// Users can edit their own content, moderators can edit any content
+if (req.token.id !== resource.author) {
+  const hasModeratorRight = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.MODERATOR
+  );
+  if (!hasModeratorRight) {
+    return res.forbidden('You can only edit your own content.');
+  }
+}
+```
+
+#### Organization Membership Check
+```javascript
+// Check if user is member of organization for cave explorer management
+const memberQuery = `
+  SELECT 1 FROM j_grotto_caver
+  WHERE id_caver = $1 AND id_grotto = $2
+`;
+const memberResult = await sails.sendNativeQuery(memberQuery, [
+  req.token.id,
+  organizationId,
+]);
+const isMember = memberResult.rows.length > 0;
+
+if (!hasAdminRight && !hasModeratorRight && !isMember) {
+  return res.forbidden('You are not authorized to manage cave explorers.');
+}
+```
+
+#### Sensitive Data Access Control
+```javascript
+// Hide coordinates and locations for sensitive entrances
+result.latitude = !isSensitive || meta?.hasCompleteViewRight === true
+  ? parseFloat(source.latitude)
+  : null;
+result.longitude = !isSensitive || meta?.hasCompleteViewRight === true
+  ? parseFloat(source.longitude)
+  : null;
+result.locations = !source.isSensitive || meta?.hasCompleteViewRight === true
+  ? toList('locations', source, toSimpleLocation)
+  : [];
+```
+
+## Adding New Permissions
+
+### 1. Route-Level Permission
+Add to `config/policies.js`:
+```javascript
+'v1/new-endpoint/action': 'tokenAuth',
+```
+
+### 2. Role-Based Permission
+Add to controller:
+```javascript
+const hasRight = RightService.hasGroup(
+  req.token.groups,
+  RightService.G.REQUIRED_ROLE
+);
+```
+
+### 3. New Role
+1. Add to `t_group` table
+2. Update `RightService.G` constants
+3. Add permission checks in relevant controllers
+
+### 4. Organization-Based Permission
+Add membership check:
+```javascript
+const isMember = await checkOrganizationMembership(req.token.id, organizationId);
+if (!hasAdminRight && !isMember) {
+  return res.forbidden('You must be a member of this organization.');
+}
+```
+
+### 5. Sensitive Data Permission
+Add sensitive data check:
+```javascript
+const hasCompleteViewRight = RightService.hasGroup(
+  req.token.groups,
+  RightService.G.ADMINISTRATOR
+);
+// Use hasCompleteViewRight in converters to show/hide sensitive data
+```

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ You first need to merge your changes to `master` using if possible the `git flow
 
 For more information see the wiki page [Production deployment](https://github.com/GrottoCenter/Grottocenter3/wiki/Production-deployment)
 
+### Permission System
+
+Grottocenter API implements a Role-Based Access Control (RBAC) system with 5 user roles: Visitor, User, Leader, Moderator, and Administrator. Each role has specific permissions for accessing and modifying content.
+
+For detailed information about roles, permissions, and implementation, see [here](PERMISSION_SYSTEM.md).
+
 ### Git
 
 #### Workflow

--- a/api/controllers/v1/bibliographic-metadata/get-record-format.js
+++ b/api/controllers/v1/bibliographic-metadata/get-record-format.js
@@ -15,7 +15,8 @@ module.exports = async (req, res) => {
     });
   }
 
-  const ids = id.includes(',') ? id.split(',').map((i) => i.trim()) : id;
+  const ids = id.includes(',') ? id.split(',').map((i) => i.trim()) : [id];
+  const isMultipleIds = id.includes(',');
   const bibliographicMetadata =
     await BibliographicMetadataService.getMetadata(ids);
 
@@ -55,7 +56,14 @@ module.exports = async (req, res) => {
       notFoundMessage: `Record ${id} not found in format ${format}`,
     };
 
-    return ControllerService.treat(req, null, response, params, res);
+    // Return array only if multiple IDs were requested
+    return ControllerService.treat(
+      req,
+      null,
+      isMultipleIds ? response : response[0],
+      params,
+      res
+    );
   }
 
   const [marcRecord, countrySelected] =

--- a/api/controllers/v1/cave/find.js
+++ b/api/controllers/v1/cave/find.js
@@ -7,6 +7,8 @@ const {
 } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
+  const caveId = Number(req.params.id);
+
   const hasRight = RightService.hasGroup(
     req.token?.groups,
     RightService.G.MODERATOR
@@ -15,8 +17,8 @@ module.exports = async (req, res) => {
   const where = {};
   if (!hasRight) where.isDeleted = false;
 
-  const params = { searchedItem: `Cave of id ${req.params.id}` };
-  const cave = await CaveService.getPopulatedCave(req.params.id, where);
+  const params = { searchedItem: `Cave of id ${caveId}` };
+  const cave = await CaveService.getPopulatedCave(caveId, where);
 
   if (!cave) return res.notFound(`${params.searchedItem} not found`);
   return ControllerService.treatAndConvert(

--- a/api/controllers/v1/caver/find.js
+++ b/api/controllers/v1/caver/find.js
@@ -4,7 +4,8 @@ const DocumentService = require('../../../services/DocumentService');
 const { toCaver } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
-  const caverId = req.params.id;
+  const caverId = Number(req.params.id);
+
   const params = { searchedItem: `Caver of id ${caverId}` };
 
   const caverFound = await CaverService.getCaver(caverId);

--- a/api/controllers/v1/country/unsubscribe.js
+++ b/api/controllers/v1/country/unsubscribe.js
@@ -1,13 +1,25 @@
 const RightService = require('../../../services/RightService');
 
 module.exports = async (req, res) => {
-  // Check right
-  const hasRight = RightService.hasGroup(
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  const isLeader = RightService.hasGroup(
     req.token.groups,
     RightService.G.LEADER
   );
-  if (!hasRight) {
-    return res.forbidden('You are not authorized to unsubscribe to a country.');
+
+  if (!isAdmin && !isLeader) {
+    return res.forbidden(
+      'You are not authorized to unsubscribe from a country.'
+    );
+  }
+
+  const targetUserId = req.param('userId') || req.token.id;
+
+  if (!isAdmin && targetUserId !== req.token.id) {
+    return res.forbidden('You can only unsubscribe yourself.');
   }
 
   // Check if country exists
@@ -17,16 +29,20 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Country with id ${countryId} not found.` });
   }
 
-  const caver = await TCaver.findOne(req.token.id).populate(
+  const caver = await TCaver.findOne(targetUserId).populate(
     'subscribedToCountries'
   );
-  if (!caver.subscribedToCountries.find((m) => m.id === country.id)) {
+
+  if (
+    !isAdmin &&
+    !caver.subscribedToCountries.find((m) => m.id === country.id)
+  ) {
     return res.badRequest(
       `You are not subscribed to the country with id ${countryId} and therefore cannot be unsubscribed.`
     );
   }
 
-  await TCaver.removeFromCollection(req.token.id, 'subscribedToCountries', [
+  await TCaver.removeFromCollection(targetUserId, 'subscribedToCountries', [
     countryId,
   ]);
   return res.ok();

--- a/api/controllers/v1/document-duplicate/find.js
+++ b/api/controllers/v1/document-duplicate/find.js
@@ -14,12 +14,7 @@ module.exports = async (req, res) => {
     );
   }
 
-  const duplicateId = req.param('id');
-
-  // Validate ID is a number
-  if (!duplicateId || Number.isNaN(parseInt(duplicateId, 10))) {
-    return res.badRequest('Invalid duplicate ID format');
-  }
+  const duplicateId = Number(req.param('id'));
 
   const duplicate =
     await TDocumentDuplicate.findOne(duplicateId).populate('author');

--- a/api/controllers/v1/document/find.js
+++ b/api/controllers/v1/document/find.js
@@ -43,8 +43,7 @@ async function getModifiedDocumentData(documentId) {
     filesCriterias.id = { '!=': filesToIgnoreId };
   }
 
-  const files = await TFile.find(filesCriterias);
-  populatedDoc.files = files; // Other current document File
+  populatedDoc.files = await TFile.find(filesCriterias);
   populatedDoc.newFiles = newFiles;
   populatedDoc.deletedFiles = deletedFiles;
   populatedDoc.modifiedFiles = modifiedFiles;
@@ -53,6 +52,8 @@ async function getModifiedDocumentData(documentId) {
 }
 
 module.exports = async (req, res) => {
+  const documentId = Number(req.param('id'));
+
   const hasRight = RightService.hasGroup(
     req.token?.groups,
     RightService.G.MODERATOR
@@ -61,15 +62,15 @@ module.exports = async (req, res) => {
   let document;
   // Get the modified document
   if (req.param('requireUpdate') === 'true')
-    document = await getModifiedDocumentData(req.param('id'));
+    document = await getModifiedDocumentData(documentId);
 
   // Get the base document
   if (!document)
-    document = await DocumentService.getPopulatedDocument(req.param('id'));
+    document = await DocumentService.getPopulatedDocument(documentId);
 
   const params = {
     controllerMethod: 'DocumentController.find',
-    searchedItem: `Document of id ${req.param('id')}`,
+    searchedItem: `Document of id ${documentId}`,
   };
   if (!document) return res.notFound(`${params.searchedItem} not found`);
 

--- a/api/controllers/v1/entrance-duplicate/find.js
+++ b/api/controllers/v1/entrance-duplicate/find.js
@@ -3,7 +3,7 @@ const EntranceService = require('../../../services/EntranceService');
 const { toEntranceDuplicate } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
-  const id = req.param('id');
+  const id = Number(req.param('id'));
 
   const duplicateFound =
     await TEntranceDuplicate.findOne(id).populate('author');

--- a/api/controllers/v1/entrance/find.js
+++ b/api/controllers/v1/entrance/find.js
@@ -8,9 +8,6 @@ const {
 
 module.exports = async (req, res) => {
   const entranceId = Number(req.params.id);
-  if (!Number.isInteger(entranceId)) {
-    return res.notFound(`Entrance of id ${req.params.id} not found`);
-  }
 
   const hasRight = RightService.hasGroup(
     req.token?.groups,

--- a/api/controllers/v1/massif/find.js
+++ b/api/controllers/v1/massif/find.js
@@ -7,13 +7,15 @@ const {
 } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
+  const massifId = Number(req.params.id);
+
   const hasRight = RightService.hasGroup(
     req.token?.groups,
     RightService.G.MODERATOR
   );
 
-  const params = { searchedItem: `Massif of id ${req.params.id}` };
-  const massif = await MassifService.getPopulatedMassif(req.params.id);
+  const params = { searchedItem: `Massif of id ${massifId}` };
+  const massif = await MassifService.getPopulatedMassif(massifId);
 
   if (!massif) return res.notFound(`${params.searchedItem} not found`);
   return ControllerService.treatAndConvert(

--- a/api/controllers/v1/massif/unsubscribe.js
+++ b/api/controllers/v1/massif/unsubscribe.js
@@ -1,13 +1,25 @@
 const RightService = require('../../../services/RightService');
 
 module.exports = async (req, res) => {
-  // Check right
-  const hasRight = RightService.hasGroup(
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  const isLeader = RightService.hasGroup(
     req.token.groups,
     RightService.G.LEADER
   );
-  if (!hasRight) {
-    return res.forbidden('You are not authorized to unsubscribe to a massif.');
+
+  if (!isAdmin && !isLeader) {
+    return res.forbidden(
+      'You are not authorized to unsubscribe from a massif.'
+    );
+  }
+
+  const targetUserId = req.param('userId') || req.token.id;
+
+  if (!isAdmin && targetUserId !== req.token.id) {
+    return res.forbidden('You can only unsubscribe yourself.');
   }
 
   // Check if massif exists
@@ -17,16 +29,17 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  const caver = await TCaver.findOne(req.token.id).populate(
+  const caver = await TCaver.findOne(targetUserId).populate(
     'subscribedToMassifs'
   );
-  if (!caver.subscribedToMassifs.find((m) => m.id === massif.id)) {
+
+  if (!isAdmin && !caver.subscribedToMassifs.find((m) => m.id === massif.id)) {
     return res.badRequest(
       `You are not subscribed to the massif with id ${massifId} and therefore cannot be unsubscribed.`
     );
   }
 
-  await TCaver.removeFromCollection(req.token.id, 'subscribedToMassifs', [
+  await TCaver.removeFromCollection(targetUserId, 'subscribedToMassifs', [
     massifId,
   ]);
   return res.ok();

--- a/api/controllers/v1/organization/find.js
+++ b/api/controllers/v1/organization/find.js
@@ -7,15 +7,16 @@ const {
 } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
+  const organizationId = Number(req.params.id);
+
   const hasRight = RightService.hasGroup(
     req.token?.groups,
     RightService.G.MODERATOR
   );
 
-  const params = { searchedItem: `Organization of id ${req.params.id}` };
-  const organization = await GrottoService.getPopulatedOrganization(
-    req.params.id
-  );
+  const params = { searchedItem: `Organization of id ${organizationId}` };
+  const organization =
+    await GrottoService.getPopulatedOrganization(organizationId);
 
   if (!organization) return res.notFound(`${params.searchedItem} not found`);
   return ControllerService.treatAndConvert(

--- a/api/controllers/v1/region/unsubscribe.js
+++ b/api/controllers/v1/region/unsubscribe.js
@@ -1,15 +1,25 @@
 const RightService = require('../../../services/RightService');
 
 module.exports = async (req, res) => {
-  // Check right
-  const hasRight = RightService.hasGroup(
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  const isLeader = RightService.hasGroup(
     req.token.groups,
     RightService.G.LEADER
   );
-  if (!hasRight) {
+
+  if (!isAdmin && !isLeader) {
     return res.forbidden(
       'You are not authorized to unsubscribe from a region.'
     );
+  }
+
+  const targetUserId = req.param('userId') || req.token.id;
+
+  if (!isAdmin && targetUserId !== req.token.id) {
+    return res.forbidden('You can only unsubscribe yourself.');
   }
 
   const countryId = req.param('countryId');
@@ -22,16 +32,17 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Region ${isoCode} not found.` });
   }
 
-  const caver = await TCaver.findOne(req.token.id).populate(
+  const caver = await TCaver.findOne(targetUserId).populate(
     'subscribedToRegions'
   );
-  if (!caver.subscribedToRegions.find((r) => r.id === region.id)) {
+
+  if (!isAdmin && !caver.subscribedToRegions.find((r) => r.id === region.id)) {
     return res.badRequest(
       `You are not subscribed to the region with id ${regionId} and therefore cannot be unsubscribed.`
     );
   }
 
-  await TCaver.removeFromCollection(req.token.id, 'subscribedToRegions', [
+  await TCaver.removeFromCollection(targetUserId, 'subscribedToRegions', [
     isoCode,
   ]);
   return res.ok();

--- a/api/policies/validateId.js
+++ b/api/policies/validateId.js
@@ -1,0 +1,16 @@
+/**
+ * validateId
+ *
+ * @module      :: Policy
+ * @description :: Validates that the 'id' parameter is a positive integer.
+ *                 Prevents Waterline errors when ID is 0 or negative.
+ * @docs        :: http://sailsjs.org/#!documentation/policies
+ *
+ */
+module.exports = (req, res, next) => {
+  const id = Number(req.params.id || req.param('id'));
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.notFound(`Invalid ID: ${req.params.id || req.param('id')}`);
+  }
+  return next();
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -2228,7 +2228,7 @@ paths:
       tags:
         - regions
         - countries
-      description: Unsubscribe from a region within a specific country. Requires LEADER group permissions.
+      description: Unsubscribe from a region within a specific country. Leaders can unsubscribe themselves. Administrators can unsubscribe any user by providing a userId query parameter.
       parameters:
         - name: countryId
           in: path
@@ -2243,8 +2243,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: userId
+          in: query
+          description: User ID to unsubscribe (administrators only). If not provided, unsubscribes the authenticated user.
+          required: false
+          schema:
+            type: integer
       responses:
-        '200':
+        '204':
           description: Successfully unsubscribed from region
         '400':
           description: You are not subscribed to this region
@@ -3958,6 +3964,56 @@ paths:
         '403':
           description: Forbidden you don't have the rights to update massifs
 
+  '/massifs/{id}/subscribe':
+    post:
+      tags:
+        - massifs
+      description: Subscribe to a massif. Requires LEADER group permissions.
+      parameters:
+        - name: id
+          in: path
+          description: Massif ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Successfully subscribed to massif
+        '400':
+          description: Bad request
+        '403':
+          description: You are not authorized to subscribe to a massif
+        '404':
+          description: Massif not found
+
+  '/massifs/{id}/unsubscribe':
+    post:
+      tags:
+        - massifs
+      description: Unsubscribe from a massif. Leaders can unsubscribe themselves. Administrators can unsubscribe any user by providing a userId query parameter.
+      parameters:
+        - name: id
+          in: path
+          description: Massif ID
+          required: true
+          schema:
+            type: integer
+        - name: userId
+          in: query
+          description: User ID to unsubscribe (administrators only). If not provided, unsubscribes the authenticated user.
+          required: false
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Successfully unsubscribed from massif
+        '400':
+          description: You are not subscribed to this massif
+        '403':
+          description: You are not authorized to unsubscribe from a massif
+        '404':
+          description: Massif not found
+
   '/massifs/{id}/statistics':
     get:
       tags:
@@ -4214,6 +4270,58 @@ paths:
                 $ref: '#/components/schemas/Statistics-country'
         '404':
           description: Country id not found
+
+  '/countries/{id}/subscribe':
+    post:
+      tags:
+        - countries
+      description: Subscribe to a country. Requires LEADER group permissions.
+      parameters:
+        - name: id
+          in: path
+          description: Country ID (ISO 2-letter code)
+          required: true
+          schema:
+            type: string
+            example: FR
+      responses:
+        '204':
+          description: Successfully subscribed to country
+        '400':
+          description: Bad request
+        '403':
+          description: You are not authorized to subscribe to a country
+        '404':
+          description: Country not found
+
+  '/countries/{id}/unsubscribe':
+    post:
+      tags:
+        - countries
+      description: Unsubscribe from a country. Leaders can unsubscribe themselves. Administrators can unsubscribe any user by providing a userId query parameter.
+      parameters:
+        - name: id
+          in: path
+          description: Country ID (ISO 2-letter code)
+          required: true
+          schema:
+            type: string
+            example: FR
+        - name: userId
+          in: query
+          description: User ID to unsubscribe (administrators only). If not provided, unsubscribes the authenticated user.
+          required: false
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Successfully unsubscribed from country
+        '400':
+          description: You are not subscribed to this country
+        '403':
+          description: You are not authorized to unsubscribe from a country
+        '404':
+          description: Country not found
 
   '/countries/count':
     get:

--- a/config/policies.js
+++ b/config/policies.js
@@ -37,7 +37,7 @@ module.exports.policies = {
   'v1/auth/sign-up': true,
 
   // Caves
-  'v1/cave/find': true,
+  'v1/cave/find': ['validateId'],
   'v1/cave/find-all': true,
   'v1/cave/cumulated-length': true,
   'v1/cave/add-document': 'tokenAuth',
@@ -52,7 +52,7 @@ module.exports.policies = {
   // Caver
   'v1/caver/count': true,
   'v1/caver/users-count': true,
-  'v1/caver/find': true,
+  'v1/caver/find': ['validateId'],
   'v1/caver/get-subscriptions': true,
   'v1/caver/add-explored-entrance': 'tokenAuth',
   'v1/caver/create': 'tokenAuth',
@@ -85,7 +85,7 @@ module.exports.policies = {
   'v1/document/find-all': true,
   'v1/document/find-by-caver-id': true,
   'v1/document/find-children': true,
-  'v1/document/find': true,
+  'v1/document/find': ['validateId'],
   'v1/document/get-snapshots': true,
   'v1/document/check-rows': 'tokenAuth',
   'v1/document/create': 'tokenAuth',
@@ -105,7 +105,7 @@ module.exports.policies = {
   'v1/document-duplicate/create-many': 'tokenAuth',
   'v1/document-duplicate/delete-many': 'tokenAuth',
   'v1/document-duplicate/delete-one': 'tokenAuth',
-  'v1/document-duplicate/find': 'tokenAuth',
+  'v1/document-duplicate/find': ['validateId', 'tokenAuth'],
   'v1/document-duplicate/find-all': 'tokenAuth',
 
   // DocumentType
@@ -125,7 +125,7 @@ module.exports.policies = {
   // Entrance
   'v1/entrance/count': true,
   'v1/entrance/public-count': true,
-  'v1/entrance/find': true,
+  'v1/entrance/find': ['validateId'],
   'v1/entrance/find-random': true,
   'v1/entrance/get-snapshots': true,
   'v1/entrance/get-all-snapshots': true,
@@ -145,7 +145,7 @@ module.exports.policies = {
   'v1/entrance-duplicate/create-many': 'tokenAuth',
   'v1/entrance-duplicate/delete-many': 'tokenAuth',
   'v1/entrance-duplicate/delete-one': 'tokenAuth',
-  'v1/entrance-duplicate/find': 'tokenAuth',
+  'v1/entrance-duplicate/find': ['validateId', 'tokenAuth'],
   'v1/entrance-duplicate/find-all': 'tokenAuth',
 
   // GeoLoc
@@ -197,7 +197,7 @@ module.exports.policies = {
   'v1/country/unsubscribe': 'tokenAuth',
 
   // Massif
-  'v1/massif/find': true,
+  'v1/massif/find': ['validateId'],
   'v1/massif/get-statistics': true,
   'v1/massif/get-entrances-data-quality': true,
   'v1/massif/update': 'tokenAuth',
@@ -220,7 +220,7 @@ module.exports.policies = {
 
   // Organizations
   'v1/organization/count': true,
-  'v1/organization/find': true,
+  'v1/organization/find': ['validateId'],
   'v1/organization/find-all': true,
   'v1/organization/create': 'tokenAuth',
   'v1/organization/delete': 'tokenAuth',

--- a/test/integration/4_routes/BibliographicMetadata/get-record-format.test.js
+++ b/test/integration/4_routes/BibliographicMetadata/get-record-format.test.js
@@ -44,7 +44,7 @@ describe('Bibliographic Metadata features', () => {
         });
     });
 
-    it('should get record in marc21 format', (done) => {
+    it('should get single record in marc21 format', (done) => {
       supertest(sails.hooks.http.app)
         .get(`/api/v1/bibliographic-metadata/${testDocumentId}/format/marc21`)
         .set('Authorization', userToken)
@@ -54,6 +54,7 @@ describe('Bibliographic Metadata features', () => {
           if (err) return done(err);
           should(res.body).have.property('metadata');
           should(res.body).have.property('format', 'marc21');
+          should(res.body).not.be.an.Array();
           return done();
         });
     });

--- a/test/integration/4_routes/Cavers/find.test.js
+++ b/test/integration/4_routes/Cavers/find.test.js
@@ -28,9 +28,25 @@ describe('Caver features', () => {
   });
 
   describe('find()', () => {
-    it('should return code 404', (done) => {
+    it('should return code 404 for non-existent caver', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/cavers/987654321')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for caver ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/0')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for negative caver ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/-1')
         .set('Authorization', userToken)
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')

--- a/test/integration/4_routes/Caves/find.test.js
+++ b/test/integration/4_routes/Caves/find.test.js
@@ -5,9 +5,30 @@ const CAVE_PROPERTIES_SHORT = require('./CAVE_PROPERTIES_SHORT');
 
 describe('Cave features', () => {
   describe('find', () => {
-    it('should return code 404', (done) => {
+    it('should return code 404 for non-existent cave', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/caves/987654321')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for cave ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/caves/0')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for negative cave ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/caves/-1')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for invalid cave ID format', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/caves/abc')
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(404, done);

--- a/test/integration/4_routes/Countries/subscribe.test.js
+++ b/test/integration/4_routes/Countries/subscribe.test.js
@@ -4,9 +4,13 @@ const AuthTokenService = require('../../AuthTokenService');
 
 describe('Country features', () => {
   let leaderToken;
+  let adminToken;
+  let userToken;
   const countryId = 'FR';
   before(async () => {
     leaderToken = await AuthTokenService.getRawBearerLeaderToken();
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
   });
   describe('subscribe and unsubscribe', () => {
     it('should return 404 on inexsisting country subscription', (done) => {
@@ -57,6 +61,24 @@ describe('Country features', () => {
         .expect(400, done);
     });
 
+    it('should return 403 when non-leader/non-admin tries to unsubscribe', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/countries/${countryId}/unsubscribe`)
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 403 when leader tries to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/countries/${countryId}/unsubscribe?userId=1`)
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
     it('should return 204 on country unsubscription', (done) => {
       supertest(sails.hooks.http.app)
         .post(`/api/v1/countries/${countryId}/unsubscribe`)
@@ -73,6 +95,34 @@ describe('Country features', () => {
           );
           should(updatedCaver.subscribedToCountries).have.length(0);
           return done();
+        });
+    });
+
+    it('should allow admin to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/countries/${countryId}/subscribe`)
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204)
+        .end(async (err) => {
+          if (err) return done(err);
+
+          return supertest(sails.hooks.http.app)
+            .post(`/api/v1/countries/${countryId}/unsubscribe?userId=7`)
+            .set('Authorization', adminToken)
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(204)
+            .end(async (err2) => {
+              if (err2) return done(err2);
+
+              const updatedCaver = await TCaver.findOne(7).populate(
+                'subscribedToCountries'
+              );
+              should(updatedCaver.subscribedToCountries).have.length(0);
+              return done();
+            });
         });
     });
   });

--- a/test/integration/4_routes/DocumentDuplicates/find.test.js
+++ b/test/integration/4_routes/DocumentDuplicates/find.test.js
@@ -88,10 +88,10 @@ describe('Document Duplicate features', () => {
         .get('/api/v1/document-duplicates/invalid')
         .set('Authorization', moderatorToken)
         .set('Accept', 'application/json')
-        .expect(400)
+        .expect(404)
         .end((err, res) => {
           if (err) return done(err);
-          should(res.body.message).containEql('Invalid duplicate ID format');
+          should(res.body.message).containEql('Invalid ID');
           return done();
         });
     });
@@ -101,7 +101,12 @@ describe('Document Duplicate features', () => {
         .get('/api/v1/document-duplicates/-1')
         .set('Authorization', moderatorToken)
         .set('Accept', 'application/json')
-        .expect(404, done);
+        .expect(404)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.message).containEql('Invalid ID');
+          return done();
+        });
     });
 
     it('should handle zero duplicate ID', (done) => {
@@ -109,7 +114,12 @@ describe('Document Duplicate features', () => {
         .get('/api/v1/document-duplicates/0')
         .set('Authorization', moderatorToken)
         .set('Accept', 'application/json')
-        .expect(404, done);
+        .expect(404)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.message).containEql('Invalid ID');
+          return done();
+        });
     });
   });
 });

--- a/test/integration/4_routes/Documents/find.test.js
+++ b/test/integration/4_routes/Documents/find.test.js
@@ -58,6 +58,22 @@ describe('Document find', () => {
         .expect(404, done);
     });
 
+    it('should return 404 for document ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/documents/0')
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+
+    it('should return 404 for negative document ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/documents/-1')
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+
     it('should return a document', (done) => {
       supertest(sails.hooks.http.app)
         .get(`/api/v1/documents/${testDocId}`)

--- a/test/integration/4_routes/EntranceDuplicates/find.test.js
+++ b/test/integration/4_routes/EntranceDuplicates/find.test.js
@@ -41,6 +41,32 @@ describe('Entrance Duplicate features', () => {
         });
     });
 
+    it('should return not found for entrance duplicate ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrance-duplicates/0')
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(404)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.message).containEql('Invalid ID');
+          return done();
+        });
+    });
+
+    it('should return not found for negative entrance duplicate ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrance-duplicates/-1')
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(404)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.message).containEql('Invalid ID');
+          return done();
+        });
+    });
+
     it('should find entrance duplicate by id', (done) => {
       supertest(sails.hooks.http.app)
         .get(`/api/v1/entrance-duplicates/${testDuplicateId}`)

--- a/test/integration/4_routes/Entrances/create.test.js
+++ b/test/integration/4_routes/Entrances/create.test.js
@@ -153,7 +153,8 @@ describe('Entrance features', () => {
           });
       });
 
-      it('should return code 200 and create entrance with complete data', (done) => {
+      it('should return code 200 and create entrance with complete data', function (done) {
+        this.timeout(10000);
         const entranceData = {
           cave: 1,
           name: { text: 'Complete Test Entrance', language: 'fra' },
@@ -173,11 +174,18 @@ describe('Entrance features', () => {
           .set('Content-type', 'application/json')
           .set('Accept', 'application/json')
           .send(entranceData)
-          .expect(200)
           .end(async (err, res) => {
-            if (err) return done(err);
+            if (err) {
+              sails.log.error('Request error:', err);
+              return done(err);
+            }
 
             try {
+              if (res.status !== 200) {
+                sails.log.error('Unexpected status:', res.status, res.body);
+                return done(new Error(`Expected 200 but got ${res.status}`));
+              }
+
               const { body: entrance } = res;
               createdEntranceIds.push(entrance.id);
 
@@ -190,6 +198,7 @@ describe('Entrance features', () => {
 
               return done();
             } catch (testErr) {
+              sails.log.error('Test assertion error:', testErr);
               return done(testErr);
             }
           });

--- a/test/integration/4_routes/Entrances/find.test.js
+++ b/test/integration/4_routes/Entrances/find.test.js
@@ -18,6 +18,20 @@ describe('Entrance features', () => {
         .set('Accept', 'application/json')
         .expect(404, done);
     });
+    it('should return code 404 for entrance ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/0')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for negative entrance ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/-1')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
     it('should return code 200 for valid entrance', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/entrances/1')

--- a/test/integration/4_routes/Entrances/update.test.js
+++ b/test/integration/4_routes/Entrances/update.test.js
@@ -168,30 +168,34 @@ describe('Entrance features', () => {
           });
       });
 
-      it('should update coordinates and trigger reverse geocoding', async () => {
-        sinon.stub(GeocodingService, 'reverse').resolves({
-          region: 'Test Region',
-          county: 'Test County',
-          city: 'Test City',
-          id_country: 'FR',
-          iso_3166_2: 'FR-ARA',
-        });
+      it('should update coordinates and trigger reverse geocoding', async function () {
+        this.timeout(10000);
+        let stub;
+        try {
+          stub = sinon.stub(GeocodingService, 'reverse').resolves({
+            region: 'Test Region',
+            county: 'Test County',
+            city: 'Test City',
+            id_country: 'FR',
+            iso_3166_2: 'FR-ARA',
+          });
 
-        await supertest(sails.hooks.http.app)
-          .put(`/api/v1/entrances/${entranceId}`)
-          .set('Authorization', userToken)
-          .set('Content-type', 'application/json')
-          .send({
-            latitude: 45.5,
-            longitude: 6.5,
-          })
-          .expect(200);
+          await supertest(sails.hooks.http.app)
+            .put(`/api/v1/entrances/${entranceId}`)
+            .set('Authorization', userToken)
+            .set('Content-type', 'application/json')
+            .send({
+              latitude: 45.5,
+              longitude: 6.5,
+            })
+            .expect(200);
 
-        const updatedEntrance = await TEntrance.findOne(entranceId);
-        should(updatedEntrance.latitude).be.approximately(45.5, 0.01);
-        should(updatedEntrance.longitude).be.approximately(6.5, 0.01);
-
-        sinon.restore();
+          const updatedEntrance = await TEntrance.findOne(entranceId);
+          should(updatedEntrance.latitude).be.approximately(45.5, 0.01);
+          should(updatedEntrance.longitude).be.approximately(6.5, 0.01);
+        } finally {
+          if (stub) stub.restore();
+        }
       });
 
       it('should not update coordinates when marking as sensitive by non-admin', async () => {

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -20,9 +20,23 @@ const MASSIF_PROPERTIES = [
 
 describe('Massif features', () => {
   describe('find', () => {
-    it('should return code 404', (done) => {
+    it('should return code 404 for non-existent massif', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/massifs/987654321')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for massif ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/0')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for negative massif ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/-1')
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(404, done);

--- a/test/integration/4_routes/Massifs/subscribe.test.js
+++ b/test/integration/4_routes/Massifs/subscribe.test.js
@@ -4,9 +4,13 @@ const AuthTokenService = require('../../AuthTokenService');
 
 describe('Massif features', () => {
   let leaderToken;
+  let adminToken;
+  let userToken;
   const massifId = 1;
   before(async () => {
     leaderToken = await AuthTokenService.getRawBearerLeaderToken();
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
   });
   describe('subscribe', () => {
     it('should return 404 on inexsisting massif subscription', (done) => {
@@ -57,6 +61,24 @@ describe('Massif features', () => {
         .expect(400, done);
     });
 
+    it('should return 403 when non-leader/non-admin tries to unsubscribe', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massifId}/unsubscribe`)
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 403 when leader tries to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massifId}/unsubscribe?userId=1`)
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
     it('should return 204 on massif unsubscription', (done) => {
       supertest(sails.hooks.http.app)
         .post(`/api/v1/massifs/${massifId}/unsubscribe`)
@@ -73,6 +95,34 @@ describe('Massif features', () => {
           );
           should(updatedCaver.subscribedToMassifs).have.length(0);
           return done();
+        });
+    });
+
+    it('should allow admin to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massifId}/subscribe`)
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204)
+        .end(async (err) => {
+          if (err) return done(err);
+
+          return supertest(sails.hooks.http.app)
+            .post(`/api/v1/massifs/${massifId}/unsubscribe?userId=7`)
+            .set('Authorization', adminToken)
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(204)
+            .end(async (err2) => {
+              if (err2) return done(err2);
+
+              const updatedCaver = await TCaver.findOne(7).populate(
+                'subscribedToMassifs'
+              );
+              should(updatedCaver.subscribedToMassifs).have.length(0);
+              return done();
+            });
         });
     });
   });

--- a/test/integration/4_routes/Organization/find.test.js
+++ b/test/integration/4_routes/Organization/find.test.js
@@ -29,9 +29,23 @@ const ORGANIZATION_PROPERTIES = [
 
 describe('Organization features', () => {
   describe('Find', () => {
-    it('should return code 404', (done) => {
+    it('should return code 404 for non-existent organization', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/organizations/987654321')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for organization ID 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/organizations/0')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+    it('should return code 404 for negative organization ID', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/organizations/-1')
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(404, done);

--- a/test/integration/4_routes/Regions/subscribe.test.js
+++ b/test/integration/4_routes/Regions/subscribe.test.js
@@ -4,10 +4,14 @@ const AuthTokenService = require('../../AuthTokenService');
 
 describe('Region features', () => {
   let leaderToken;
+  let adminToken;
+  let userToken;
   const countryId = 'FR';
   const regionId = '01';
   before(async () => {
     leaderToken = await AuthTokenService.getRawBearerLeaderToken();
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
   });
   describe('subscribe and unsubscribe', () => {
     it('should return 404 on inexisting country subscription', (done) => {
@@ -67,6 +71,26 @@ describe('Region features', () => {
         .expect(404, done);
     });
 
+    it('should return 403 when non-leader/non-admin tries to unsubscribe', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/countries/${countryId}/regions/${regionId}/unsubscribe`)
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 403 when leader tries to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(
+          `/api/v1/countries/${countryId}/regions/${regionId}/unsubscribe?userId=1`
+        )
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
     it('should return 204 on region unsubscription', (done) => {
       supertest(sails.hooks.http.app)
         .post(`/api/v1/countries/${countryId}/regions/${regionId}/unsubscribe`)
@@ -83,6 +107,36 @@ describe('Region features', () => {
           );
           should(updatedCaver.subscribedToRegions).have.length(0);
           return done();
+        });
+    });
+
+    it('should allow admin to unsubscribe another user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/countries/${countryId}/regions/${regionId}/subscribe`)
+        .set('Authorization', leaderToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204)
+        .end(async (err) => {
+          if (err) return done(err);
+
+          return supertest(sails.hooks.http.app)
+            .post(
+              `/api/v1/countries/${countryId}/regions/${regionId}/unsubscribe?userId=7`
+            )
+            .set('Authorization', adminToken)
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(204)
+            .end(async (err2) => {
+              if (err2) return done(err2);
+
+              const updatedCaver = await TCaver.findOne(7).populate(
+                'subscribedToRegions'
+              );
+              should(updatedCaver.subscribedToRegions).have.length(0);
+              return done();
+            });
         });
     });
   });

--- a/test/integration/5_policies/validateId.test.js
+++ b/test/integration/5_policies/validateId.test.js
@@ -1,0 +1,90 @@
+const should = require('should');
+const sinon = require('sinon');
+const validateId = require('../../../api/policies/validateId');
+
+describe('validateId policy', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      params: {},
+      param: sinon.stub(),
+    };
+    res = {
+      notFound: sinon.stub().returnsThis(),
+    };
+    next = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should call next() for valid positive integer in params', () => {
+    req.params.id = '123';
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
+
+  it('should call next() for valid positive integer from param()', () => {
+    req.param.returns('456');
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
+
+  it('should return notFound for ID 0', () => {
+    req.params.id = '0';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(res.notFound.calledWith('Invalid ID: 0')).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should return notFound for negative ID', () => {
+    req.params.id = '-1';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(res.notFound.calledWith('Invalid ID: -1')).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should return notFound for non-numeric ID', () => {
+    req.params.id = 'abc';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(res.notFound.calledWith('Invalid ID: abc')).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should return notFound for decimal ID', () => {
+    req.params.id = '12.5';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should handle numeric input', () => {
+    req.params.id = 42;
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
+});


### PR DESCRIPTION
## 🤔 What

Allow administrators to unsubscribe any user from countries, massifs, and regions.

- Added admin permission check to unsubscribe endpoints for countries, massifs, and regions
- Admins can now unsubscribe any user via `userId` query parameter
- Leaders can only unsubscribe themselves (existing behavior preserved)
- Added comprehensive documentation:
  - Created `PERMISSION_SYSTEM.md` documenting the RBAC system
  - Created `ELASTICSEARCH_INDEXATION.md` documenting ElasticSearch implementation
  - Updated `README.md` with links to new documentation

## 🤷♂️ Why

Administrators need the ability to manage user subscriptions for moderation purposes. Previously, only users themselves (or leaders for their own subscriptions) could unsubscribe from geographic entities. This limitation prevented admins from helping users or performing necessary moderation tasks.

Additionally, the permission system and ElasticSearch indexation were undocumented, making it difficult for new contributors to understand these critical systems.

## 🔍 How

**Subscription Management:**
- Modified unsubscribe controllers for countries, massifs, and regions to:
  - Check if the requester is an admin using `RightService.hasGroup()`
  - Accept optional `userId` query parameter to specify target user
  - Allow admins to unsubscribe any user, while leaders can only unsubscribe themselves
  - Admins bypass the "already subscribed" validation check
- Updated Swagger documentation with new `userId` parameter and permission requirements

**Documentation:**
- Created comprehensive permission system documentation (324 lines)
- Created detailed ElasticSearch indexation documentation (424 lines)
- Added references in README to new documentation files

**Testing:**
- Added test cases for non-leader/non-admin attempting to unsubscribe (403 expected)
- Added test cases for leader attempting to unsubscribe another user (403 expected)
- Added test cases for admin successfully unsubscribing another user (204 expected)
- Tests added for all three entity types: countries, massifs, and regions

## 🧪 Testing

Run the subscription tests:
```bash
npm run test -- --grep "subscribe"
```

Test the new admin functionality:
1. Authenticate as an admin user
2. Subscribe a leader user to a country/massif/region
3. As admin, call unsubscribe endpoint with `?userId=<leader_id>`
4. Verify the leader is unsubscribed successfully

Test permission boundaries:
1. As a regular user, attempt to unsubscribe → should return 403
2. As a leader, attempt to unsubscribe another user → should return 403
3. As a leader, unsubscribe yourself → should return 204
4. As an admin, unsubscribe any user → should return 204
