### PR TITLE
fix(snapshot): error when an Entrance has no associated Cave

### DIFF
--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -479,14 +479,18 @@ module.exports = {
   getCollectionAncestors: async (documentIds) => {
     if (documentIds.length === 0) return [];
 
+    // Infinite loop should normaly not happen unless the t_document table is not properly formated as a tree
+    // In case it happend search for:
+    // - Self reference: SELECT id, id_parent FROM t_document WHERE id = id_parent;
+    // - Cycle: A → B → A
     const query = `
       WITH RECURSIVE doc_hierarchy AS (
         SELECT id, id_parent, id_type
-        FROM t_document 
+        FROM t_document
         WHERE id = ANY($1)
-        
+
         UNION ALL
-        
+
         SELECT d.id, d.id_parent, d.id_type
         FROM t_document d
         JOIN doc_hierarchy dh ON d.id = dh.id_parent

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -123,12 +123,15 @@ module.exports = {
           entrance.names = nameResult[0].names;
           entrance.name = entrance.names[0].name;
         }
-        const caveName = await NameService.setNames(
-          [{ id: entrance.cave.id ?? entrance.cave }],
-          'cave'
-        );
-        if (caveName && caveName.length > 0) {
-          entrance.caveName = caveName[0].name;
+
+        if (entrance.cave) {
+          const caveName = await NameService.setNames(
+            [{ id: entrance.cave?.id ?? entrance.cave }],
+            'cave'
+          );
+          if (caveName && caveName.length > 0) {
+            entrance.caveName = caveName[0].name;
+          }
         }
 
         return entrance;

--- a/api/services/GrottoService.js
+++ b/api/services/GrottoService.js
@@ -86,10 +86,7 @@ module.exports = {
     const authorDocIds = organization.documents.map((e) => e.id);
 
     // Get documents where organization is editor
-    const editorDocs = await TDocument.find({ editor: organizationId })
-      .populate('descriptions')
-      .populate('type')
-      .populate('files', { where: { isValidated: true } });
+    const editorDocs = await TDocument.find({ editor: organizationId });
 
     // Combine both sets of documents and remove duplicates
     const allDocIds = [


### PR DESCRIPTION
Small fixes of production errors:
- Handle the case when an entrance has no associated cave in the snapshot
- Add a comment to help debugging infinite loop in `getCollectionAncestors`