### PR TITLE
Fix/fixes 500 errors

### DIFF
--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -97,7 +97,7 @@ module.exports = {
       ? tEntranceSensitivity[0].isSensitive
       : true;
     const hasRight = isEntranceSensitive
-      ? RightService.hasGroup(token.groups, RightService.G.ADMINISTRATOR)
+      ? RightService.hasGroup(token?.groups, RightService.G.ADMINISTRATOR)
       : true; // No need to call hasRight if it's not a sensitive entrance
     /* eslint-disable no-param-reassign */
     return Promise.all(

--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -101,11 +101,14 @@ async function collectionSearch({
   const q = query || '*';
   const filterBy = buildFilter(filter, isLogicalCompareAnd);
 
+  // Cap size at Typesense's limit of 1000 hits per page
+  const perPage = size ? Math.min(size, 1000) : size;
+
   const params = {
     q,
     query_by: allEntities[entity].query.query_by,
     page, // Page starts at 1
-    per_page: size,
+    per_page: perPage,
     ...(sort && { sort_by: `${sort},_text_match:desc` }),
     ...(filterBy && { filter_by: filterBy }),
     ...(fields && { include_fields: fields.join(',') }),

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3513,8 +3513,9 @@ paths:
                   description: The page number, start at 1
                 size:
                   type: integer
-                  description: The size of the page, default 10
+                  description: The size of the page, default 10. Maximum 1000 due to search engine limitations.
                   default: 10
+                  maximum: 1000
       responses:
         '200':
           description: Successful operation

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -301,6 +301,36 @@ describe('SearchService', () => {
       const call = typesenseStub.search.getCall(0);
       should(call.args[1].include_fields).equal('id,name');
     });
+
+    it('should cap size parameter at 1000 to prevent Typesense errors', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        query: 'test',
+        entity: 'organizations',
+        size: 2000,
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].per_page).equal(1000);
+    });
+
+    it('should not modify size parameter when under 1000', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        query: 'test',
+        entity: 'organizations',
+        size: 500,
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].per_page).equal(500);
+    });
   });
 
   describe('fieldSearch()', () => {

--- a/test/integration/4_routes/Snapshots/get-snapshots-entrances-fix.test.js
+++ b/test/integration/4_routes/Snapshots/get-snapshots-entrances-fix.test.js
@@ -1,0 +1,38 @@
+const supertest = require('supertest');
+const should = require('should');
+
+describe('Entrance snapshots fix for undefined token', () => {
+  describe('get-snapshots() without authentication', () => {
+    it('should handle undefined token gracefully and return 200', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/1/snapshots')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: entrances } = res;
+          should(entrances).not.be.empty();
+          should(entrances.entrances).be.an.Array();
+          return done();
+        });
+    });
+
+    it('should handle undefined token for sensitive entrance and hide coordinates', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/2/snapshots')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: entrances } = res;
+          should(entrances).not.be.empty();
+          should(entrances.entrances[0]).not.be.null();
+          should(entrances.entrances[0].latitude).be.null();
+          should(entrances.entrances[0].longitude).be.null();
+          return done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

This PR fixes two critical 500 errors in the API:

- Fixed null pointer exception when accessing token.groups in EntranceService
- Added size parameter capping at 1000 in SearchService to prevent Typesense errors
- Updated Swagger documentation to document the 1000 maximum limit
- Added comprehensive test coverage for both fixes

## 🤷♂️ Why

The API was throwing 500 errors in two scenarios:
1. When checking user permissions for sensitive entrances without authentication (undefined token), causing `token.groups` access to fail
2. When search requests with size > 1000 were sent to Typesense, which has a hard limit of 1000 hits per page

These errors were impacting the user experience and API reliability, especially for unauthenticated users.

## 🔍 How

**EntranceService Fix:**
- Changed `token.groups` to `token?.groups` using optional chaining to safely handle undefined tokens
- Prevents null pointer exceptions when unauthenticated users access entrance snapshots

**SearchService Fix:**
- Added `Math.min(size, 1000)` to cap the per_page parameter at Typesense's limit
- Only applies capping when size is provided, preserving default behavior otherwise

**Documentation:**
- Updated `swaggerV1.yaml` to document the 1000 maximum limit for the size parameter
- Added clear description about search engine limitations

**Testing:**
- Added two test cases in `SearchService.test.js` to verify size capping behavior
- Created `get-snapshots-entrances-fix.test.js` to test unauthenticated access to entrance snapshots

## 🧪 Testing

Run the following tests to verify the fixes:

```bash
# Run specific tests for the fixes
npm run test -- --grep "SearchService"
npm run test -- --grep "get-snapshots-entrances-fix"

# Run all tests to ensure no regressions
npm run test
```

Test scenarios:
- Search with invalid page size parameters (should handle gracefully)
- Entrance operations with role verification edge cases
- Verify no 500 errors are thrown in previously failing scenarios
