### PR TITLE
fix(sql): widen j_document_subject.code_subject from bpchar(5) to bpchar(8)

### DIFF
--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -1100,7 +1100,7 @@ CREATE TABLE j_document_region (
 -- DROP TABLE j_document_subject;
 CREATE TABLE j_document_subject (
 	id_document int4 NOT NULL,
-	code_subject bpchar(5) NOT NULL,
+	code_subject bpchar(8) NOT NULL,
 	CONSTRAINT j_document_subject_pk PRIMARY KEY (id_document, code_subject),
 	CONSTRAINT j_document_subject_t_document_fk FOREIGN KEY (id_document) REFERENCES t_document(id),
 	CONSTRAINT j_document_subject_t_subject_fk FOREIGN KEY (code_subject) REFERENCES t_subject(code)


### PR DESCRIPTION
## 🤔 What

- Widens the `code_subject` column in `j_document_subject` from `bpchar(5)` to `bpchar(8)`.

## 🤷‍♂️ Why

The `j_document_subject.code_subject` foreign key column was defined as `bpchar(5)`, but the referenced primary key `t_subject.code` is `bpchar(8)`. This mismatch could cause truncation when inserting subject codes longer than 5 characters.

## 🔍 How

Single-line change in `sql/0_tables.sql` aligning the column width with the parent table definition.

## 🧪 Testing

No application code changes — this is a schema-only fix. Verify by inspecting the column definition or running the table creation script against a fresh database.

## 📸 Previews

N/A
