### PR TITLE
fix(name): align h_name.name column to varchar(200) and add name length validation

### DIFF
--- a/api/controllers/v1/cave/create.js
+++ b/api/controllers/v1/cave/create.js
@@ -7,6 +7,7 @@
 const CaveService = require('../../../services/CaveService');
 const ControllerService = require('../../../services/ControllerService');
 const { toCave } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   const rawDescriptionsData = req.param('descriptions');
@@ -21,6 +22,12 @@ module.exports = async (req, res) => {
     return res.badRequest(
       'You must provide a complete name object (with attributes "text" and "language").'
     );
+  }
+
+  // Validate name length
+  const nameError = validateNameLength(rawNameData.text);
+  if (nameError) {
+    return res.badRequest(nameError);
   }
 
   // description is optional

--- a/api/controllers/v1/cave/update.js
+++ b/api/controllers/v1/cave/update.js
@@ -2,6 +2,7 @@ const ControllerService = require('../../../services/ControllerService');
 const CaveService = require('../../../services/CaveService');
 const NotificationService = require('../../../services/NotificationService');
 const { toCave } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   const caveId = req.param('id');
@@ -31,6 +32,13 @@ module.exports = async (req, res) => {
   if (newTemperature) updatedFields.temperature = newTemperature;
   if (newIsDiving) updatedFields.isDiving = newIsDiving;
 
+  // Validate name length
+  const nameText = req.body.name?.text;
+  const nameError = validateNameLength(nameText);
+  if (nameError) {
+    return res.badRequest(nameError);
+  }
+
   // Handle name manually
   // Currently, use only one name per cave (even if the model can handle multiple names)
   // Done before the TCave update so the last_change_cave DB trigger will fetch the last updated name
@@ -38,8 +46,8 @@ module.exports = async (req, res) => {
     cave: caveId,
     isMain: true,
   }).set({
-    name: req.param('name')?.text,
-    language: req.param('name')?.language,
+    name: nameText,
+    language: req.body.name?.language,
   });
 
   await TCave.updateOne({ id: caveId }).set(updatedFields);

--- a/api/controllers/v1/entrance/create.js
+++ b/api/controllers/v1/entrance/create.js
@@ -1,5 +1,6 @@
 const ControllerService = require('../../../services/ControllerService');
 const EntranceService = require('../../../services/EntranceService');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   const name = req.param('name');
@@ -7,6 +8,12 @@ module.exports = async (req, res) => {
     return res.badRequest(
       'You must provide a name (with a language) for the new entrance'
     );
+  }
+
+  // Validate name length
+  const nameError = validateNameLength(name.text);
+  if (nameError) {
+    return res.badRequest(nameError);
   }
 
   const caveId = req.param('cave');

--- a/api/controllers/v1/entrance/update.js
+++ b/api/controllers/v1/entrance/update.js
@@ -4,6 +4,7 @@ const GeocodingService = require('../../../services/GeocodingService');
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const { toEntrance } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   const entranceId = req.param('id');
@@ -63,6 +64,13 @@ module.exports = async (req, res) => {
     }
   }
 
+  // Validate name length
+  const nameText = req.param('name')?.text;
+  const nameError = validateNameLength(nameText);
+  if (nameError) {
+    return res.badRequest(nameError);
+  }
+
   // Handle name manually
   // Currently, use only one name per entrance (even if the model can handle multiple names)
   // Done before the TCave update so the last_change_cave DB trigger will fetch the last updated name
@@ -70,7 +78,7 @@ module.exports = async (req, res) => {
     entrance: entranceId,
     isMain: true,
   }).set({
-    name: req.param('name')?.text,
+    name: nameText,
     language: req.param('name')?.language,
   });
 

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -3,6 +3,7 @@ const MassifService = require('../../../services/MassifService');
 const NotificationService = require('../../../services/NotificationService');
 const RecentChangeService = require('../../../services/RecentChangeService');
 const { toMassif } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 // eslint-disable-next-line consistent-return
 module.exports = async (req, res) => {
@@ -25,6 +26,12 @@ module.exports = async (req, res) => {
   }
   if (missingParamaters.length > 0) {
     return res.badRequest(`${missingParamaters} parameter(s) must be provided`);
+  }
+
+  // Validate name length
+  const nameError = validateNameLength(req.body.name);
+  if (nameError) {
+    return res.badRequest(nameError);
   }
 
   // Launch creation request using transaction: it performs a rollback if an error occurs

--- a/api/controllers/v1/name/update.js
+++ b/api/controllers/v1/name/update.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const ErrorService = require('../../../services/ErrorService');
 const { toName } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   // Check if name exists
@@ -12,8 +13,15 @@ module.exports = async (req, res) => {
     });
   }
 
+  // Validate name length
+  const nameText = req.param('name');
+  const nameError = validateNameLength(nameText);
+  if (nameError) {
+    return res.badRequest(nameError);
+  }
+
   const cleanedData = {
-    name: req.param('name'),
+    name: nameText,
   };
 
   try {

--- a/api/controllers/v1/organization/create.js
+++ b/api/controllers/v1/organization/create.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const GrottoService = require('../../../services/GrottoService');
 const { toOrganization } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   // Check params
@@ -8,6 +9,12 @@ module.exports = async (req, res) => {
     return res.badRequest(
       'You must provide a name to create a new organization.'
     );
+  }
+
+  // Validate name length
+  const nameError = validateNameLength(req.body.name?.text);
+  if (nameError) {
+    return res.badRequest(nameError);
   }
 
   const cleanedData = {

--- a/api/utils/nameValidation.js
+++ b/api/utils/nameValidation.js
@@ -1,0 +1,17 @@
+const NAME_MAX_LENGTH = 200;
+
+/**
+ * Validates that a name string does not exceed the DB column limit.
+ * Returns an error message if invalid, or null if valid.
+ *
+ * @param {string} name - The name text to validate
+ * @returns {string|null} Error message or null
+ */
+const validateNameLength = (name) => {
+  if (name && name.length > NAME_MAX_LENGTH) {
+    return `Name is too long (${name.length} characters). Maximum is ${NAME_MAX_LENGTH}.`;
+  }
+  return null;
+};
+
+module.exports = { NAME_MAX_LENGTH, validateNameLength };

--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -1021,7 +1021,7 @@ CREATE TABLE h_history (
 -- DROP TABLE h_name;
 CREATE TABLE h_name (
 	id serial NOT NULL,
-	"name" varchar(100) NULL,
+	"name" varchar(200) NULL,
 	is_main bool NOT NULL DEFAULT false,
 	id_author int4 NOT NULL,
 	id_reviewer int4 NULL,


### PR DESCRIPTION
## 🤔 What

- Fix server crash (500) when updating an entrance/cave/massif name longer than 100 characters

- Add input validation for name length across all name create/update endpoints

- Add SQL migration to align `h_name.name` column with `t_name.name` (`varchar(100)` → `varchar(200)`)

## 🤷‍♂️ Why

Updating entrance 89682 with the name `"Grande Fontaine (?) [Trou Bleu] [Source de l'Ornel] [Exsurgence de l'Ornel] [Grande Fontaine de la Lonne]"` (101 characters) crashed the server with an unhandled `AdapterError: value too long for type character varying(100)`.

The root cause is a schema mismatch: `t_name.name` is `varchar(200)` but the history table `h_name.name` was `varchar(100)`. The PostgreSQL trigger `histo_update_name()` copies the old name into `h_name` before any update, and that insert fails for names exceeding 100 characters.

## 🔍 How

Two-part fix:

1. **SQL migration** (`sql/8_2026_02_12_fix_h_name_varchar.sql`): ALTERs `h_name.name` from `varchar(100)` to `varchar(200)` to match `t_name.name`. Also updated `sql/0_tables.sql` so new deployments get the correct schema from the start.

2. **Shared validation utility** (`api/utils/nameValidation.js`): Exports `validateNameLength` and `NAME_MAX_LENGTH` (200) so the limit is defined in one place.

3. **Input validation** in controllers that write to `TName`:

   - `api/controllers/v1/entrance/update.js`

   - `api/controllers/v1/entrance/create.js`

   - `api/controllers/v1/cave/update.js`

   - `api/controllers/v1/cave/create.js`

   - `api/controllers/v1/name/update.js`

   - `api/controllers/v1/massif/create.js`

   - `api/controllers/v1/organization/create.js`

   Each now calls `validateNameLength` before hitting the DB and returns a `400 Bad Request` with a clear message if the name exceeds 200 characters.

## 🧪 Testing

1. Reset local db: `npm run dev:clean`

2. Start the dev server and attempt to update an entrance with a name longer than 100 characters — it should now succeed.

3. Attempt to update with a name longer than 200 characters — should return a 400 error with a descriptive message.

4. Run existing tests: `npm run test`

## 📸 Previews

_N/A — backend-only change, no UI impact._