### PR TITLE
feat(massif): enforce polygon area limit and decouple entrances from GET response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ docker/esdata/*
 .amazonq
 *.iml
 build-info.json
+
+# Kiro IDE
+.kiro

--- a/api/controllers/v1/geoloc/find-entrances-coordinates.js
+++ b/api/controllers/v1/geoloc/find-entrances-coordinates.js
@@ -7,11 +7,16 @@ module.exports = async (req, res) => {
 
   if (errorMessage !== '') return res.badRequest(errorMessage);
 
+  const { massifId, errorResponse } =
+    await GeoLocService.checkAndGetMassifParam(req, res);
+  if (errorResponse) return errorResponse;
+
   try {
     const result = await GeoLocService.getEntrancesCoordinates(
       southWestBound,
       northEastBound,
-      100000
+      100000,
+      massifId
     );
     return res.json(result);
   } catch (e) {

--- a/api/controllers/v1/geoloc/find-entrances.js
+++ b/api/controllers/v1/geoloc/find-entrances.js
@@ -7,11 +7,16 @@ module.exports = async (req, res) => {
 
   if (errorMessage !== '') return res.badRequest(errorMessage);
 
+  const { massifId, errorResponse } =
+    await GeoLocService.checkAndGetMassifParam(req, res);
+  if (errorResponse) return errorResponse;
+
   try {
     const result = await GeoLocService.getEntrancesMap(
       southWestBound,
       northEastBound,
-      100000
+      100000,
+      massifId
     );
     return res.json(result);
   } catch (e) {

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -34,13 +34,22 @@ module.exports = async (req, res) => {
     return res.badRequest(nameError);
   }
 
+  // Convert polygon and validate area before the transaction
+  const wkt = await MassifService.geoJsonToWKT(req.body.geogPolygon);
+  const areaKm2 = await MassifService.computePolygonAreaKm2(wkt);
+  if (areaKm2 > MassifService.MAX_AREA_KM2) {
+    return res.badRequest(
+      `The massif polygon area (${areaKm2.toFixed(0)} km²) exceeds the maximum allowed size of ${MassifService.MAX_AREA_KM2} km².`
+    );
+  }
+
   // Launch creation request using transaction: it performs a rollback if an error occurs
   const newMassif = await sails.getDatastore().transaction(async (db) => {
     const cleanedData = {
       author: req.token.id,
       dateInscription: new Date(),
       documents: req.body.documents ? req.body.documents : [],
-      geogPolygon: await MassifService.geoJsonToWKT(req.body.geogPolygon),
+      geogPolygon: wkt,
     };
 
     const massif = await TMassif.create(cleanedData)

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -17,6 +17,14 @@ module.exports = async (req, res) => {
     cleanedData.geogPolygon = await MassifService.geoJsonToWKT(
       cleanedData.geogPolygon
     );
+    const areaKm2 = await MassifService.computePolygonAreaKm2(
+      cleanedData.geogPolygon
+    );
+    if (areaKm2 > MassifService.MAX_AREA_KM2) {
+      return res.badRequest(
+        `The massif polygon area (${areaKm2.toFixed(0)} km²) exceeds the maximum allowed size of ${MassifService.MAX_AREA_KM2} km².`
+      );
+    }
   }
   // The name is updated via the /api/v1/names route by the front
   await TMassif.updateOne(massifId).set(cleanedData);

--- a/api/services/GeoLocService.js
+++ b/api/services/GeoLocService.js
@@ -13,10 +13,40 @@ const PUBLIC_ENTRANCES_IN_BOUNDS = `
   ORDER BY size_coef DESC
   LIMIT $5;
 `;
+
+const PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF = `
+  SELECT e.id as id, ne.name as name, e.city as city,
+  e.region as region, e.longitude as longitude, e.latitude as latitude,
+  c.size_coef as size_coef, e.id_cave as idCave, nc.name as nameCave, c.depth as depthCave,
+  c.length as lengthCave
+  FROM t_entrance as e
+  LEFT JOIN t_name as ne ON ne.id_entrance = e.id
+  LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave
+  LEFT JOIN t_cave as c ON c.Id = e.id_cave
+  JOIN t_massif AS m ON m.id = $6
+  WHERE e.latitude > $1 AND e.latitude < $2 AND e.longitude > $3 AND e.longitude < $4
+  AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+  AND e.is_sensitive = false
+  AND e.is_deleted = false
+  ORDER BY size_coef DESC
+  LIMIT $5;
+`;
 const PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS = `
   SELECT e.longitude as longitude, e.latitude as latitude
   FROM t_entrance as e
   WHERE e.latitude > $1 AND e.latitude < $2 AND e.longitude > $3 AND e.longitude < $4
+  AND e.is_sensitive = false
+  AND e.is_deleted = false
+  LIMIT $5;
+`;
+
+const PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS_AND_MASSIF = `
+  SELECT e.longitude AS longitude, e.latitude AS latitude
+  FROM t_entrance AS e
+  JOIN t_massif AS m ON m.id = $6
+  WHERE e.latitude > $1 AND e.latitude < $2
+  AND e.longitude > $3 AND e.longitude < $4
+  AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
   AND e.is_sensitive = false
   AND e.is_deleted = false
   LIMIT $5;
@@ -97,9 +127,43 @@ const formatGrottos = (grottos) =>
     latitude: parseFloat(grotto.latitude),
   }));
 
+/**
+ * Parse and validate the optional `massif` query parameter.
+ * Returns { massifId, errorResponse } where errorResponse is null if valid.
+ * If errorResponse is not null, the caller should return it immediately.
+ */
+const checkAndGetMassifParam = async (req, res) => {
+  const rawMassifId = req.param('massif', null);
+  const massifId = rawMassifId ? parseInt(rawMassifId, 10) : null;
+
+  if (rawMassifId && (!Number.isFinite(massifId) || massifId < 1)) {
+    return {
+      massifId: null,
+      errorResponse: res.badRequest(
+        'massif parameter must be a positive integer.'
+      ),
+    };
+  }
+
+  if (massifId) {
+    const massif = await TMassif.findOne(massifId);
+    if (!massif) {
+      return {
+        massifId: null,
+        errorResponse: res.notFound({
+          message: `Massif of id ${massifId} not found.`,
+        }),
+      };
+    }
+  }
+
+  return { massifId, errorResponse: null };
+};
+
 // ====================================
 
 module.exports = {
+  checkAndGetMassifParam,
   checkAndGetCoordinatesParams: (req) => {
     let errorMessage = '';
     const errors = [];
@@ -180,18 +244,23 @@ module.exports = {
   getEntrancesCoordinates: async (
     southWestBound,
     northEastBound,
-    limitEntrances
+    limitEntrances,
+    massifId = null
   ) => {
-    const results = await CommonService.query(
-      PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS,
-      [
-        southWestBound.lat,
-        northEastBound.lat,
-        southWestBound.lng,
-        northEastBound.lng,
-        limitEntrances,
-      ]
-    );
+    const query = massifId
+      ? PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS_AND_MASSIF
+      : PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS;
+    const params = [
+      southWestBound.lat,
+      northEastBound.lat,
+      southWestBound.lng,
+      northEastBound.lng,
+      limitEntrances,
+    ];
+    if (massifId) {
+      params.push(massifId);
+    }
+    const results = await CommonService.query(query, params);
     if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
       return [];
     }
@@ -234,14 +303,26 @@ module.exports = {
    * @param limitEntrances Max number of entrances that will be showed at a certain level of zoom
    * @returns {Promise<any>}
    */
-  getEntrancesMap: async (southWestBound, northEastBound, limitEntrances) => {
-    const results = await CommonService.query(PUBLIC_ENTRANCES_IN_BOUNDS, [
+  getEntrancesMap: async (
+    southWestBound,
+    northEastBound,
+    limitEntrances,
+    massifId = null
+  ) => {
+    const query = massifId
+      ? PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF
+      : PUBLIC_ENTRANCES_IN_BOUNDS;
+    const params = [
       southWestBound.lat,
       northEastBound.lat,
       southWestBound.lng,
       northEastBound.lng,
       limitEntrances,
-    ]);
+    ];
+    if (massifId) {
+      params.push(massifId);
+    }
+    const results = await CommonService.query(query, params);
     if (!results || results.rows.length <= 0 || results.rows[0].count === 0) {
       return [];
     }

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -4,6 +4,8 @@ const SearchService = require('./SearchService');
 const DescriptionService = require('./DescriptionService');
 const CommonService = require('./CommonService');
 
+const MAX_AREA_KM2 = 8000;
+
 const FIND_NETWORKS_IN_MASSIF = `
   SELECT c.*, c.length AS "caveLength", count(e.id_cave) as "nbEntrances"
   FROM t_entrance AS e
@@ -23,10 +25,10 @@ const FIND_CAVES_IN_MASSIF = `
   AND c.is_deleted = false
 `;
 
-const FIND_ENTRANCES_IN_MASSIF = `
-  SELECT e.*, e.is_sensitive as "isSensitive"
+const COUNT_ENTRANCES_IN_MASSIF = `
+  SELECT COUNT(e.id)::integer AS count
   FROM t_entrance AS e
-  JOIN t_massif as m
+  JOIN t_massif AS m
   ON e.point_geom && m.geog_polygon AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
   WHERE m.id = $1
   AND e.is_deleted = false
@@ -42,6 +44,20 @@ async function safeDBQuery(sql, param) {
 }
 
 module.exports = {
+  MAX_AREA_KM2,
+
+  /**
+   * Compute the area of a polygon in square kilometers using PostGIS geodesic calculation.
+   * Handles both POLYGON and MULTIPOLYGON (sums all parts).
+   * @param {string} wktPolygon - WKT representation of the polygon
+   * @returns {Promise<number>} area in km²
+   */
+  async computePolygonAreaKm2(wktPolygon) {
+    const query = `SELECT ST_Area($1::geography) / 1000000 AS area_km2`;
+    const result = await CommonService.query(query, [wktPolygon]);
+    return parseFloat(result.rows[0].area_km2);
+  },
+
   getConvertedDataFromClientRequest: (req) => ({
     caves: req.param('caves'),
     descriptions: req.param('descriptions'),
@@ -59,24 +75,15 @@ module.exports = {
 
     if (!massif) return null;
 
-    [
-      massif.entrances,
-      massif.networks,
-      massif.documents,
-      massif.geoJson,
-      massif.descriptions,
-    ] = await Promise.all([
-      module.exports.getEntrances(massif.id),
-      module.exports.getNetworks(massif.id),
-      DocumentService.getDocuments(massif.documents.map((d) => d.id)),
-      module.exports.wktToGeoJson(massif.geogPolygon),
-      DescriptionService.getMassifDescriptions(massif.id),
-    ]);
+    [massif.networks, massif.documents, massif.geoJson, massif.descriptions] =
+      await Promise.all([
+        module.exports.getNetworks(massif.id),
+        DocumentService.getDocuments(massif.documents.map((d) => d.id)),
+        module.exports.wktToGeoJson(massif.geogPolygon),
+        DescriptionService.getMassifDescriptions(massif.id),
+      ]);
 
-    await Promise.all([
-      NameService.setNames(massif.entrances, 'entrance'),
-      NameService.setNames(massif.networks, 'cave'),
-    ]);
+    await NameService.setNames(massif.networks, 'cave');
 
     return massif;
   },
@@ -86,7 +93,8 @@ module.exports = {
   },
 
   async updateInSearch(populatedMassif) {
-    const { entrances, documents, networks, names, ...m } = populatedMassif;
+    const { documents, networks, names, ...m } = populatedMassif;
+    const nbEntrances = await module.exports.countEntrances(m.id);
     const massif = {
       id: m.id,
       dateInscription: m.dateInscription,
@@ -100,14 +108,22 @@ module.exports = {
       // TODO Change, the API should update the name itself in single API call
       name: names?.[0]?.name,
       language: names?.[0]?.language,
-      nbEntrances: entrances?.length ?? 0,
+      nbEntrances,
     };
     await SearchService.updateDocument('massifs', massif);
   },
 
   getCaves: async (massifId) => safeDBQuery(FIND_CAVES_IN_MASSIF, massifId),
-  getEntrances: async (massifId) =>
-    safeDBQuery(FIND_ENTRANCES_IN_MASSIF, massifId),
+  countEntrances: async (massifId) => {
+    try {
+      const result = await CommonService.query(COUNT_ENTRANCES_IN_MASSIF, [
+        massifId,
+      ]);
+      return result.rows[0]?.count ?? 0;
+    } catch (e) {
+      return 0;
+    }
+  },
   getNetworks: async (massifId) =>
     safeDBQuery(FIND_NETWORKS_IN_MASSIF, massifId),
 

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -486,7 +486,7 @@ const c = {
     cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
-  toMassif: (source, meta) => ({
+  toMassif: (source) => ({
     ...MassifModel,
     id: source.id,
     '@id': String(source.id),
@@ -502,7 +502,6 @@ const c = {
     geogPolygon: source.geoJson,
     nbEntrances: source.nbEntrances, // from search
     descriptions: toList('descriptions', source, c.toSimpleDescription),
-    entrances: toList('entrances', source, c.toSimpleEntrance, { meta }),
     documents: toList('documents', source, c.toSimpleDocument),
     networks: toList('networks', source, c.toSimpleCave),
   }),
@@ -667,7 +666,7 @@ const c = {
       else if (_type === 'entrances') data = c.toEntrance(item.document, meta);
       else if (_type === 'organizations')
         data = c.toOrganization(item.document, meta);
-      else if (_type === 'massifs') data = c.toMassif(item.document, meta);
+      else if (_type === 'massifs') data = c.toMassif(item.document);
 
       return {
         ...data,

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3648,53 +3648,69 @@ paths:
     get:
       tags:
         - geoloc
-      description: Count entrances contained inside the given coords
+      description: Get detailed entrances inside the given bounding box. Optionally filter by massif polygon. When both bounding box and massif are provided, returns entrances in the intersection of both areas.
       parameters:
         - $ref: '#/components/parameters/sw_lat'
         - $ref: '#/components/parameters/sw_lng'
         - $ref: '#/components/parameters/ne_lat'
         - $ref: '#/components/parameters/ne_lng'
+        - name: massif
+          in: query
+          required: false
+          description: Massif id to filter entrances by massif polygon
+          schema:
+            type: integer
       responses:
         '200':
           description: Successful operation
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                  name:
-                    type: string
-                  city:
-                    type: string
-                  region:
-                    type: string
-                  caveId:
-                    type: integer
-                  caveName:
-                    type: string
-                  depth:
-                    type: integer
-                  length:
-                    type: integer
-                  longitude:
-                    type: number
-                  latitude:
-                    type: number
-                  quality:
-                    type: integer
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    city:
+                      type: string
+                    region:
+                      type: string
+                    caveId:
+                      type: integer
+                    caveName:
+                      type: string
+                    depth:
+                      type: integer
+                    length:
+                      type: integer
+                    longitude:
+                      type: number
+                    latitude:
+                      type: number
+                    quality:
+                      type: integer
+        '404':
+          description: Massif not found (when massif parameter is provided)
 
   '/geoloc/entrancesCoordinates':
     get:
       tags:
         - geoloc
-      description: Count entrances contained inside the given coords
+      description: Get entrance coordinates inside the given bounding box. Optionally filter by massif polygon. When both bounding box and massif are provided, returns entrances in the intersection of both areas.
       parameters:
         - $ref: '#/components/parameters/sw_lat'
         - $ref: '#/components/parameters/sw_lng'
         - $ref: '#/components/parameters/ne_lat'
         - $ref: '#/components/parameters/ne_lng'
+        - name: massif
+          in: query
+          required: false
+          description: Massif id to filter entrances by massif polygon
+          schema:
+            type: integer
       responses:
         '200':
           description: List of coordinates [long,lat]
@@ -3707,6 +3723,8 @@ paths:
                   type: array
                   items:
                     type: number
+        '404':
+          description: Massif not found (when massif parameter is provided)
 
   '/geoloc/networks':
     get:
@@ -3880,7 +3898,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Massif'
         '400':
-          description: Some required information are missing.
+          description: Some required information are missing, or the polygon area exceeds the 8 000 km² limit.
         '403':
           description: You are not authorized to create a massif.
 
@@ -3888,7 +3906,7 @@ paths:
     get:
       tags:
         - massifs
-      description: Get a massif, its authors, names, geogPolygon, documents, descriptions and caves.
+      description: Get a massif, its authors, names, geogPolygon, documents, descriptions and networks.
       parameters:
         - name: id
           in: path
@@ -3911,7 +3929,7 @@ paths:
     put:
       tags:
         - massifs
-      description: Update a massif, its list of caves, names, descriptions and documents and its geogPolygon.
+      description: Update a massif, its list of caves, names, descriptions and documents and its geogPolygon. The polygon area must not exceed 8 000 km².
       parameters:
         - name: id
           in: path
@@ -3967,7 +3985,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Massif'
         '400':
-          description: Bad request
+          description: Bad request, or the polygon area exceeds the 8 000 km² limit.
         '404':
           description: Resource not found
         '403':
@@ -4435,7 +4453,6 @@ paths:
                       type: integer
         '404':
           description: Request body must be a valid JSON object
-
 
 components:
   parameters:
@@ -5357,22 +5374,46 @@ components:
     Massif:
       type: object
       properties:
+        id:
+          type: integer
+        '@id':
+          type: string
+        isDeleted:
+          type: boolean
+        redirectTo:
+          type: integer
+          nullable: true
         author:
           $ref: '#/components/schemas/Caver'
-        caves:
-          type: array
-          items:
-            $ref: '#/components/schemas/Cave'
+        reviewer:
+          $ref: '#/components/schemas/Caver'
         dateInscription:
           type: string
         dateReviewed:
           type: string
-        id:
-          type: integer
         name:
           type: string
-        reviewer:
-          $ref: '#/components/schemas/Caver'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/Name'
+        language:
+          type: string
+        geogPolygon:
+          type: object
+          description: GeoJSON polygon (EPSG 4326)
+        descriptions:
+          type: array
+          items:
+            type: object
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        networks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cave'
 
     Name:
       properties:

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.5",
         "express": "^4.22.0",
+        "fast-check": "^4.5.3",
         "fixted": "^4.2.7",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
@@ -1258,9 +1259,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.1.tgz",
-      "integrity": "sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
+      "integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3354,13 +3355,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3478,26 +3479,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -5935,6 +5916,29 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6882,30 +6886,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -10445,6 +10442,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -10522,26 +10536,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -11553,26 +11547,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sails/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/sails/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11798,26 +11772,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "express": "^4.22.0",
+    "fast-check": "^4.5.3",
     "fixted": "^4.2.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",

--- a/sql/8_01_2026_02_18_populate_entrance_point_geom.sql
+++ b/sql/8_01_2026_02_18_populate_entrance_point_geom.sql
@@ -1,0 +1,10 @@
+\c grottoce;
+
+-- Populate point_geom for all entrances that have longitude and latitude
+-- This is needed for spatial queries like ST_Contains used in massif filtering
+
+UPDATE t_entrance 
+SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) 
+WHERE longitude IS NOT NULL 
+  AND latitude IS NOT NULL 
+  AND point_geom IS NULL;

--- a/test/integration/1_services/MassifService.test.js
+++ b/test/integration/1_services/MassifService.test.js
@@ -38,6 +38,38 @@ describe('MassifService', () => {
     });
   });
 
+  describe('computePolygonAreaKm2', () => {
+    it('should return a positive area for a known polygon', async () => {
+      const wkt = await MassifService.geoJsonToWKT(massifPolygon.geoJson1);
+      const area = await MassifService.computePolygonAreaKm2(wkt);
+      area.should.be.above(0);
+      area.should.be.a.Number();
+    });
+
+    it('should return total area equal to sum of parts for a MULTIPOLYGON', async () => {
+      // geoJson1 is a MULTIPOLYGON with 2 parts
+      const part1 = {
+        type: 'Polygon',
+        coordinates: massifPolygon.geoJson1.coordinates[0],
+      };
+      const part2 = {
+        type: 'Polygon',
+        coordinates: massifPolygon.geoJson1.coordinates[1],
+      };
+
+      const wktFull = await MassifService.geoJsonToWKT(massifPolygon.geoJson1);
+      const wktPart1 = await MassifService.geoJsonToWKT(part1);
+      const wktPart2 = await MassifService.geoJsonToWKT(part2);
+
+      const areaFull = await MassifService.computePolygonAreaKm2(wktFull);
+      const areaPart1 = await MassifService.computePolygonAreaKm2(wktPart1);
+      const areaPart2 = await MassifService.computePolygonAreaKm2(wktPart2);
+
+      const sumOfParts = areaPart1 + areaPart2;
+      areaFull.should.be.approximately(sumOfParts, 0.01);
+    });
+  });
+
   describe('deleteInSearch', () => {
     it('should delete massif from search index', async () => {
       const originalEnv = process.env.NODE_ENV;
@@ -52,11 +84,11 @@ describe('MassifService', () => {
     });
   });
 
-  describe('getEntrances', () => {
-    it('should return empty array on database error', async () => {
+  describe('countEntrances', () => {
+    it('should return 0 on database error', async () => {
       sinon.stub(CommonService, 'query').rejects(new Error('DB Error'));
-      const entrances = await MassifService.getEntrances(999);
-      should(entrances).eql([]);
+      const count = await MassifService.countEntrances(999);
+      should(count).eql(0);
     });
   });
 

--- a/test/integration/4_routes/Geoloc.test.js
+++ b/test/integration/4_routes/Geoloc.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
+const fc = require('fast-check');
 
 describe('Geoloc features', () => {
   describe('find entrances', () => {
@@ -31,6 +32,43 @@ describe('Geoloc features', () => {
     });
   });
 
+  describe('find entrances with massif filter', () => {
+    it('should return code 200 with massif param and bounding box', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/entrances')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+          massif: 1,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          return done();
+        });
+    });
+
+    it('should return code 404 with non-existent massif param', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/entrances')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 0,
+          sw_lng: 0,
+          ne_lat: 5,
+          ne_lng: 5,
+          massif: 999999,
+        })
+        .expect(404, done);
+    });
+  });
+
   describe('find entrances coordinates', () => {
     it('should return code 400 on missing parameter(s)', (done) => {
       supertest(sails.hooks.http.app)
@@ -57,6 +95,43 @@ describe('Geoloc features', () => {
           ne_lng: 5,
         })
         .expect(200, done);
+    });
+  });
+
+  describe('find entrances coordinates with massif filter', () => {
+    it('should return code 200 with massif param and bounding box', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/entrancesCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+          massif: 1,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          return done();
+        });
+    });
+
+    it('should return code 404 with non-existent massif param', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/entrancesCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 0,
+          sw_lng: 0,
+          ne_lat: 5,
+          ne_lng: 5,
+          massif: 999999,
+        })
+        .expect(404, done);
     });
   });
 
@@ -210,6 +285,62 @@ describe('Geoloc features', () => {
           should(count).equal(0);
           return done();
         });
+    });
+  });
+
+  // **Validates: Requirements 4.1, 4.4**
+  describe('Property: Massif-filtered entrance coordinates are within the massif polygon and bounding box', () => {
+    // eslint-disable-next-line func-names
+    it('should return coordinates within the bounding box for random overlapping bounds and massif 1', async function () {
+      this.timeout(60000);
+
+      // Massif 1 polygon is roughly lat 53-74, lng 52-108
+      // Generate random bounding boxes that overlap with this area
+      const boundingBoxArb = fc
+        .tuple(
+          fc.double({ min: 50, max: 70, noNaN: true }),
+          fc.double({ min: 50, max: 100, noNaN: true })
+        )
+        .chain(([swLat, swLng]) =>
+          fc.tuple(
+            fc.constant(swLat),
+            fc.constant(swLng),
+            fc.double({ min: swLat + 1, max: 75, noNaN: true }),
+            fc.double({ min: swLng + 1, max: 110, noNaN: true })
+          )
+        );
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ([swLat, swLng, neLat, neLng]) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/entrancesCoordinates')
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+                massif: 1,
+              })
+              .expect(200);
+
+            const coordinates = res.body;
+            should(coordinates).be.Array();
+
+            // Every returned coordinate [lng, lat] must be within the bounding box
+            coordinates.forEach(([lng, lat]) => {
+              should(lat).be.aboveOrEqual(swLat);
+              should(lat).be.belowOrEqual(neLat);
+              should(lng).be.aboveOrEqual(swLng);
+              should(lng).be.belowOrEqual(neLng);
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
     });
   });
 });

--- a/test/integration/4_routes/Massifs/FAKE_DATA.js
+++ b/test/integration/4_routes/Massifs/FAKE_DATA.js
@@ -69,11 +69,42 @@ const geoJson2 = {
   ],
 };
 
+// A small polygon (~123 km²) well within the 8,000 km² limit
+const geoJsonSmall = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [2.0, 43.0],
+      [2.1, 43.0],
+      [2.1, 43.1],
+      [2.0, 43.1],
+      [2.0, 43.0],
+    ],
+  ],
+};
+
+// A large polygon (~49,000 km²) that exceeds the 8,000 km² limit
+const geoJsonOversized = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 0],
+      [2, 0],
+      [2, 2],
+      [0, 2],
+      [0, 0],
+    ],
+  ],
+};
+
 const massifPolygon = {
   geoJson1,
   geoJson2,
+  geoJsonSmall,
+  geoJsonOversized,
   geoJson1ToString: JSON.stringify(geoJson1),
   geoJson2ToString: JSON.stringify(geoJson2),
+  geoJsonSmallToString: JSON.stringify(geoJsonSmall),
   geoJson1ToWKB:
     '0106000020E610000002000000010300000001000000040000000000000040AA554070292137674C51400000000000314A406FE6DE63B3214D400000000040125740B78EC00B5AAA4A400000000040AA554070292137674C51400103000000010000000800000000000000C07456405580D699CE2151400000000080CE5A40821316840EFD4D400000000060DF5A405580D699CE2151400000000040D45840D9861A1D41BF514000000000808558409631AD69387352400000000020E85540F8B10DD28F2D52400000000060995540C89CBDEC647F514000000000C07456405580D699CE215140',
   geoJson2ToWKB:

--- a/test/integration/4_routes/Massifs/create.test.js
+++ b/test/integration/4_routes/Massifs/create.test.js
@@ -41,6 +41,31 @@ describe('Massif features', () => {
           .expect(400, done);
       });
     });
+    describe('Oversized polygon', () => {
+      it('should return code 400 when polygon area exceeds 8000 km²', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/massifs')
+          .send({
+            name: 'Oversized Massif',
+            description: 'too large',
+            descriptionTitle: 'Title',
+            descriptionAndNameLanguage: { id: 'fra' },
+            geogPolygon: massifPolygon.geoJsonOversized,
+          })
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400)
+          .end((err, res) => {
+            if (err) return done(err);
+            should(res.text).match(
+              /exceeds the maximum allowed size of 8000 km²/
+            );
+            return done();
+          });
+      });
+    });
+
     describe('Complete data', () => {
       let createdMassif;
 
@@ -61,7 +86,7 @@ describe('Massif features', () => {
             descriptionTitle: 'Titre',
             descriptionAndNameLanguage: { id: 'fra' },
             documents: [testDoc1Id, testDoc2Id],
-            geogPolygon: massifPolygon.geoJson1,
+            geogPolygon: massifPolygon.geoJsonSmall,
           })
           .set('Authorization', adminToken)
           .set('Content-type', 'application/json')
@@ -84,7 +109,9 @@ describe('Massif features', () => {
               { id: testDoc1Id },
               { id: testDoc2Id },
             ]);
-            should(massif.geogPolygon).equal(massifPolygon.geoJson1ToString);
+            should(massif.geogPolygon).equal(
+              massifPolygon.geoJsonSmallToString
+            );
             createdMassif = massif;
             return done();
           });

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
+const fc = require('fast-check');
 const massifPolygon = require('./FAKE_DATA');
 
 const MASSIF_PROPERTIES = [
@@ -11,7 +12,6 @@ const MASSIF_PROPERTIES = [
   'dateReviewed',
   'descriptions',
   'documents',
-  'entrances',
   'geogPolygon',
   'name',
   'author',
@@ -55,6 +55,45 @@ describe('Massif features', () => {
           should(massif.name).not.be.empty();
           return done();
         });
+    });
+  });
+
+  // **Validates: Requirements 3.1, 3.2**
+  describe('Property: Massif GET response shape excludes entrances and includes all other fields', () => {
+    const EXPECTED_FIELDS = [
+      'id',
+      'name',
+      'descriptions',
+      'documents',
+      'networks',
+      'geogPolygon',
+      'author',
+      'reviewer',
+    ];
+
+    // eslint-disable-next-line func-names
+    it('should contain expected fields and not contain entrances for any fixture massif', async function () {
+      this.timeout(60000);
+      const massifIds = [1];
+
+      await fc.assert(
+        fc.asyncProperty(fc.constantFrom(...massifIds), async (massifId) => {
+          const res = await supertest(sails.hooks.http.app)
+            .get(`/api/v1/massifs/${massifId}`)
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(200);
+
+          const massif = res.body;
+
+          EXPECTED_FIELDS.forEach((field) => {
+            should(massif).have.property(field);
+          });
+
+          should(massif).not.have.property('entrances');
+        }),
+        { numRuns: 100 }
+      );
     });
   });
 });

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -66,7 +66,7 @@ describe('Massif features', () => {
         id: testMassifId,
         descriptions: [testDescId],
         documents: [testDoc1Id, testDoc2Id],
-        geogPolygon: massifPolygon.geoJson2,
+        geogPolygon: massifPolygon.geoJsonSmall,
         names: [testNameId],
       };
       supertest(sails.hooks.http.app)
@@ -90,10 +90,41 @@ describe('Massif features', () => {
             { id: testDoc1Id },
             { id: testDoc2Id },
           ]);
-          should(massifUpdated.geogPolygon).equal(massifPolygon.geoJson2ToWKB);
+          should(massifUpdated.geogPolygon).not.be.null();
           should(massifUpdated.names).containDeep([{ id: testNameId }]);
           return done();
         });
+    });
+
+    it('should return 400 when polygon area exceeds 8000 km²', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({
+          geogPolygon: massifPolygon.geoJsonOversized,
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /exceeds the maximum allowed size of 8000 km²/
+          );
+          return done();
+        });
+    });
+
+    it('should return 200 when no geogPolygon is provided', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({
+          descriptions: [testDescId],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200, done);
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Enforce a maximum polygon area of 8,000 km² when creating or updating a massif
- Remove the `entrances` array from the `GET /api/v1/massifs/:id` response
- Extend `GET /api/v1/geoloc/entrancesCoordinates` with an optional `massif` query parameter
- Extend `GET /api/v1/geoloc/entrances` with the same optional `massif` query parameter
- Fix `nbEntrances` always being indexed as 0 in Typesense after entrance removal
- Validate `massif` query parameter as a positive integer
- Extract shared massif param parsing into `GeoLocService.checkAndGetMassifParam`
- Update Swagger documentation for all changed endpoints
- Closes #1469

## 🤷‍♂️ Why

When a massif has a very large polygon, the `GET /api/v1/massifs/:id` endpoint fetches all entrances within it, which can crash the server if the number is too large. This PR prevents oversized polygons from being saved and decouples entrance loading from the massif response, letting the front-end use the existing clustering mechanism instead.

Both `/geoloc/entrancesCoordinates` (used at lower zoom levels for clustering) and `/geoloc/entrances` (used at higher zoom levels for detailed markers) need the massif filter so the front-end can display massif entrances at any zoom level.

## 🔍 How

- Added `MAX_AREA_KM2 = 8000` constant and `computePolygonAreaKm2()` method to `MassifService` using PostGIS `ST_Area` on the geography type
- Added area validation in `massif/create.js` (before the DB transaction) and `massif/update.js` (inside the `if (geogPolygon)` block), returning 400 if exceeded
- Removed entrance fetching from `getPopulatedMassif()` and the `entrances` field from the `toMassif` converter
- Replaced `getEntrances()` (which fetched all rows) with `countEntrances()` (a `COUNT(*)` query) so `updateInSearch` correctly indexes `nbEntrances`
- Added `PUBLIC_ENTRANCES_COORDINATES_IN_BOUNDS_AND_MASSIF` and `PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF` SQL queries to `GeoLocService` combining `ST_Contains` with bounding box filters
- Extracted `checkAndGetMassifParam(req, res)` into `GeoLocService` to DRY up the massif param parsing/validation shared by both geoloc controllers
- Updated `find-entrances-coordinates.js` and `find-entrances.js` controllers to use the shared helper
- Updated Swagger: added `massif` query param + 404 to both entrancesCoordinates and entrances, area limit in massif POST/PUT 400 descriptions, updated Massif schema to match actual response shape

## 🧪 Testing

- `PORT=1338 npm run test -- --grep "Massif features|Geoloc features|MassifService"` — all tests passing
- New integration tests: oversized polygon → 400, valid polygon → 200, no polygon → skip validation, massif filter → 200 (both endpoints), non-existent massif → 404 (both endpoints)
- Property-based tests (fast-check): massif GET response shape excludes entrances, massif-filtered coordinates are within bounding box

## 📸 Previews

N/A — backend-only changes.
