### PR TITLE
fix(name): batch NameService queries to prevent PostgreSQL bind parameter overflow

### DIFF
--- a/api/services/NameService.js
+++ b/api/services/NameService.js
@@ -1,5 +1,25 @@
 /* eslint-disable no-param-reassign */
 
+const BATCH_SIZE = 3000; // Stay well under PostgreSQL's bind parameter limit
+
+/**
+ * Query in batches to avoid exceeding PostgreSQL's bind parameter limit.
+ * @param {Function} queryFn - async function that takes an array of ids and returns results
+ * @param {Array} ids - full list of ids to query
+ * @returns {Promise<Array>} concatenated results from all batches
+ */
+async function batchQuery(queryFn, ids) {
+  if (ids.length <= BATCH_SIZE) return queryFn(ids);
+  const results = [];
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const batch = ids.slice(i, i + BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const batchResults = await queryFn(batch);
+    results.push(...batchResults);
+  }
+  return results;
+}
+
 function extractMainName(entity) {
   const mainName = entity.names.find((n) => n.isMain);
   if (mainName) entity.name = mainName.name;
@@ -16,7 +36,10 @@ module.exports = {
     if (!entitiesToComplete) return null;
 
     const allIds = entitiesToComplete.map((e) => e.id);
-    const allNames = await TName.find().where({ [entitiesType]: allIds });
+    const allNames = await batchQuery(
+      (ids) => TName.find().where({ [entitiesType]: ids }),
+      allIds
+    );
     for (const entity of entitiesToComplete) {
       entity.names = allNames.filter((n) => n[entitiesType] === entity.id);
       extractMainName(entity);
@@ -31,7 +54,10 @@ module.exports = {
     if (emptyNameCaves.length === 0) return entitiesToComplete;
 
     const caveIds = emptyNameCaves.map((c) => c.id);
-    const entrances = await TEntrance.find({ cave: caveIds }).populate('names');
+    const entrances = await batchQuery(
+      (ids) => TEntrance.find({ cave: ids }).populate('names'),
+      caveIds
+    );
     for (const cave of emptyNameCaves) {
       cave.names = entrances.find((e) => e.cave === cave.id)?.names ?? [];
       extractMainName(cave);


### PR DESCRIPTION
## 🤔 What

Fix server crash (500) on `GET /api/v1/massifs/:id` for massifs with a large number of entrances/caves.

- Fixes `OperationalError [AdapterError]: bind message has 16198 parameter formats but 0 parameters` on `/api/v1/massifs/630`
- Adds batched querying to `NameService.setNames` to stay within PostgreSQL's bind parameter limit

## 🤷‍♂️ Why

Massif 630 contains ~16,198 entrances/caves. When `NameService.setNames` is called, it passes all entity IDs into a single `WHERE IN (...)` clause via Waterline. PostgreSQL rejects queries that exceed its bind parameter limit, causing the adapter to throw an unhandled error and crash the request.

This affects any massif (or potentially any entity list) large enough to exceed the limit.

## 🔍 How

Added a `batchQuery` helper function in `api/services/NameService.js` that chunks large ID arrays into batches of 3,000 before executing the database query. Results from all batches are concatenated and returned transparently.

Both queries in `setNames` now go through `batchQuery`:
1. `TName.find().where({ [entitiesType]: ids })` — the main name lookup
2. `TEntrance.find({ cave: ids }).populate('names')` — the cave-name fallback via entrance

For small arrays (≤3,000 IDs), `batchQuery` is a no-op passthrough, so there is no performance impact on the common case.

## 🧪 Testing

- Request `GET /api/v1/massifs/630` — should return 200 with populated massif data instead of crashing with a 500.
- Existing `NameService` integration tests should continue to pass (`npm run test -- --grep "NameService"`).

## 📸 Previews

N/A — backend-only fix, no UI changes.
