### PR TITLE
fix(dbSync): build datastore config from Azure env vars in resync script

### DIFF
--- a/scripts/resync-search.js
+++ b/scripts/resync-search.js
@@ -15,25 +15,51 @@ const { makeDbSync } = require('../api/dbSync/dbSync');
 
 const withExport = process.argv.includes('--export');
 
-sailsApp.load(
-  { hooks: { views: false, sockets: false, http: false } },
-  async (err) => {
-    if (err) {
-      console.error('Failed to load Sails:', err);
-      process.exit(1);
-    }
+const loadConfig = { hooks: { views: false, sockets: false, http: false } };
 
-    let exitCode = 0;
-    try {
-      sails.log.info(
-        `[resync] Starting manual resync (file export: ${withExport})`
-      );
-      await makeDbSync(withExport);
-    } catch (e) {
-      sails.log.error('[resync] Failed:', e);
-      exitCode = 1;
-    }
+// Build the datastore config from individual env vars set on Azure App Service.
+// Sails' double-underscore env var overrides do not reliably override the
+// hardcoded url in config/datastores.js, so we construct it explicitly.
+const dbHost = process.env.sails_datastores__default__url;
+const dbUser = process.env.sails_datastores__default__user;
+const dbPass = process.env.sails_datastores__default__password;
+const dbName = process.env.sails_datastores__default__database;
 
-    sailsApp.lower(() => process.exit(exitCode));
+if (dbHost && dbUser && dbPass && dbName) {
+  const dbPort = process.env.sails_datastores__default__port || 5432;
+  loadConfig.datastores = {
+    default: {
+      url: `postgres://${dbUser}:${encodeURIComponent(dbPass)}@${dbHost}:${dbPort}/${dbName}`,
+      ssl:
+        process.env.sails_datastores__default__ssl__rejectUnauthorized ===
+        'false'
+          ? { rejectUnauthorized: false }
+          : true,
+    },
+  };
+} else if (process.env.DATABASE_URL) {
+  // Fallback: allow a full connection string via DATABASE_URL.
+  loadConfig.datastores = {
+    default: { url: process.env.DATABASE_URL, ssl: true },
+  };
+}
+
+sailsApp.load(loadConfig, async (err) => {
+  if (err) {
+    console.error('Failed to load Sails:', err);
+    process.exit(1);
   }
-);
+
+  let exitCode = 0;
+  try {
+    sails.log.info(
+      `[resync] Starting manual resync (file export: ${withExport})`
+    );
+    await makeDbSync(withExport);
+  } catch (e) {
+    sails.log.error('[resync] Failed:', e);
+    exitCode = 1;
+  }
+
+  sailsApp.lower(() => process.exit(exitCode));
+});


### PR DESCRIPTION
## 🤔 What

- Fix `resync-search.js` script failing to connect to the database when run via SSH on Azure App Service.

## 🤷‍♂️ Why

Sails double-underscore env var overrides (`sails_datastores__default__url`) do not reliably override the hardcoded `url` in `config/datastores.js`. On Azure, the env vars provide individual fields (`user`, `password`, `database`) and `url` contains only the hostname, not a full connection string. This caused the script to always fall back to the dev default (`localhost:33060`).

Additionally, `sails-postgresql` does not pick up SSL config from URL query params, so Azure PostgreSQL rejected the connection with "no encryption".

## 🔍 How

The script now explicitly reads the individual Azure env vars and constructs a proper PostgreSQL connection URL with SSL config, passing it directly to `sails.load()` which takes highest precedence. Falls back to a `DATABASE_URL` env var if individual vars are not set.

## 🧪 Testing

Tested live on the Azure App Service via SSH. Confirmed the script connects and runs successfully.

## 📸 Previews

N/A