### PR TITLE
feat(relevanceOrdering): auto-assign relevance on entity creation and add move-relevance endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,5 +123,6 @@ coverage
 docker/esdata/*
 !docker/esdata/for-docker-compose
 .amazonq
+.kiro
 *.iml
 build-info.json

--- a/api/controllers/v1/comment/create.js
+++ b/api/controllers/v1/comment/create.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const NotificationService = require('../../../services/NotificationService');
 const CommentService = require('../../../services/CommentService');
+const RelevanceService = require('../../../services/RelevanceService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
 const { toSimpleComment } = require('../../../services/mapping/converters');
 
@@ -20,6 +21,10 @@ module.exports = async (req, res) => {
   );
   if (!linkedEntity) return null;
 
+  const relevance = await RelevanceService.computeNextRelevance('comment', {
+    [linkedEntity.type]: linkedEntity.id,
+  });
+
   const newComment = await TComment.create({
     author: req.token.id,
     body,
@@ -32,7 +37,7 @@ module.exports = async (req, res) => {
     dateInscription: new Date(),
     language,
     [linkedEntity.type]: linkedEntity.id,
-    // TODO compute relevance
+    relevance,
   }).fetch();
 
   const populatedComment = await CommentService.getComment(newComment.id);

--- a/api/controllers/v1/comment/move-relevance.js
+++ b/api/controllers/v1/comment/move-relevance.js
@@ -1,0 +1,18 @@
+const RelevanceService = require('../../../services/RelevanceService');
+
+module.exports = async (req, res) => {
+  const id = Number(req.params.id);
+  const direction = Number(req.body.direction);
+
+  try {
+    const result = await RelevanceService.moveRelevance(
+      'comment',
+      id,
+      direction
+    );
+    return res.ok(result);
+  } catch (err) {
+    if (err.status === 404) return res.notFound({ message: err.message });
+    return res.badRequest({ message: err.message });
+  }
+};

--- a/api/controllers/v1/description/create.js
+++ b/api/controllers/v1/description/create.js
@@ -2,6 +2,7 @@ const ControllerService = require('../../../services/ControllerService');
 const NotificationService = require('../../../services/NotificationService');
 const DescriptionService = require('../../../services/DescriptionService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
+const RelevanceService = require('../../../services/RelevanceService');
 const { toSimpleDescription } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
@@ -20,6 +21,10 @@ module.exports = async (req, res) => {
   );
   if (!linkedEntity) return null;
 
+  const relevance = await RelevanceService.computeNextRelevance('description', {
+    [linkedEntity.type]: linkedEntity.id,
+  });
+
   const newDescription = await TDescription.create({
     author: req.token.id,
     dateInscription: new Date(),
@@ -27,7 +32,7 @@ module.exports = async (req, res) => {
     title,
     language,
     [linkedEntity.type]: linkedEntity.id,
-    // TODO compute relevance
+    relevance,
   }).fetch();
 
   const populatedDescription = await DescriptionService.getDescription(

--- a/api/controllers/v1/description/move-relevance.js
+++ b/api/controllers/v1/description/move-relevance.js
@@ -1,0 +1,18 @@
+const RelevanceService = require('../../../services/RelevanceService');
+
+module.exports = async (req, res) => {
+  const id = Number(req.params.id);
+  const direction = Number(req.body.direction);
+
+  try {
+    const result = await RelevanceService.moveRelevance(
+      'description',
+      id,
+      direction
+    );
+    return res.ok(result);
+  } catch (err) {
+    if (err.status === 404) return res.notFound({ message: err.message });
+    return res.badRequest({ message: err.message });
+  }
+};

--- a/api/controllers/v1/history/create.js
+++ b/api/controllers/v1/history/create.js
@@ -1,3 +1,4 @@
+const RelevanceService = require('../../../services/RelevanceService');
 const ControllerService = require('../../../services/ControllerService');
 const NotificationService = require('../../../services/NotificationService');
 const HistoryService = require('../../../services/HistoryService');
@@ -20,13 +21,17 @@ module.exports = async (req, res) => {
   );
   if (!linkedEntity) return null;
 
+  const relevance = await RelevanceService.computeNextRelevance('history', {
+    entrance: entranceId,
+  });
+
   const newHistory = await THistory.create({
     author: req.token.id,
     body,
     dateInscription: new Date(),
     entrance: entranceId,
     language: languageId,
-    // TODO compute relevance
+    relevance,
   }).fetch();
 
   const populatedHistory = await HistoryService.getHistory(newHistory.id);

--- a/api/controllers/v1/history/move-relevance.js
+++ b/api/controllers/v1/history/move-relevance.js
@@ -1,0 +1,18 @@
+const RelevanceService = require('../../../services/RelevanceService');
+
+module.exports = async (req, res) => {
+  const id = Number(req.params.id);
+  const direction = Number(req.body.direction);
+
+  try {
+    const result = await RelevanceService.moveRelevance(
+      'history',
+      id,
+      direction
+    );
+    return res.ok(result);
+  } catch (err) {
+    if (err.status === 404) return res.notFound({ message: err.message });
+    return res.badRequest({ message: err.message });
+  }
+};

--- a/api/controllers/v1/location/create.js
+++ b/api/controllers/v1/location/create.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const NotificationService = require('../../../services/NotificationService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
+const RelevanceService = require('../../../services/RelevanceService');
 const LocationService = require('../../../services/LocationService');
 const { toSimpleLocation } = require('../../../services/mapping/converters');
 
@@ -20,14 +21,18 @@ module.exports = async (req, res) => {
   );
   if (!linkedEntity) return null;
 
+  const relevance = await RelevanceService.computeNextRelevance('location', {
+    entrance: entranceId,
+  });
+
   const newLocation = await TLocation.create({
     author: req.token.id,
     body,
     dateInscription: new Date(),
     entrance: entranceId,
     language: languageId,
+    relevance,
     title: req.param('title', null),
-    // TODO compute relevance
   }).fetch();
 
   const locationPopulated = await LocationService.getLocation(newLocation.id);

--- a/api/controllers/v1/location/move-relevance.js
+++ b/api/controllers/v1/location/move-relevance.js
@@ -1,0 +1,18 @@
+const RelevanceService = require('../../../services/RelevanceService');
+
+module.exports = async (req, res) => {
+  const id = Number(req.params.id);
+  const direction = Number(req.body.direction);
+
+  try {
+    const result = await RelevanceService.moveRelevance(
+      'location',
+      id,
+      direction
+    );
+    return res.ok(result);
+  } catch (err) {
+    if (err.status === 404) return res.notFound({ message: err.message });
+    return res.badRequest({ message: err.message });
+  }
+};

--- a/api/controllers/v1/rigging/create.js
+++ b/api/controllers/v1/rigging/create.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const NotificationService = require('../../../services/NotificationService');
 const RiggingService = require('../../../services/RiggingService');
+const RelevanceService = require('../../../services/RelevanceService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
 const { toSimpleRigging } = require('../../../services/mapping/converters');
 
@@ -22,6 +23,11 @@ module.exports = async (req, res) => {
   const parsedObstacles = await RiggingService.serializeObstaclesForDB(
     req.param('obstacles', [])
   );
+
+  const relevance = await RelevanceService.computeNextRelevance('rigging', {
+    [linkedEntity.type]: linkedEntity.id,
+  });
+
   const newRigging = await TRigging.create({
     author: req.token.id,
     title,
@@ -32,7 +38,7 @@ module.exports = async (req, res) => {
     dateInscription: new Date(),
     language,
     [linkedEntity.type]: linkedEntity.id,
-    // TODO compute relevance
+    relevance,
   }).fetch();
 
   const populatedRigging = await RiggingService.getRigging(newRigging.id);

--- a/api/controllers/v1/rigging/move-relevance.js
+++ b/api/controllers/v1/rigging/move-relevance.js
@@ -1,0 +1,18 @@
+const RelevanceService = require('../../../services/RelevanceService');
+
+module.exports = async (req, res) => {
+  const id = Number(req.params.id);
+  const direction = Number(req.body.direction);
+
+  try {
+    const result = await RelevanceService.moveRelevance(
+      'rigging',
+      id,
+      direction
+    );
+    return res.ok(result);
+  } catch (err) {
+    if (err.status === 404) return res.notFound({ message: err.message });
+    return res.badRequest({ message: err.message });
+  }
+};

--- a/api/services/RelevanceService.js
+++ b/api/services/RelevanceService.js
@@ -1,0 +1,162 @@
+/**
+ * ENTITY_CONFIG maps each relevance entity type to its Waterline model
+ * and the parent fields that define its scope.
+ *
+ * Models (TLocation, TDescription, etc.) are Sails globals — no imports needed.
+ */
+const ENTITY_CONFIG = {
+  location: {
+    model: 'tlocation',
+    parentFields: ['entrance'],
+  },
+  description: {
+    model: 'tdescription',
+    parentFields: ['entrance', 'cave', 'massif', 'document'],
+  },
+  comment: {
+    model: 'tcomment',
+    parentFields: ['entrance', 'cave'],
+  },
+  rigging: {
+    model: 'trigging',
+    parentFields: ['entrance', 'cave'],
+  },
+  history: {
+    model: 'thistory',
+    parentFields: ['entrance', 'cave'],
+  },
+};
+
+function getConfig(entityType) {
+  const config = ENTITY_CONFIG[entityType];
+  if (!config) {
+    const err = new Error(`Invalid entity type: ${entityType}.`);
+    err.status = 400;
+    throw err;
+  }
+  return config;
+}
+
+function getModel(entityType) {
+  const config = getConfig(entityType);
+  return sails.models[config.model];
+}
+
+module.exports = {
+  ENTITY_CONFIG,
+
+  /**
+   * Extracts the parent scope from an entity instance.
+   *
+   * @param {string} entityType - One of 'location', 'description', 'comment', 'rigging', 'history'
+   * @param {Object} entity - The entity record
+   * @returns {Object} e.g. { entrance: 42 }
+   */
+  getParentScope(entityType, entity) {
+    const config = getConfig(entityType);
+    for (const field of config.parentFields) {
+      if (entity[field] != null) {
+        return { [field]: entity[field] };
+      }
+    }
+    return {};
+  },
+
+  /**
+   * Computes MAX(relevance) + 1 for the given entity type within the parent scope.
+   * Only considers non-deleted entities.
+   *
+   * @param {string} entityType - One of 'location', 'description', 'comment', 'rigging', 'history'
+   * @param {Object} parentFieldValues - e.g. { entrance: 42 }
+   * @returns {Promise<number>} The next relevance value (1 if no existing entities)
+   */
+  async computeNextRelevance(entityType, parentFieldValues) {
+    const Model = getModel(entityType);
+    const where = { ...parentFieldValues, isDeleted: false };
+    const results = await Model.find({
+      where,
+      select: ['relevance'],
+      sort: 'relevance DESC',
+      limit: 1,
+    });
+    if (results.length === 0) {
+      return 1;
+    }
+    return results[0].relevance + 1;
+  },
+
+  /**
+   * Swaps the relevance of the target entity with its adjacent neighbor.
+   *
+   * @param {string} entityType - One of 'location', 'description', 'comment', 'rigging', 'history'
+   * @param {number} entityId - ID of the entity to move
+   * @param {number} direction - 1 (move down / increase relevance) or -1 (move up / decrease relevance)
+   * @returns {Promise<{moved: Object, swapped: Object}>} Both entities with updated relevance
+   * @throws {Error} With .status property for not-found (404), deleted (400), boundary (400), invalid direction (400)
+   */
+  async moveRelevance(entityType, entityId, direction) {
+    if (direction !== 1 && direction !== -1) {
+      const err = new Error('Direction must be 1 or -1.');
+      err.status = 400;
+      throw err;
+    }
+
+    const config = getConfig(entityType);
+    const Model = sails.models[config.model];
+    const label = entityType.charAt(0).toUpperCase() + entityType.slice(1);
+
+    const target = await Model.findOne({ id: entityId });
+    if (!target) {
+      const err = new Error(`${label} of id ${entityId} not found.`);
+      err.status = 404;
+      throw err;
+    }
+    if (target.isDeleted) {
+      const err = new Error(`${label} of id ${entityId} is deleted.`);
+      err.status = 400;
+      throw err;
+    }
+
+    const parentScope = this.getParentScope(entityType, target);
+
+    const where = {
+      ...parentScope,
+      isDeleted: false,
+      id: { '!=': entityId },
+    };
+
+    let sort;
+    if (direction === 1) {
+      where.relevance = { '>': target.relevance };
+      sort = 'relevance ASC';
+    } else {
+      where.relevance = { '<': target.relevance };
+      sort = 'relevance DESC';
+    }
+
+    const neighbors = await Model.find({
+      where,
+      sort,
+      limit: 1,
+    });
+
+    if (neighbors.length === 0) {
+      const err = new Error(
+        `${label} of id ${entityId} cannot be moved further in that direction.`
+      );
+      err.status = 400;
+      throw err;
+    }
+
+    const neighbor = neighbors[0];
+
+    const moved = await Model.updateOne({ id: entityId }).set({
+      relevance: neighbor.relevance,
+    });
+    const swapped = await Model.updateOne({ id: neighbor.id }).set({
+      relevance: target.relevance,
+    });
+
+    return { moved, swapped };
+  },
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -1073,6 +1073,42 @@ paths:
         '404':
           description: We don't find these description's snapshots.
 
+  '/descriptions/{id}/move-relevance':
+    patch:
+      tags:
+        - descriptions
+      description: Move a description up or down in the relevance ordering within its cave, entrance, massif, or document scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - direction
+              properties:
+                direction:
+                  type: integer
+                  enum: [1, -1]
+                  description: "1 to move down (increase relevance), -1 to move up (decrease relevance)"
+      responses:
+        '200':
+          description: Successful swap — returns both entities with updated relevance values
+        '400':
+          description: Invalid direction, entity is deleted, or entity is already at boundary
+        '401':
+          description: Authentication required
+        '404':
+          description: Entity not found
+
   '/documents':
     post:
       tags:
@@ -2536,6 +2572,42 @@ paths:
         '404':
           description: We don't find these location's snapshots.
 
+  '/locations/{id}/move-relevance':
+    patch:
+      tags:
+        - locations
+      description: Move a location up or down in the relevance ordering within its entrance scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - direction
+              properties:
+                direction:
+                  type: integer
+                  enum: [1, -1]
+                  description: "1 to move down (increase relevance), -1 to move up (decrease relevance)"
+      responses:
+        '200':
+          description: Successful swap — returns both entities with updated relevance values
+        '400':
+          description: Invalid direction, entity is deleted, or entity is already at boundary
+        '401':
+          description: Authentication required
+        '404':
+          description: Entity not found
+
   '/histories':
     post:
       tags:
@@ -2688,6 +2760,42 @@ paths:
         '404':
           description: We don't find these comment's snapshots.
 
+  '/comments/{id}/move-relevance':
+    patch:
+      tags:
+        - comments
+      description: Move a comment up or down in the relevance ordering within its entrance or cave scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - direction
+              properties:
+                direction:
+                  type: integer
+                  enum: [1, -1]
+                  description: "1 to move down (increase relevance), -1 to move up (decrease relevance)"
+      responses:
+        '200':
+          description: Successful swap — returns both entities with updated relevance values
+        '400':
+          description: Invalid direction, entity is deleted, or entity is already at boundary
+        '401':
+          description: Authentication required
+        '404':
+          description: Entity not found
+
   '/riggings':
     post:
       tags:
@@ -2755,6 +2863,78 @@ paths:
                 $ref: '#/components/schemas/Rigging'
         '404':
           description: We don't find these rigging's snapshots.
+
+  '/riggings/{id}/move-relevance':
+    patch:
+      tags:
+        - riggings
+      description: Move a rigging up or down in the relevance ordering within its entrance or cave scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - direction
+              properties:
+                direction:
+                  type: integer
+                  enum: [1, -1]
+                  description: "1 to move down (increase relevance), -1 to move up (decrease relevance)"
+      responses:
+        '200':
+          description: Successful swap — returns both entities with updated relevance values
+        '400':
+          description: Invalid direction, entity is deleted, or entity is already at boundary
+        '401':
+          description: Authentication required
+        '404':
+          description: Entity not found
+
+  '/histories/{id}/move-relevance':
+    patch:
+      tags:
+        - histories
+      description: Move a history up or down in the relevance ordering within its entrance or cave scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - direction
+              properties:
+                direction:
+                  type: integer
+                  enum: [1, -1]
+                  description: "1 to move down (increase relevance), -1 to move up (decrease relevance)"
+      responses:
+        '200':
+          description: Successful swap — returns both entities with updated relevance values
+        '400':
+          description: Invalid direction, entity is deleted, or entity is already at boundary
+        '401':
+          description: Authentication required
+        '404':
+          description: Entity not found
 
   '/names/{id}':
     patch:
@@ -4493,6 +4673,11 @@ components:
         type: integer
         minimum: 1
         maximum: 22
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     Auth-success:
       type: object

--- a/config/policies.js
+++ b/config/policies.js
@@ -78,6 +78,7 @@ module.exports.policies = {
   'v1/description/update': 'tokenAuth',
   'v1/description/delete': 'tokenAuth',
   'v1/description/restore': 'tokenAuth',
+  'v1/description/move-relevance': ['validateId', 'tokenAuth'],
 
   // Document
   'v1/document/count': true,
@@ -166,6 +167,7 @@ module.exports.policies = {
   'v1/location/update': 'tokenAuth',
   'v1/location/delete': 'tokenAuth',
   'v1/location/restore': 'tokenAuth',
+  'v1/location/move-relevance': ['validateId', 'tokenAuth'],
 
   // History
   'v1/history/get-snapshots': true,
@@ -173,6 +175,7 @@ module.exports.policies = {
   'v1/history/update': 'tokenAuth',
   'v1/history/delete': 'tokenAuth',
   'v1/history/restore': 'tokenAuth',
+  'v1/history/move-relevance': ['validateId', 'tokenAuth'],
 
   // Rigging
   'v1/rigging/get-snapshots': true,
@@ -180,6 +183,7 @@ module.exports.policies = {
   'v1/rigging/update': 'tokenAuth',
   'v1/rigging/delete': 'tokenAuth',
   'v1/rigging/restore': 'tokenAuth',
+  'v1/rigging/move-relevance': ['validateId', 'tokenAuth'],
 
   // Comment
   'v1/comment/get-snapshots': true,
@@ -187,6 +191,7 @@ module.exports.policies = {
   'v1/comment/update': 'tokenAuth',
   'v1/comment/delete': 'tokenAuth',
   'v1/comment/restore': 'tokenAuth',
+  'v1/comment/move-relevance': ['validateId', 'tokenAuth'],
 
   // Country
   'v1/country/count': true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -295,6 +295,14 @@ module.exports.routes = {
   'DELETE /api/v1/riggings/:id': 'v1/rigging/delete',
   'POST /api/v1/riggings/:id/restore': 'v1/rigging/restore',
 
+  // Relevance ordering
+  'PATCH /api/v1/locations/:id/move-relevance': 'v1/location/move-relevance',
+  'PATCH /api/v1/descriptions/:id/move-relevance':
+    'v1/description/move-relevance',
+  'PATCH /api/v1/comments/:id/move-relevance': 'v1/comment/move-relevance',
+  'PATCH /api/v1/riggings/:id/move-relevance': 'v1/rigging/move-relevance',
+  'PATCH /api/v1/histories/:id/move-relevance': 'v1/history/move-relevance',
+
   // Document Subject
   'GET /api/v1/documents/subjects': 'v1/subject/find-all',
   'GET /api/v1/documents/subjects/:code': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.5",
         "express": "^4.22.0",
+        "fast-check": "^4.5.3",
         "fixted": "^4.2.7",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
@@ -1258,9 +1259,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.1.tgz",
-      "integrity": "sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
+      "integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3354,13 +3355,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3478,26 +3479,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -5935,6 +5916,29 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6882,30 +6886,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -10445,6 +10442,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -10522,26 +10536,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -11553,26 +11547,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sails/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/sails/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11798,26 +11772,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "express": "^4.22.0",
+    "fast-check": "^4.5.3",
     "fixted": "^4.2.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",

--- a/sql/6_04_2026_02_13_normalize-relevance.sql
+++ b/sql/6_04_2026_02_13_normalize-relevance.sql
@@ -1,0 +1,89 @@
+-- normalize-relevance.sql
+--
+-- Normalizes relevance values for t_location, t_description, t_comment,
+-- t_rigging, and t_history to sequential positive integers (1, 2, 3, ...) within
+-- each parent scope. Deleted entities get relevance = 0.
+--
+-- Ordering: current relevance ASC, then id ASC as tiebreaker.
+-- This script is idempotent — running it multiple times produces the same result.
+--
+-- Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6
+
+\c grottoce;
+
+BEGIN;
+
+-- t_location: scoped by id_entrance
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY id_entrance
+    ORDER BY relevance, id
+  ) AS new_relevance
+  FROM t_location
+  WHERE is_deleted = false
+)
+UPDATE t_location SET relevance = ranked.new_relevance
+FROM ranked WHERE t_location.id = ranked.id;
+
+UPDATE t_location SET relevance = 0 WHERE is_deleted = true;
+
+-- t_description: scoped by id_entrance, id_cave, id_massif, id_document
+-- A description belongs to exactly one parent; COALESCE(field, 0) ensures
+-- NULLs are grouped correctly so each parent scope is partitioned independently.
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY COALESCE(id_entrance, 0), COALESCE(id_cave, 0),
+                COALESCE(id_massif, 0), COALESCE(id_document, 0)
+    ORDER BY relevance, id
+  ) AS new_relevance
+  FROM t_description
+  WHERE is_deleted = false
+)
+UPDATE t_description SET relevance = ranked.new_relevance
+FROM ranked WHERE t_description.id = ranked.id;
+
+UPDATE t_description SET relevance = 0 WHERE is_deleted = true;
+
+-- t_comment: scoped by id_entrance, id_cave
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY COALESCE(id_entrance, 0), COALESCE(id_cave, 0)
+    ORDER BY relevance, id
+  ) AS new_relevance
+  FROM t_comment
+  WHERE is_deleted = false
+)
+UPDATE t_comment SET relevance = ranked.new_relevance
+FROM ranked WHERE t_comment.id = ranked.id;
+
+UPDATE t_comment SET relevance = 0 WHERE is_deleted = true;
+
+-- t_rigging: scoped by id_entrance, id_cave
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY COALESCE(id_entrance, 0), COALESCE(id_cave, 0)
+    ORDER BY relevance, id
+  ) AS new_relevance
+  FROM t_rigging
+  WHERE is_deleted = false
+)
+UPDATE t_rigging SET relevance = ranked.new_relevance
+FROM ranked WHERE t_rigging.id = ranked.id;
+
+UPDATE t_rigging SET relevance = 0 WHERE is_deleted = true;
+
+-- t_history: scoped by id_entrance, id_cave
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY COALESCE(id_entrance, 0), COALESCE(id_cave, 0)
+    ORDER BY relevance, id
+  ) AS new_relevance
+  FROM t_history
+  WHERE is_deleted = false
+)
+UPDATE t_history SET relevance = ranked.new_relevance
+FROM ranked WHERE t_history.id = ranked.id;
+
+UPDATE t_history SET relevance = 0 WHERE is_deleted = true;
+
+COMMIT;

--- a/test/integration/1_services/RelevanceService.test.js
+++ b/test/integration/1_services/RelevanceService.test.js
@@ -1,0 +1,452 @@
+const should = require('should');
+const fc = require('fast-check');
+const RelevanceService = require('../../../api/services/RelevanceService');
+
+describe('RelevanceService', () => {
+  describe('computeNextRelevance()', () => {
+    /**
+     * Property 1: Creation assigns next relevance
+     *
+     * For any parent scope containing N non-deleted entities with relevance
+     * values, computeNextRelevance should return max(existing) + 1.
+     * When N is 0, it should return 1.
+     *
+     * **Validates: Requirements 1.1, 1.2, 1.3**
+     */
+    it('should assign max(existing relevance) + 1, or 1 for empty scope', async function pbt1() {
+      this.timeout(120000);
+      // Use a high entrance ID to avoid fixture conflicts
+      const BASE_ENTRANCE_ID = 9000;
+      let scenarioIndex = 0;
+
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(fc.integer({ min: 1, max: 10000 }), {
+            minLength: 0,
+            maxLength: 10,
+          }),
+          async (relevanceValues) => {
+            scenarioIndex += 1;
+            const entranceId = BASE_ENTRANCE_ID + scenarioIndex;
+            const createdIds = [];
+
+            try {
+              // Set up: create TComment entities with the generated relevance values
+              // eslint-disable-next-line no-await-in-loop
+              const created = await Promise.all(
+                relevanceValues.map((rel) =>
+                  TComment.create({
+                    author: 1,
+                    dateInscription: new Date().toISOString(),
+                    relevance: rel,
+                    title: `PBT comment ${scenarioIndex}`,
+                    body: `Property test body`,
+                    entrance: entranceId,
+                    language: 'fra',
+                    isDeleted: false,
+                  }).fetch()
+                )
+              );
+              created.forEach((c) => createdIds.push(c.id));
+
+              // Act: compute next relevance
+              const result = await RelevanceService.computeNextRelevance(
+                'comment',
+                { entrance: entranceId }
+              );
+
+              // Assert
+              if (relevanceValues.length === 0) {
+                should(result).equal(1);
+              } else {
+                const maxRelevance = Math.max(...relevanceValues);
+                should(result).equal(maxRelevance + 1);
+              }
+            } finally {
+              // Cleanup: destroy all created comments
+              if (createdIds.length > 0) {
+                await TComment.destroy({ id: createdIds });
+              }
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should only consider non-deleted entities (ignores deleted)', async function pbt2() {
+      this.timeout(120000);
+      const entranceId = 8999;
+      const createdIds = [];
+
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(fc.integer({ min: 1, max: 10000 }), {
+            minLength: 1,
+            maxLength: 5,
+          }),
+          fc.array(fc.integer({ min: 1, max: 10000 }), {
+            minLength: 1,
+            maxLength: 5,
+          }),
+          async (activeRelevances, deletedRelevances) => {
+            createdIds.length = 0;
+
+            try {
+              // Create active (non-deleted) comments
+              const activeCreated = await Promise.all(
+                activeRelevances.map((rel) =>
+                  TComment.create({
+                    author: 1,
+                    dateInscription: new Date().toISOString(),
+                    relevance: rel,
+                    title: 'PBT active',
+                    body: 'Active comment',
+                    entrance: entranceId,
+                    language: 'fra',
+                    isDeleted: false,
+                  }).fetch()
+                )
+              );
+              activeCreated.forEach((c) => createdIds.push(c.id));
+
+              // Create deleted comments (should be ignored)
+              const deletedCreated = await Promise.all(
+                deletedRelevances.map((rel) =>
+                  TComment.create({
+                    author: 1,
+                    dateInscription: new Date().toISOString(),
+                    relevance: rel,
+                    title: 'PBT deleted',
+                    body: 'Deleted comment',
+                    entrance: entranceId,
+                    language: 'fra',
+                    isDeleted: true,
+                  }).fetch()
+                )
+              );
+              deletedCreated.forEach((c) => createdIds.push(c.id));
+
+              // Act
+              const result = await RelevanceService.computeNextRelevance(
+                'comment',
+                { entrance: entranceId }
+              );
+
+              // Assert: should only consider active relevances
+              const maxActive = Math.max(...activeRelevances);
+              should(result).equal(maxActive + 1);
+            } finally {
+              if (createdIds.length > 0) {
+                await TComment.destroy({ id: createdIds });
+              }
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Unit test: returns 1 for empty scope
+     * **Validates: Requirements 1.2**
+     */
+    it('should return 1 when no entities exist in the scope', async () => {
+      const entranceId = 6001;
+      // Ensure no comments exist for this entrance
+      await TComment.destroy({ entrance: entranceId });
+
+      const result = await RelevanceService.computeNextRelevance('comment', {
+        entrance: entranceId,
+      });
+
+      should(result).equal(1);
+    });
+
+    /**
+     * Unit test: ignores deleted entities when computing next relevance
+     * **Validates: Requirements 1.3**
+     */
+    it('should return 1 when only deleted entities exist in the scope', async () => {
+      const entranceId = 6002;
+      const createdIds = [];
+
+      try {
+        // Create only deleted comments
+        const created = await Promise.all(
+          [3, 7, 10].map((rel) =>
+            TComment.create({
+              author: 1,
+              dateInscription: new Date().toISOString(),
+              relevance: rel,
+              title: 'Deleted only test',
+              body: 'Should be ignored',
+              entrance: entranceId,
+              language: 'fra',
+              isDeleted: true,
+            }).fetch()
+          )
+        );
+        created.forEach((c) => createdIds.push(c.id));
+
+        const result = await RelevanceService.computeNextRelevance('comment', {
+          entrance: entranceId,
+        });
+
+        should(result).equal(1);
+      } finally {
+        if (createdIds.length > 0) {
+          await TComment.destroy({ id: createdIds });
+        }
+      }
+    });
+  });
+
+  describe('moveRelevance()', () => {
+    /**
+     * Property 2: Move swaps exactly two entities and preserves all others
+     *
+     * For any parent scope containing at least 2 non-deleted entities, and any
+     * valid move direction (+1 or -1) applied to a non-boundary entity, the move
+     * operation should exchange the relevance values of exactly the target entity
+     * and its adjacent neighbor, while all other entities in the scope retain
+     * their original relevance values.
+     *
+     * **Validates: Requirements 2.1, 5.1**
+     */
+    it('should swap exactly two entities and preserve all others', async function pbt3() {
+      this.timeout(120000);
+      const BASE_ENTRANCE_ID = 7000;
+      let scenarioIndex = 0;
+
+      await fc.assert(
+        fc.asyncProperty(
+          fc.uniqueArray(fc.integer({ min: 1, max: 10000 }), {
+            minLength: 2,
+            maxLength: 10,
+          }),
+          fc.constantFrom(1, -1),
+          async (relevanceValues, direction) => {
+            scenarioIndex += 1;
+            const entranceId = BASE_ENTRANCE_ID + scenarioIndex;
+            const createdIds = [];
+
+            try {
+              // Create TComment entities with unique relevance values
+              const created = await Promise.all(
+                relevanceValues.map((rel) =>
+                  TComment.create({
+                    author: 1,
+                    dateInscription: new Date().toISOString(),
+                    relevance: rel,
+                    title: `PBT move ${scenarioIndex}`,
+                    body: 'Property test body',
+                    entrance: entranceId,
+                    language: 'fra',
+                    isDeleted: false,
+                  }).fetch()
+                )
+              );
+              const entities = created.map((c, i) => ({
+                id: c.id,
+                relevance: relevanceValues[i],
+              }));
+              created.forEach((c) => createdIds.push(c.id));
+
+              // Sort entities by relevance to determine ordering
+              entities.sort((a, b) => a.relevance - b.relevance);
+
+              // Pick a non-boundary target index for the chosen direction
+              // direction 1 (down): cannot be last, so index in [0, len-2]
+              // direction -1 (up): cannot be first, so index in [1, len-1]
+              let targetIndex;
+              if (direction === 1) {
+                targetIndex = scenarioIndex % (entities.length - 1); // [0, len-2]
+              } else {
+                targetIndex = 1 + (scenarioIndex % (entities.length - 1)); // [1, len-1]
+              }
+
+              const target = entities[targetIndex];
+              const neighborIndex =
+                direction === 1 ? targetIndex + 1 : targetIndex - 1;
+              const neighbor = entities[neighborIndex];
+
+              // Record all relevance values before the move
+              const beforeMap = {};
+              for (const e of entities) {
+                beforeMap[e.id] = e.relevance;
+              }
+
+              // Act: perform the move
+              const result = await RelevanceService.moveRelevance(
+                'comment',
+                target.id,
+                direction
+              );
+
+              // Fetch all entities after the move
+              const afterEntities = await TComment.find({
+                id: createdIds,
+              });
+              const afterMap = {};
+              for (const e of afterEntities) {
+                afterMap[e.id] = e.relevance;
+              }
+
+              // Assert: target now has neighbor's old relevance
+              should(afterMap[target.id]).equal(
+                beforeMap[neighbor.id],
+                `Target ${target.id} should have neighbor's old relevance`
+              );
+
+              // Assert: neighbor now has target's old relevance
+              should(afterMap[neighbor.id]).equal(
+                beforeMap[target.id],
+                `Neighbor ${neighbor.id} should have target's old relevance`
+              );
+
+              // Assert: all other entities retain their original relevance
+              for (const e of entities) {
+                if (e.id !== target.id && e.id !== neighbor.id) {
+                  should(afterMap[e.id]).equal(
+                    beforeMap[e.id],
+                    `Entity ${e.id} should retain its original relevance`
+                  );
+                }
+              }
+
+              // Assert: result contains the moved and swapped entities
+              should(result).have.property('moved');
+              should(result).have.property('swapped');
+              should(result.moved.id).equal(target.id);
+              should(result.swapped.id).equal(neighbor.id);
+            } finally {
+              if (createdIds.length > 0) {
+                await TComment.destroy({ id: createdIds });
+              }
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Unit test: throws 404 for non-existent entity
+     * **Validates: Requirements 2.2**
+     */
+    it('should throw 404 for a non-existent entity', async () => {
+      try {
+        await RelevanceService.moveRelevance('comment', 999999, 1);
+        should.fail('Expected an error to be thrown');
+      } catch (err) {
+        should(err.status).equal(404);
+        should(err.message).equal('Comment of id 999999 not found.');
+      }
+    });
+
+    /**
+     * Unit test: throws 400 for a deleted entity
+     * **Validates: Requirements 2.3**
+     */
+    it('should throw 400 for a deleted entity', async () => {
+      const entranceId = 6003;
+      let commentId;
+
+      try {
+        const comment = await TComment.create({
+          author: 1,
+          dateInscription: new Date().toISOString(),
+          relevance: 1,
+          title: 'Deleted entity test',
+          body: 'This comment is deleted',
+          entrance: entranceId,
+          language: 'fra',
+          isDeleted: true,
+        }).fetch();
+        commentId = comment.id;
+
+        try {
+          await RelevanceService.moveRelevance('comment', commentId, 1);
+          should.fail('Expected an error to be thrown');
+        } catch (err) {
+          should(err.status).equal(400);
+          should(err.message).equal(`Comment of id ${commentId} is deleted.`);
+        }
+      } finally {
+        if (commentId) {
+          await TComment.destroy({ id: commentId });
+        }
+      }
+    });
+
+    /**
+     * Unit test: throws 400 at boundary (single entity, no neighbor)
+     * **Validates: Requirements 2.4**
+     */
+    it('should throw 400 when entity is at boundary', async () => {
+      const entranceId = 6004;
+      let commentId;
+
+      try {
+        const comment = await TComment.create({
+          author: 1,
+          dateInscription: new Date().toISOString(),
+          relevance: 1,
+          title: 'Boundary test',
+          body: 'Only comment in scope',
+          entrance: entranceId,
+          language: 'fra',
+          isDeleted: false,
+        }).fetch();
+        commentId = comment.id;
+
+        // Try moving up — no neighbor above
+        try {
+          await RelevanceService.moveRelevance('comment', commentId, -1);
+          should.fail('Expected an error to be thrown');
+        } catch (err) {
+          should(err.status).equal(400);
+          should(err.message).equal(
+            `Comment of id ${commentId} cannot be moved further in that direction.`
+          );
+        }
+
+        // Try moving down — no neighbor below
+        try {
+          await RelevanceService.moveRelevance('comment', commentId, 1);
+          should.fail('Expected an error to be thrown');
+        } catch (err) {
+          should(err.status).equal(400);
+          should(err.message).equal(
+            `Comment of id ${commentId} cannot be moved further in that direction.`
+          );
+        }
+      } finally {
+        if (commentId) {
+          await TComment.destroy({ id: commentId });
+        }
+      }
+    });
+
+    /**
+     * Unit test: throws 400 for invalid direction values
+     * **Validates: Requirements 2.4**
+     */
+    it('should throw 400 for invalid direction values', async () => {
+      const invalidDirections = [0, 2, -3];
+
+      await Promise.all(
+        invalidDirections.map(async (dir) => {
+          try {
+            await RelevanceService.moveRelevance('comment', 1, dir);
+            should.fail(`Expected an error for direction ${dir}`);
+          } catch (err) {
+            should(err.status).equal(400);
+            should(err.message).equal('Direction must be 1 or -1.');
+          }
+        })
+      );
+    });
+  });
+});

--- a/test/integration/4_routes/relevance.test.js
+++ b/test/integration/4_routes/relevance.test.js
@@ -1,0 +1,109 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../AuthTokenService');
+
+describe('move-relevance routes', () => {
+  let userToken;
+  before(async () => {
+    userToken = await AuthTokenService.getRawBearerUserToken();
+  });
+
+  describe('authentication', () => {
+    it('should return 401 without auth token', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/comments/1/move-relevance')
+        .send({ direction: 1 })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+  });
+
+  describe('PATCH /api/v1/comments/:id/move-relevance', () => {
+    // Create two comments with distinct relevance on entrance 999
+    // so we can test a valid swap without interfering with other fixtures.
+    let commentA;
+    let commentB;
+
+    before(async () => {
+      commentA = await TComment.create({
+        author: 2,
+        title: 'Relevance test A',
+        body: 'body A',
+        entrance: 999,
+        language: 'eng',
+        relevance: 1,
+        dateInscription: new Date(),
+      }).fetch();
+
+      commentB = await TComment.create({
+        author: 2,
+        title: 'Relevance test B',
+        body: 'body B',
+        entrance: 999,
+        language: 'eng',
+        relevance: 2,
+        dateInscription: new Date(),
+      }).fetch();
+    });
+
+    after(async () => {
+      if (commentA) await TComment.destroyOne({ id: commentA.id });
+      if (commentB) await TComment.destroyOne({ id: commentB.id });
+    });
+
+    it('should return 200 and swap relevance values', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch(`/api/v1/comments/${commentA.id}/move-relevance`)
+        .send({ direction: 1 })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body).have.property('moved');
+          should(res.body).have.property('swapped');
+          should(res.body.moved.relevance).equal(2);
+          should(res.body.swapped.relevance).equal(1);
+          return done();
+        });
+    });
+  });
+
+  describe('invalid direction', () => {
+    it('should return 400 for direction 0', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/comments/1/move-relevance')
+        .send({ direction: 0 })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400, done);
+    });
+  });
+
+  describe('routes exist for all entity types', () => {
+    // Sending an invalid direction to each route: if the route exists
+    // we get 400 (bad request), not 404 (not found).
+    const entityRoutes = [
+      '/api/v1/locations/1/move-relevance',
+      '/api/v1/descriptions/1/move-relevance',
+      '/api/v1/comments/1/move-relevance',
+      '/api/v1/riggings/3/move-relevance',
+      '/api/v1/histories/1/move-relevance',
+    ];
+
+    entityRoutes.forEach((route) => {
+      it(`should respond with 400 (not 404) for ${route}`, (done) => {
+        supertest(sails.hooks.http.app)
+          .patch(route)
+          .send({ direction: 0 })
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400, done);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #574

## 🤔 What

- Auto-assign relevance on creation of Location, Description, Comment, Rigging, and History entities (`MAX(relevance) + 1` within the parent scope, or `1` if empty)
- New `PATCH /api/v1/<entityType>/:id/move-relevance` endpoints for all five entity types, allowing users to swap an entity's position up (`-1`) or down (`+1`) with its adjacent neighbor
- SQL migration script to normalize existing relevance values to sequential positive integers (1, 2, 3, ...) per scope, fixing duplicates, negatives, and gaps in the current data
- Swagger documentation for all five new endpoints

## 🤷‍♂️ Why

The `relevance` attribute on Location, Description, Comment, Rigging, and History controls display ordering, but it was never managed by the API:
- On creation, relevance was left unset (there were `// TODO compute relevance` placeholders in the create controllers)
- There was no way for users to reorder entities
- Existing data had duplicate relevance values within the same scope, negative values, and gaps — making any future ordering logic unreliable

This change makes relevance a fully managed, consistent attribute so the front-end can implement drag-and-drop or up/down reordering.

## 🔍 How

- A shared `RelevanceService` (`api/services/RelevanceService.js`) handles all logic for the five entity types via an `ENTITY_CONFIG` map, avoiding code duplication:
  - `computeNextRelevance(entityType, parentFieldValues)` — queries `MAX(relevance)` within the scoped parent
  - `moveRelevance(entityType, entityId, direction)` — finds the adjacent neighbor and swaps their relevance values
  - `getParentScope(entityType, entity)` — determines the parent scope by inspecting which parent field is set on the entity
- The five existing create controllers (`location/create.js`, `description/create.js`, `comment/create.js`, `rigging/create.js`, `history/create.js`) now call `computeNextRelevance` before creating the entity
- Five new `move-relevance.js` controllers are thin wrappers that call `moveRelevance` and map service errors to HTTP responses (404, 400)
- Routes added in `config/routes.js`, protected by `tokenAuth` in `config/policies.js`
- Historisation entries (H-tables) are handled automatically by the existing PostgreSQL triggers — no application code needed
- `sql/6_04_2026_02_13_normalize-relevance.sql` uses `ROW_NUMBER() OVER (PARTITION BY <parent_fields> ORDER BY relevance, id)` CTEs to renumber each scope sequentially, and sets deleted entities' relevance to 0. The script is idempotent and wrapped in a transaction.

## 🧪 Testing

- Property-based tests (fast-check, 100 iterations each):
  - Property 1: Creation assigns `max + 1` (or 1 for empty scope)
  - Property 2: Move swaps exactly two entities and preserves all others
- Service-level unit tests: empty scope, deleted entities, 404/400 error cases
- Route-level integration tests: 401 without auth, 200 valid swap, 400 invalid direction, routes exist for all five types
- Run `npm run test` to execute all tests
- To test the migration: `docker cp sql/6_04_2026_02_13_normalize-relevance.sql grotto-postgres:/tmp/normalize-relevance.sql && docker exec grotto-postgres psql -U root -d grottoce -f /tmp/normalize-relevance.sql`
- To test the endpoints manually (requires a running dev server):
  1. Get a token: `curl -X POST http://localhost:1337/api/v1/login -H "Content-Type: application/json" -d '{"email":"admin@admin.com","password":"admin@admin.com"}'`
  2. Move a rigging down: `curl -X PATCH http://localhost:1337/api/v1/riggings/17/move-relevance -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -d '{"direction":1}'`

## 📸 Previews

No UI changes — this is a backend-only feature. The endpoints return JSON:

```json
{
  "moved": { "id": 17, "relevance": 2, "title": "Accès par l'ancienne entrée", "..." },
  "swapped": { "id": 18, "relevance": 1, "title": "Des Meulières aux galeries...", "..." }
}
```

Error responses:
```json
{"message": "Rigging of id 17 cannot be moved further in that direction."}  // 400
{"message": "Location of id 99999 not found."}                              // 404
{"message": "Direction must be 1 or -1."}                                   // 400
```
