### PR TITLE
fix(search): use range filter for datePublication to match partial dates

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -7,12 +7,40 @@ function escapeCSV(v) {
   return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
 }
 
+/**
+ * Resolve a dot-notation key from a Typesense document.
+ * Typesense with enable_nested_fields returns nested structures,
+ * e.g. "authors.nickname" is stored as authors: [{ nickname: "X" }].
+ * This function traverses the path and flattens arrays of primitives
+ * into a semicolon-separated string suitable for CSV.
+ */
+function resolveField(doc, key) {
+  // Try flat key first (works for simple fields like "title", "id")
+  if (Object.prototype.hasOwnProperty.call(doc, key)) return doc[key];
+
+  const parts = key.split('.');
+  let current = doc[parts[0]];
+  for (let i = 1; i < parts.length && current != null; i += 1) {
+    if (Array.isArray(current)) {
+      // Extract the sub-field from each element in the array
+      current = current
+        .map((item) => item?.[parts[i]])
+        .filter((v) => v != null);
+    } else {
+      current = current[parts[i]];
+    }
+  }
+
+  if (Array.isArray(current)) return current.join('; ');
+  return current;
+}
+
 function documentsToCSV(documents, columns) {
   const csvRows = documents
     .map((doc) => {
       const row = [];
       for (const key of columns) {
-        row.push(escapeCSV(doc[key]));
+        row.push(escapeCSV(resolveField(doc, key)));
       }
       return row.join(',');
     })

--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -17,10 +17,45 @@ const allEntities = {
 };
 const allEntitiesKeys = Object.keys(allEntities);
 
+/**
+ * Increment the last numeric segment of a date string to compute
+ * an exclusive upper bound for prefix-based range filtering.
+ * Works with any depth: "2025" -> "2026", "2025-01" -> "2025-02",
+ * "2025-12" -> "2026-01", "2025-01-31" -> "2025-02-01", etc.
+ */
+function getDateUpperBound(value) {
+  const parts = value.split('-').map(Number);
+  if (parts.some(Number.isNaN)) return null;
+
+  // Increment from the last segment, carrying over when needed
+  // Limits: month max 12, day max 31 (intentionally simple ceiling)
+  const limits = [Infinity, 12, 31];
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    parts[i] += 1;
+    if (parts[i] <= (limits[i] ?? Infinity)) break;
+    parts[i] = 1;
+    if (i === 0) return null; // overflow past year — shouldn't happen in practice
+  }
+
+  return parts
+    .map((p, i) => (i === 0 ? `${p}` : String(p).padStart(2, '0')))
+    .join('-');
+}
+
 function buildFilter(filter, isLogicalCompareAnd = true) {
   const out = Object.entries(filter)
     .filter(([, v]) => v)
-    .map(([k, v]) => {
+    .flatMap(([k, v]) => {
+      // For datePublication, use a range filter so that partial dates
+      // (year, year-month, or full date) match all more-specific entries.
+      // e.g. "2025" matches "2025", "2025-01", "2025-01-15", etc.
+      if (k === 'datePublication' && typeof v === 'string') {
+        const upperBound = getDateUpperBound(v);
+        if (upperBound) {
+          return [`${k}:>=${v}`, `${k}:<${upperBound}`];
+        }
+      }
+
       let vFmt = v;
       let operator = ':'; // Partial equal
       if (Array.isArray(v))
@@ -28,7 +63,7 @@ function buildFilter(filter, isLogicalCompareAnd = true) {
       else if (typeof v === 'boolean' || typeof v === 'number')
         operator = ':='; // Exact equal
       else vFmt = `\`${v}\``;
-      return `${k}${operator}${vFmt}`;
+      return [`${k}${operator}${vFmt}`];
     });
   return out.join(isLogicalCompareAnd ? ' && ' : ' || ');
 }

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -522,5 +522,69 @@ describe('SearchService', () => {
       const call = typesenseStub.search.getCall(0);
       should(call.args[1].filter_by).equal('country:`FR`');
     });
+
+    it('should use range filter for datePublication with year only', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'documents',
+        filter: { datePublication: '2025' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'datePublication:>=2025 && datePublication:<2026'
+      );
+    });
+
+    it('should use range filter for datePublication with year-month', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'documents',
+        filter: { datePublication: '2025-01' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'datePublication:>=2025-01 && datePublication:<2025-02'
+      );
+    });
+
+    it('should handle datePublication year-month rollover (December)', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'documents',
+        filter: { datePublication: '2025-12' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'datePublication:>=2025-12 && datePublication:<2026-01'
+      );
+    });
+
+    it('should use exact match for datePublication with full date', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'documents',
+        filter: { datePublication: '2025-01-15' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'datePublication:>=2025-01-15 && datePublication:<2025-01-16'
+      );
+    });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix document search by publication date to return all documents within a given period, not just exact string matches.
- Fix CSV export showing `[object Object]` for Author and Country/Region columns.

## 🤷‍♂️ Why

1. A user reported that searching for documents of type "Numéro" with publication year `2025` did not return monthly bulletins (e.g. "Le P'tit Usania") because they are stored with month precision (`2025-08`). The `buildFilter` function was generating an exact-match Typesense filter, which only matched documents with exactly `"2025"` as their `datePublication` value.

2. A user reported that CSV exports for document searches display `[object Object]` instead of actual values for "Author" and "Country/Region" fields. This happened because Typesense returns nested fields (like `authors.nickname`) as nested objects, but the export code was accessing them as flat keys and falling back to `String()` coercion.

## 🔍 How

### Date publication range filter (`SearchService.js`)

`datePublication` is stored as a variable-precision string: `"2025"`, `"2025-01"`, or `"2025-01-15"`. These are lexicographically sortable.

Instead of exact matching, `buildFilter` now detects `datePublication` filters and generates a range query using Typesense's `>=` and `<` operators:

- `"2025"` → `datePublication:>=2025 && datePublication:<2026`
- `"2025-01"` → `datePublication:>=2025-01 && datePublication:<2025-02`
- `"2025-12"` → `datePublication:>=2025-12 && datePublication:<2026-01`
- `"2025-01-15"` → `datePublication:>=2025-01-15 && datePublication:<2025-01-16`

The `getDateUpperBound` function works generically by incrementing the last segment of the date string and carrying over when it overflows (month > 12, day > 31).

### CSV export nested field resolution (`advanced-search-export.js`)

Added a `resolveField` function that traverses dot-notation keys through the nested Typesense document structure. For array fields like `authors`, it extracts the sub-field from each element and joins them with `"; "`.

- `authors.nickname` → `"PANOS Vladimir; DUPONT Jean"`
- `iso3166.iso` → `"FR; FR-OCC"`
- `editor.name` → `"MDPI"` (single object, not array)

## 🧪 Testing

Run the SearchService tests:

```bash
npx mocha test/integration/1_services/SearchService.test.js --timeout 10000
```

To verify the date fix against production:

```bash
# Year-only search (previously returned only 2 results)
curl -s -X POST 'https://api.grottocenter.org/api/v1/advanced-search' \
  -H 'Content-Type: application/json' \
  -d '{"query":"","entity":"documents","filter":{"type":"Issue","datePublication":"2025"},"matchAllFields":true,"page":1,"size":20}'
```

To verify the CSV export fix against production:

```bash
curl -s -X POST 'https://api.grottocenter.org/api/v1/advanced-search/export' \
  -H 'Content-Type: application/json' \
  -d '{"query":"karst","entity":"documents","filter":{"type":"Issue","iso3166.iso":"FR"},"matchAllFields":true,"columns":["id","title","authors.nickname","iso3166.iso"],"columnsName":["ID","Title","Authors","Country"]}'
```

## 📸 Previews

N/A — backend-only changes, no UI modifications.
