### PR TITLE
fix(search): increase max_filter_by_candidates for prefix date filters

### DIFF
--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -18,6 +18,7 @@ const allEntities = {
 const allEntitiesKeys = Object.keys(allEntities);
 
 function buildFilter(filter, isLogicalCompareAnd = true) {
+  let hasPrefixFilter = false;
   const out = Object.entries(filter)
     .filter(([, v]) => v)
     .flatMap(([k, v]) => {
@@ -26,6 +27,7 @@ function buildFilter(filter, isLogicalCompareAnd = true) {
       // e.g. "2025" matches "2025", "2025-01", "2025-01-15", etc.
       // Typesense supports prefix matching on string fields with := and *.
       if (k === 'datePublication' && typeof v === 'string') {
+        hasPrefixFilter = true;
         return [`${k}:=${v}*`];
       }
 
@@ -38,7 +40,10 @@ function buildFilter(filter, isLogicalCompareAnd = true) {
       else vFmt = `\`${v}\``;
       return [`${k}${operator}${vFmt}`];
     });
-  return out.join(isLogicalCompareAnd ? ' && ' : ' || ');
+  return {
+    filterBy: out.join(isLogicalCompareAnd ? ' && ' : ' || '),
+    hasPrefixFilter,
+  };
 }
 
 async function isAlive() {
@@ -81,7 +86,7 @@ async function multiCollectionsSearch({
   entities = entities.filter((e) => allEntitiesKeys.includes(e));
   if (entities.length === 0) return null;
   const q = query || '*';
-  const filterBy = buildFilter(filter);
+  const { filterBy, hasPrefixFilter } = buildFilter(filter);
 
   const collections = entities.map((e) => ({
     collection: e,
@@ -92,6 +97,10 @@ async function multiCollectionsSearch({
   return typesense.multiSearch(collections, {
     per_page: 20,
     q,
+    // Typesense defaults max_filter_by_candidates to 4, which is too low
+    // for prefix filters like datePublication:=2025* that can match many
+    // distinct values (2025, 2025-01, …, 2025-12, 2025-01-15, etc.).
+    ...(hasPrefixFilter && { max_filter_by_candidates: 100 }),
   });
 }
 
@@ -107,7 +116,10 @@ async function collectionSearch({
 } = {}) {
   if (!allEntitiesKeys.includes(entity)) return null;
   const q = query || '*';
-  const filterBy = buildFilter(filter, isLogicalCompareAnd);
+  const { filterBy, hasPrefixFilter } = buildFilter(
+    filter,
+    isLogicalCompareAnd
+  );
 
   // Cap size at Typesense's limit of 1000 hits per page
   const perPage = size ? Math.min(size, 1000) : size;
@@ -120,6 +132,10 @@ async function collectionSearch({
     ...(sort && { sort_by: `${sort},_text_match:desc` }),
     ...(filterBy && { filter_by: filterBy }),
     ...(fields && { include_fields: fields.join(',') }),
+    // Typesense defaults max_filter_by_candidates to 4, which is too low
+    // for prefix filters like datePublication:=2025* that can match many
+    // distinct values (2025, 2025-01, …, 2025-12, 2025-01-15, etc.).
+    ...(hasPrefixFilter && { max_filter_by_candidates: 100 }),
   };
 
   return typesense.search(entity, params);
@@ -136,7 +152,10 @@ async function fieldSearch({
   if (!allEntitiesKeys.includes(entity)) return null;
   if (!field) return null;
   const q = query || '*';
-  const filterBy = buildFilter(filter, isLogicalCompareAnd);
+  const { filterBy, hasPrefixFilter } = buildFilter(
+    filter,
+    isLogicalCompareAnd
+  );
 
   const params = {
     q,
@@ -146,6 +165,7 @@ async function fieldSearch({
     sort_by: '_group_found:desc',
     per_page: size,
     ...(filterBy && { filter_by: filterBy }),
+    ...(hasPrefixFilter && { max_filter_by_candidates: 100 }),
   };
 
   return typesense.search(entity, params);

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -564,5 +564,48 @@ describe('SearchService', () => {
       const call = typesenseStub.search.getCall(0);
       should(call.args[1].filter_by).equal('datePublication:=2025-01-15*');
     });
+
+    it('should set max_filter_by_candidates when datePublication prefix filter is used', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'documents',
+        filter: { datePublication: '2025' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].max_filter_by_candidates).equal(100);
+    });
+
+    it('should not set max_filter_by_candidates when no prefix filter is used', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'organizations',
+        filter: { country: 'FR' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].max_filter_by_candidates).be.undefined();
+    });
+
+    it('should set max_filter_by_candidates in multiCollectionsSearch with prefix filter', async () => {
+      typesenseStub.multiSearch = sinon
+        .stub(typesense, 'multiSearch')
+        .resolves({ results: [] });
+
+      await SearchService.multiCollectionsSearch({
+        query: 'test',
+        entities: ['documents'],
+        filter: { datePublication: '2025' },
+      });
+
+      const call = typesenseStub.multiSearch.getCall(0);
+      should(call.args[1].max_filter_by_candidates).equal(100);
+    });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix document search by publication date returning incomplete results when using prefix filters (e.g. searching for year "2025" only returned a fraction of matching documents).
- Set `max_filter_by_candidates: 100` on all Typesense search requests that involve a prefix filter.

## 🤷‍♂️ Why

Typesense's `max_filter_by_candidates` parameter defaults to **4**, meaning it only considers the top 4 distinct prefix matches when evaluating a `filter_by` with a wildcard. For `datePublication:=2025*`, there are 13+ distinct matching values (`"2025"`, `"2025-01"`, `"2025-02"`, …, `"2025-12"`, plus full dates like `"2025-01-15"`). The default cap of 4 caused Typesense to silently ignore the rest, returning only a subset of documents.

This is why searching for "Le P'tit Usania" issues published in 2025 returned 3 instead of 12.

Ref: [Typesense docs — `max_filter_by_candidates`](https://typesense.org/docs/30.1/api/search.html)

## 🔍 How

- `buildFilter()` in `SearchService.js` now returns `{ filterBy, hasPrefixFilter }` instead of a plain string, tracking whether a prefix wildcard filter was generated.
- All three search functions (`collectionSearch`, `multiCollectionsSearch`, `fieldSearch`) conditionally add `max_filter_by_candidates: 100` to the Typesense query params when a prefix filter is present.
- No changes to the filter syntax itself — `datePublication:=2025*` was already correct.

### Files changed

- `api/services/SearchService.js` — `buildFilter` returns an object; all callers pass `max_filter_by_candidates` when needed.
- `test/integration/1_services/SearchService.test.js` — added 3 test cases for `max_filter_by_candidates` behavior.

## 🧪 Testing

```bash
npx mocha test/integration/1_services/SearchService.test.js --timeout 10000
```

To verify in production: search for documents with type "Issue" and datePublication "2025" — all 12 monthly "Le P'tit Usania" issues should now appear.

## 📸 Previews

N/A — backend-only change, no UI modifications.
