### PR TITLE
fix(search): handle nested objects in CSV export to prevent [object Object] output

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -8,31 +8,59 @@ function escapeCSV(v) {
 }
 
 /**
+ * Convert a value to a CSV-safe primitive.
+ * - primitives pass through
+ * - arrays of primitives are joined with "; "
+ * - plain objects are stringified by picking the first string-valued field
+ * - arrays of objects: extract the first string field from each, then join
+ */
+function toPrimitive(val) {
+  if (val == null) return val;
+  if (typeof val !== 'object') return val;
+
+  if (Array.isArray(val)) {
+    const flat = val.map((item) => toPrimitive(item)).filter((v) => v != null);
+    return flat.join('; ');
+  }
+
+  // Plain object — pick the first string-valued property as a display value
+  const strVal = Object.values(val).find((v) => typeof v === 'string');
+  return strVal ?? JSON.stringify(val);
+}
+
+/**
  * Resolve a dot-notation key from a Typesense document.
  * Typesense with enable_nested_fields returns nested structures,
  * e.g. "authors.nickname" is stored as authors: [{ nickname: "X" }].
  * This function traverses the path and flattens arrays of primitives
  * into a semicolon-separated string suitable for CSV.
+ *
+ * Also handles the case where a parent key (e.g. "authors") is requested
+ * instead of a nested path (e.g. "authors.nickname") — objects and arrays
+ * of objects are coerced to readable strings.
  */
 function resolveField(doc, key) {
-  // Try flat key first (works for simple fields like "title", "id")
-  if (Object.prototype.hasOwnProperty.call(doc, key)) return doc[key];
-
-  const parts = key.split('.');
-  let current = doc[parts[0]];
-  for (let i = 1; i < parts.length && current != null; i += 1) {
-    if (Array.isArray(current)) {
-      // Extract the sub-field from each element in the array
-      current = current
-        .map((item) => item?.[parts[i]])
-        .filter((v) => v != null);
-    } else {
-      current = current[parts[i]];
+  // For dot-notation keys, always traverse the nested structure
+  if (key.includes('.')) {
+    const parts = key.split('.');
+    let current = doc[parts[0]];
+    for (let i = 1; i < parts.length && current != null; i += 1) {
+      if (Array.isArray(current)) {
+        // Extract the sub-field from each element in the array
+        current = current
+          .map((item) => item?.[parts[i]])
+          .filter((v) => v != null);
+      } else {
+        current = current[parts[i]];
+      }
     }
+
+    if (Array.isArray(current)) return current.join('; ');
+    return current;
   }
 
-  if (Array.isArray(current)) return current.join('; ');
-  return current;
+  // Simple key — return directly, but coerce objects to readable strings
+  return toPrimitive(doc[key]);
 }
 
 function documentsToCSV(documents, columns) {

--- a/test/integration/4_routes/AdvancedSearchExport.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport.test.js
@@ -265,6 +265,88 @@ describe('Advanced Search Export features', () => {
         });
     });
 
+    it('should flatten nested objects when parent key is used as column', (done) => {
+      const SearchService = require('../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [
+          {
+            document: {
+              id: '1',
+              title: 'Karst Book',
+              authors: [
+                { id: 10, nickname: 'PANOS Vladimir' },
+                { id: 20, nickname: 'DUPONT Jean' },
+              ],
+              iso3166: [
+                { iso: 'FR', name: 'France' },
+                { iso: 'FR-OCC', name: 'Occitanie' },
+              ],
+              editor: { id: 5, name: 'MDPI' },
+            },
+          },
+        ],
+        found: 1,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'documents',
+          columns: ['id', 'title', 'authors', 'iso3166', 'editor'],
+          columnsName: ['ID', 'Title', 'Author', 'Country', 'Editor'],
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          // Should NOT contain [object Object]
+          should(res.text).not.match(/\[object Object\]/);
+          // Authors: first string field is nickname (id is number)
+          should(res.text).match(/PANOS Vladimir; DUPONT Jean/);
+          // iso3166: first string field is iso
+          should(res.text).match(/FR; FR-OCC/);
+          // editor: single object, first string field is name (id is number)
+          should(res.text).match(/MDPI/);
+          return done();
+        });
+    });
+
+    it('should resolve dot-notation keys through nested structures', (done) => {
+      const SearchService = require('../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [
+          {
+            document: {
+              id: '1',
+              authors: [
+                { id: 10, nickname: 'Author A' },
+                { id: 20, nickname: 'Author B' },
+              ],
+              editor: { id: 5, name: 'Publisher X' },
+            },
+          },
+        ],
+        found: 1,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'documents',
+          columns: ['id', 'authors.nickname', 'editor.name'],
+          columnsName: ['ID', 'Author', 'Editor'],
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).not.match(/\[object Object\]/);
+          should(res.text).match(/Author A; Author B/);
+          should(res.text).match(/Publisher X/);
+          return done();
+        });
+    });
+
     it('should handle null and undefined values in CSV', (done) => {
       const SearchService = require('../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({


### PR DESCRIPTION
## 🤔 What

- Fix CSV export displaying `[object Object]` for Author, Country/Region, and other nested fields.
- Make `resolveField` robust against both parent keys (`"authors"`) and dot-notation keys (`"authors.nickname"`).
- Add `toPrimitive` helper to gracefully coerce nested objects/arrays into CSV-safe strings.
- Add test coverage for nested object handling in CSV export.

## 🤷‍♂️ Why

A user reported that CSV exports for document searches display `[object Object]` instead of actual values for "Author" and "Country/Region" fields.

Root cause: the front-end sends parent object keys (e.g. `"authors"`, `"iso3166"`) in the `columns` array, not the Typesense nested field paths (`"authors.nickname"`, `"iso3166.iso"`). Typesense returns these as nested objects, and `String()` coercion produces `[object Object]`.

A previous fix (commit `35424e4`) added a `resolveField` function for dot-notation traversal, but it didn't help because the front-end never sends dot-notation keys for these fields.

## 🔍 How

- Removed the `hasOwnProperty` early-return in `resolveField` for dot-notation keys — always traverse the nested structure to avoid returning raw objects if Typesense ever includes flat keys with object values.
- Added `toPrimitive(val)` as a safety net for simple (non-dot) keys:
  - Primitives pass through unchanged.
  - Arrays of primitives are joined with `"; "`.
  - Plain objects: picks the first string-valued property as display value.
  - Arrays of objects: recursively applies the above, then joins.
- This means `"authors"` → `"PANOS Vladimir; DUPONT Jean"` (extracts `nickname`, the first string property) even without the front-end fix.

A companion `FRONTEND_FIX.md` documents the front-end change needed: replace `"authors"` → `"authors.nickname"` and `"iso3166"` → `"iso3166.iso"` in the export columns payload.

## 🧪 Testing

Two new test cases in `AdvancedSearchExport.test.js`:

1. Parent keys as columns — verifies `toPrimitive` flattens `authors`, `iso3166`, and `editor` objects into readable strings.
2. Dot-notation keys — verifies traversal still works for `authors.nickname` and `editor.name`.

Manual verification against production:

```bash
curl -s -X POST 'https://api.grottocenter.org/api/v1/advanced-search/export' \
  -H 'Content-Type: application/json' \
  -d '{"query":"","entity":"documents","filter":{"datePublication":"2025"},"matchAllFields":true,"columns":["id","title","authors","iso3166"],"columnsName":["ID","Title","Authors","Country / Region"]}'
```

Should output author nicknames and ISO codes, not `[object Object]`.

## 📸 Previews

N/A — backend-only change, no UI modifications.
