### PR TITLE
fix(search): parameterize title filter in bibliographic metadata search to prevent SQL injection

### DIFF
--- a/api/services/BibliographicMetadataService.js
+++ b/api/services/BibliographicMetadataService.js
@@ -348,14 +348,15 @@ module.exports = {
 
     if (titleFilter) {
       // search by title - use unaccent if available, otherwise fall back to simple ILIKE
+      const titleParam = `%${titleFilter}%`;
       let sqlTitle;
       try {
         // Try with unaccent first
         sqlTitle = `SELECT id_document AS id, children
               FROM v_bibliographic_metadata
               WHERE metadata_status = 'registered'
-              AND unaccent(dc_title) ILIKE unaccent('%${titleFilter}%')`;
-        const { rows } = await sails.sendNativeQuery(sqlTitle);
+              AND unaccent(dc_title) ILIKE unaccent($1)`;
+        const { rows } = await sails.sendNativeQuery(sqlTitle, [titleParam]);
         const ids = rows.map((m) => m.id);
         const childrenIds = rows.flatMap((m) => {
           if (!m.children || !Array.isArray(m.children)) return [];
@@ -379,8 +380,8 @@ module.exports = {
           sqlTitle = `SELECT id_document AS id, children
                 FROM v_bibliographic_metadata
                 WHERE metadata_status = 'registered'
-                AND dc_title ILIKE '%${titleFilter}%'`;
-          const { rows } = await sails.sendNativeQuery(sqlTitle);
+                AND dc_title ILIKE $1`;
+          const { rows } = await sails.sendNativeQuery(sqlTitle, [titleParam]);
           const ids = rows.map((m) => m.id);
           const children = rows.flatMap((m) => m.children || []);
           matchingIds = Array.from(new Set([...ids, ...children]));


### PR DESCRIPTION
## 🤔 What

- Fix SQL injection vulnerability in `POST /api/v1/bibliographic-metadata/search`
- The `title` field from the request body was interpolated directly into a raw SQL query string in `BibliographicMetadataService.searchMetadata()`
- Both the `unaccent` path and the `ILIKE` fallback path were affected

## 🤷‍♂️ Why

The `titleFilter` value was dropped into the SQL string via template literal (`'%${titleFilter}%'`), meaning any special characters — like the apostrophe in French text `d'un` — would break the query or, worse, allow arbitrary SQL execution.

This is a critical security vulnerability: the endpoint is unauthenticated, and the injection point allows full read access to the database (any table the DB user can query), including `t_caver` (emails, hashed passwords, personal data).

## 🔍 How

Replaced direct string interpolation with parameterized queries using `$1` placeholders passed to `sails.sendNativeQuery()`:

```js
// Before (vulnerable)
`AND unaccent(dc_title) ILIKE unaccent('%${titleFilter}%')`
const { rows } = await sails.sendNativeQuery(sqlTitle);

// After (safe)
`AND unaccent(dc_title) ILIKE unaccent($1)`
const { rows } = await sails.sendNativeQuery(sqlTitle, [titleParam]);
```

The `titleParam` is constructed as `%${titleFilter}%` in JavaScript, so the `%` wildcards are still applied, but the value is never interpreted as SQL syntax by PostgreSQL.

Both code paths (with `unaccent` and the fallback without it) were fixed.

## 🧪 Testing

Verify the fix works with special characters in title search:

```bash
curl -X POST http://localhost:1337/api/v1/bibliographic-metadata/search \
  -H 'Content-Type: application/json' \
  -d '{"and": [{"title": "description d'\''un nouveau pselaphide"}, {"bibliographiclevel": "m"}]}'
```

This should return results (or an empty array) without a 500 error.

Verify injection is blocked:

```bash
curl -X POST http://localhost:1337/api/v1/bibliographic-metadata/search \
  -H 'Content-Type: application/json' \
  -d '{"and": [{"title": "x'\'' OR 1=1 --"}, {"bibliographiclevel": "m"}]}'
```

This should return `{"data":[]}`, not all records.

## 📸 Previews

N/A — backend-only change, no UI impact.
