### PR TITLE
fix(app): remove uncaughtException and unhandledRejection handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,17 +60,6 @@ try {
   process.exit(1);
 } // -•
 
-// Last-resort safety net: log and survive instead of crashing.
-// Individual controllers should still handle their own errors —
-// these handlers exist only to prevent a full server reboot when
-// an edge case slips through.
-process.on('uncaughtException', (err) => {
-  console.error(new Date().toISOString(), 'Uncaught exception:', err);
-});
-process.on('unhandledRejection', (reason) => {
-  console.error(new Date().toISOString(), 'Unhandled rejection:', reason);
-});
-
 // Start server
 sails.lift(rc('sails'));
 sails.on('lifted', () => console.log(new Date().toISOString(), 'Sails lifted'));


### PR DESCRIPTION
## 🤔 What

- Remove `process.on('uncaughtException', ...)` handler from `app.js`
- Remove `process.on('unhandledRejection', ...)` handler from `app.js`

## 🤷‍♂️ Why

These handlers catch exceptions/rejections and log them, but the process keeps running in a potentially corrupted state. This is dangerous because:

- After an uncaught exception, Node.js considers the process to be in an undefined state — open file descriptors, half-finished I/O, and corrupted in-memory data can cause silent data corruption
- The process exits with code 0 (clean), so Docker/PM2 don't know a restart is needed
- Node's default behavior (crash with full stack trace + exit code 1) is the correct approach — the process manager handles the restart cleanly

## 🔍 How

Removed both `process.on` handlers. Node's default behavior now applies:
- `uncaughtException`: prints stack trace to stderr, exits with code 1
- `unhandledRejection`: logs a warning (Node's default in v24)

The process manager (Docker restart policy, PM2, Azure App Service) will detect the non-zero exit and restart the process in a clean state.

## 🧪 Testing

No functional changes to test. Verify the server starts normally with `npm run dev`.

## 📸 Previews

N/A
