### PR TITLE
fix: Only the first sub entities are exported

### DIFF
--- a/api/dbSync/entities/entrance.js
+++ b/api/dbSync/entities/entrance.js
@@ -57,6 +57,7 @@ async function* processRows(source) {
           'is_diving AS "isDiving"',
         ],
         join: [`LEFT JOIN t_name n ON n.id_cave = c.id AND n.is_main = true`],
+        transform: (e) => e, // Allow to also keep the id
         where: [],
       },
       {

--- a/api/dbSync/utils.js
+++ b/api/dbSync/utils.js
@@ -23,16 +23,22 @@ async function joinMany({
   const { rows: foreignRows } = await CommonService.query(query, [ids]);
   // Remove the table alias if present. So we can match it with our rows
   const cleanForeignField = foreignField.split('.').pop();
+  // Remember:
+  // - A single row can attach multiple different foreign rows (ie: the entrance can have multiple locations)
+  // - The same foreign row can be attached to multiple different rows (ie: the same cave can be attached to multiple entrances)
   for (const row of rows) {
-    const frow = foreignRows.find((e) => e[cleanForeignField] === row[rowsKey]);
-    if (!frow) continue; // eslint-disable-line no-continue
+    const fRows = foreignRows.filter(
+      (e) => e[cleanForeignField] === row[rowsKey]
+    );
+    if (fRows.length === 0) continue; // eslint-disable-line no-continue
     if (!row[localField]) row[localField] = [];
-
-    if (transform) {
-      row[localField].push(transform(frow));
-    } else {
-      const { [cleanForeignField]: _, ...cleanFRow } = frow;
-      row[localField].push(cleanFRow);
+    for (const fRow of fRows) {
+      if (transform) {
+        row[localField].push(transform(fRow));
+      } else {
+        const { [cleanForeignField]: _, ...cleanFRow } = fRow;
+        row[localField].push(cleanFRow);
+      }
     }
   }
 }


### PR DESCRIPTION
fix: Only the first sub entities are exported

For example, if an entry have multiple comments, only the first one was exported.