### PR TITLE
fix(search): use prefix filter for datePublication on string field

### DIFF
--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -17,43 +17,16 @@ const allEntities = {
 };
 const allEntitiesKeys = Object.keys(allEntities);
 
-/**
- * Increment the last numeric segment of a date string to compute
- * an exclusive upper bound for prefix-based range filtering.
- * Works with any depth: "2025" -> "2026", "2025-01" -> "2025-02",
- * "2025-12" -> "2026-01", "2025-01-31" -> "2025-02-01", etc.
- */
-function getDateUpperBound(value) {
-  const parts = value.split('-').map(Number);
-  if (parts.some(Number.isNaN)) return null;
-
-  // Increment from the last segment, carrying over when needed
-  // Limits: month max 12, day max 31 (intentionally simple ceiling)
-  const limits = [Infinity, 12, 31];
-  for (let i = parts.length - 1; i >= 0; i -= 1) {
-    parts[i] += 1;
-    if (parts[i] <= (limits[i] ?? Infinity)) break;
-    parts[i] = 1;
-    if (i === 0) return null; // overflow past year — shouldn't happen in practice
-  }
-
-  return parts
-    .map((p, i) => (i === 0 ? `${p}` : String(p).padStart(2, '0')))
-    .join('-');
-}
-
 function buildFilter(filter, isLogicalCompareAnd = true) {
   const out = Object.entries(filter)
     .filter(([, v]) => v)
     .flatMap(([k, v]) => {
-      // For datePublication, use a range filter so that partial dates
+      // For datePublication, use a prefix filter so that partial dates
       // (year, year-month, or full date) match all more-specific entries.
       // e.g. "2025" matches "2025", "2025-01", "2025-01-15", etc.
+      // Typesense supports prefix matching on string fields with := and *.
       if (k === 'datePublication' && typeof v === 'string') {
-        const upperBound = getDateUpperBound(v);
-        if (upperBound) {
-          return [`${k}:>=${v}`, `${k}:<${upperBound}`];
-        }
+        return [`${k}:=${v}*`];
       }
 
       let vFmt = v;

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -523,7 +523,7 @@ describe('SearchService', () => {
       should(call.args[1].filter_by).equal('country:`FR`');
     });
 
-    it('should use range filter for datePublication with year only', async () => {
+    it('should use prefix filter for datePublication with year only', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
         .resolves({ hits: [] });
@@ -534,12 +534,10 @@ describe('SearchService', () => {
       });
 
       const call = typesenseStub.search.getCall(0);
-      should(call.args[1].filter_by).equal(
-        'datePublication:>=2025 && datePublication:<2026'
-      );
+      should(call.args[1].filter_by).equal('datePublication:=2025*');
     });
 
-    it('should use range filter for datePublication with year-month', async () => {
+    it('should use prefix filter for datePublication with year-month', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
         .resolves({ hits: [] });
@@ -550,28 +548,10 @@ describe('SearchService', () => {
       });
 
       const call = typesenseStub.search.getCall(0);
-      should(call.args[1].filter_by).equal(
-        'datePublication:>=2025-01 && datePublication:<2025-02'
-      );
+      should(call.args[1].filter_by).equal('datePublication:=2025-01*');
     });
 
-    it('should handle datePublication year-month rollover (December)', async () => {
-      typesenseStub.search = sinon
-        .stub(typesense, 'search')
-        .resolves({ hits: [] });
-
-      await SearchService.collectionSearch({
-        entity: 'documents',
-        filter: { datePublication: '2025-12' },
-      });
-
-      const call = typesenseStub.search.getCall(0);
-      should(call.args[1].filter_by).equal(
-        'datePublication:>=2025-12 && datePublication:<2026-01'
-      );
-    });
-
-    it('should use exact match for datePublication with full date', async () => {
+    it('should use prefix filter for datePublication with full date', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
         .resolves({ hits: [] });
@@ -582,9 +562,7 @@ describe('SearchService', () => {
       });
 
       const call = typesenseStub.search.getCall(0);
-      should(call.args[1].filter_by).equal(
-        'datePublication:>=2025-01-15 && datePublication:<2025-01-16'
-      );
+      should(call.args[1].filter_by).equal('datePublication:=2025-01-15*');
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix document search by publication date to return all documents within a given period, not just zero results.
- The previous fix (range operators `>=` / `<`) was deployed but did not work because `datePublication` is a `string` field in Typesense, and comparison operators only work on numeric types.

## 🤷‍♂️ Why

The original PR attempted to fix date filtering by generating range queries (`datePublication:>=2025 && datePublication:<2026`). While the logic was correct conceptually, Typesense's `>=`, `<`, `>`, `<=` operators are only supported on `int32`, `int64`, `float`, and geopoint fields — not strings. This caused the filter to silently return 0 results in production.

The `datePublication` field is stored as a variable-precision string (`"2025"`, `"2025-08"`, `"2025-01-15"`) and is defined as `type: 'string'` in the Typesense schema.

## 🔍 How

Replaced the range-based filter with Typesense's prefix filtering (available since v27.0). For string fields, the `:=` operator combined with a trailing `*` performs a starts-with match:

- `"2025"` → `datePublication:=2025*` (matches `"2025"`, `"2025-01"`, `"2025-08"`, etc.)
- `"2025-01"` → `datePublication:=2025-01*` (matches `"2025-01"`, `"2025-01-15"`, etc.)
- `"2025-01-15"` → `datePublication:=2025-01-15*` (matches `"2025-01-15"`)

This produces a single filter entry instead of two, which also fixes a latent bug where OR-mode queries (`matchAllFields: false`) would have split the range into separate OR clauses.

Removed the now-unnecessary `getDateUpperBound` function.

### Files changed

- `api/services/SearchService.js` — replaced range filter with prefix filter, removed `getDateUpperBound`
- `test/integration/1_services/SearchService.test.js` — updated 3 test cases to match new filter format

## 🧪 Testing

```bash
npx mocha test/integration/1_services/SearchService.test.js --timeout 10000
```

## 📸 Previews

N/A — backend-only changes, no UI modifications.
