### PR TITLE
feat(massif): increase max area from 8000 to 35000 km²

### DIFF
--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -4,7 +4,7 @@ const SearchService = require('./SearchService');
 const DescriptionService = require('./DescriptionService');
 const CommonService = require('./CommonService');
 
-const MAX_AREA_KM2 = 8000;
+const MAX_AREA_KM2 = 35000;
 
 const FIND_NETWORKS_IN_MASSIF = `
   SELECT c.*, c.length AS "caveLength", count(e.id_cave) as "nbEntrances"

--- a/test/integration/4_routes/Massifs/FAKE_DATA.js
+++ b/test/integration/4_routes/Massifs/FAKE_DATA.js
@@ -69,7 +69,7 @@ const geoJson2 = {
   ],
 };
 
-// A small polygon (~123 km²) well within the 8,000 km² limit
+// A small polygon (~123 km²) well within the 35,000 km² limit
 const geoJsonSmall = {
   type: 'Polygon',
   coordinates: [
@@ -83,7 +83,7 @@ const geoJsonSmall = {
   ],
 };
 
-// A large polygon (~49,000 km²) that exceeds the 8,000 km² limit
+// A large polygon (~49,000 km²) that exceeds the 35,000 km² limit
 const geoJsonOversized = {
   type: 'Polygon',
   coordinates: [

--- a/test/integration/4_routes/Massifs/create.test.js
+++ b/test/integration/4_routes/Massifs/create.test.js
@@ -42,7 +42,7 @@ describe('Massif features', () => {
       });
     });
     describe('Oversized polygon', () => {
-      it('should return code 400 when polygon area exceeds 8000 km²', (done) => {
+      it('should return code 400 when polygon area exceeds 35000 km²', (done) => {
         supertest(sails.hooks.http.app)
           .post('/api/v1/massifs')
           .send({
@@ -59,7 +59,7 @@ describe('Massif features', () => {
           .end((err, res) => {
             if (err) return done(err);
             should(res.text).match(
-              /exceeds the maximum allowed size of 8000 km²/
+              /exceeds the maximum allowed size of 35000 km²/
             );
             return done();
           });

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -96,7 +96,7 @@ describe('Massif features', () => {
         });
     });
 
-    it('should return 400 when polygon area exceeds 8000 km²', (done) => {
+    it('should return 400 when polygon area exceeds 35000 km²', (done) => {
       supertest(sails.hooks.http.app)
         .put(`/api/v1/massifs/${testMassifId}`)
         .send({
@@ -109,7 +109,7 @@ describe('Massif features', () => {
         .end((err, res) => {
           if (err) return done(err);
           should(res.text).match(
-            /exceeds the maximum allowed size of 8000 km²/
+            /exceeds the maximum allowed size of 35000 km²/
           );
           return done();
         });


### PR DESCRIPTION
## 🤔 What

Increase the maximum allowed massif polygon area from 8,000 km² to 35,000 km².

## 🤷‍♂️ Why

The previous 8,000 km² limit was too restrictive for some legitimate massifs.

## 🔍 How

- Updated `MAX_AREA_KM2` constant in `MassifService.js` from 8000 to 35000.
- Updated the corresponding integration tests and comments in create, update, and fake data files.

## 🧪 Testing

Existing integration tests for massif create and update cover the new limit. The oversized test polygon (~49,000 km²) still exceeds 35,000 km².

## 📸 Previews

N/A
