### PR TITLE
fix(files): fixes the availability of the crypto dependence while accessing Azure Blob

### DIFF
--- a/api/services/FileService.js
+++ b/api/services/FileService.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const {
   BlobServiceClient,
   StorageSharedKeyCredential,
@@ -5,6 +6,11 @@ const {
   generateBlobSASQueryParameters,
 } = require('@azure/storage-blob');
 const stream = require('stream');
+
+// Ensure crypto is available globally for Azure SDK
+if (!global.crypto) {
+  global.crypto = crypto;
+}
 
 const AZURE_ACCOUNT = 'grottocenter';
 const AZURE_CONTAINER_DOCUMENTS = 'documents';


### PR DESCRIPTION
## 🤔 What

Fix Azure Storage Blob SDK `crypto` module error in production

- Added explicit `crypto` module import in FileService
- Made `crypto` globally available for Azure SDK dependencies
- Fixes 500 errors on `/api/v1/cavers/export/db` endpoint
- Fixes 500 errors on document upload endpoint `/api/v1/documents/:id`

## 🤷♂️ Why

The Azure Storage Blob SDK's underlying dependency (`@typespec/ts-http-runtime`) requires the Node.js `crypto` module to generate UUIDs, but it wasn't available in the production Azure App Service environment. This caused:

1. Database export downloads to fail with `ReferenceError: crypto is not defined`
2. Document uploads to fail with the same error

Production logs showed:
```
ReferenceError: crypto is not defined
    at randomUUID (/node_modules/@typespec/ts-http-runtime/dist/commonjs/util/uuidUtils.js:12:5)
```

## 🔍 How

Modified `api/services/FileService.js`:
- Imported Node.js built-in `crypto` module at the top
- Added global polyfill: `global.crypto = crypto` to ensure Azure SDK can access it
- This makes `crypto` available to all Azure SDK operations (upload, download, metadata)

## 🧪 Testing

Test the following endpoints in production:
1. `GET /api/v1/cavers/export/db` - Should return database export URL and metadata
2. `PUT /api/v1/documents/:id` - Should successfully upload documents to Azure Blob Storage

Both should now work without 500 errors.
