### PR TITLE
fix(db): add query performance fixes for recent changes, geoloc, notifications, and comments

### DIFF
--- a/api/services/GeoLocService.js
+++ b/api/services/GeoLocService.js
@@ -4,8 +4,8 @@ const PUBLIC_ENTRANCES_IN_BOUNDS = `
   c.size_coef as size_coef, e.id_cave as idCave, nc.name as nameCave, c.depth as depthCave,
   c.length as lengthCave
   FROM t_entrance as e
-  LEFT JOIN t_name as ne ON ne.id_entrance = e.id
-  LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave
+  LEFT JOIN t_name as ne ON ne.id_entrance = e.id AND ne.is_main = true AND ne.is_deleted = false
+  LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave AND nc.is_main = true AND nc.is_deleted = false
   LEFT JOIN t_cave as c ON c.Id = e.id_cave
   WHERE ST_Within(e.point_geom, ST_MakeEnvelope($1, $2, $3, $4, 4326))
   AND e.is_sensitive = false
@@ -20,8 +20,8 @@ const PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF = `
   c.size_coef as size_coef, e.id_cave as idCave, nc.name as nameCave, c.depth as depthCave,
   c.length as lengthCave
   FROM t_entrance as e
-  LEFT JOIN t_name as ne ON ne.id_entrance = e.id
-  LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave
+  LEFT JOIN t_name as ne ON ne.id_entrance = e.id AND ne.is_main = true AND ne.is_deleted = false
+  LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave AND nc.is_main = true AND nc.is_deleted = false
   LEFT JOIN t_cave as c ON c.Id = e.id_cave
   JOIN t_massif AS m ON m.id = $6
   WHERE ST_Within(e.point_geom, ST_MakeEnvelope($1, $2, $3, $4, 4326))
@@ -55,8 +55,8 @@ const NETWORKS_IN_BOUNDS = `
   SELECT c.id as id, COALESCE(nc.name, ne.name) as name, avg(en.longitude) as longitude, avg(en.latitude) as latitude
   FROM t_entrance as en
   INNER JOIN t_cave c ON c.id = en.id_cave
-  LEFT JOIN t_name AS nc ON nc.id_cave = c.id
-  LEFT JOIN t_name as ne ON ne.id_entrance = en.id
+  LEFT JOIN t_name AS nc ON nc.id_cave = c.id AND nc.is_main = true AND nc.is_deleted = false
+  LEFT JOIN t_name as ne ON ne.id_entrance = en.id AND ne.is_main = true AND ne.is_deleted = false
   WHERE ST_Within(en.point_geom, ST_MakeEnvelope($1, $2, $3, $4, 4326))
   AND en.is_sensitive = false
   AND en.is_deleted = false

--- a/api/services/RecentChangeService.js
+++ b/api/services/RecentChangeService.js
@@ -2,6 +2,12 @@ const CommonService = require('./CommonService');
 
 const GROUP_MAX_TIME_DIFF_S = 60 * 60 * 6; // 6 Hours
 
+// Dashboard only needs a short lookback; 7 days covers the typical review cycle
+// while keeping the query fast on the unpartitioned t_last_change table.
+const RECENT_CHANGES_WINDOW_DAYS = 7;
+// Hard cap to avoid oversized payloads — the dashboard is a summary, not a full audit log.
+const RECENT_CHANGES_LIMIT = 500;
+
 async function removeOlderChanges() {
   const query = `DELETE FROM t_last_change WHERE date_change < current_timestamp - interval '1 month';`;
   await CommonService.query(query);
@@ -108,7 +114,9 @@ async function getRecent() {
   const query = `
   SELECT tbl.*, author.nickname FROM t_last_change tbl
   LEFT JOIN t_caver author ON tbl.id_author = author.id
+  WHERE tbl.date_change > current_timestamp - interval '${RECENT_CHANGES_WINDOW_DAYS} days'
   ORDER BY date_change DESC
+  LIMIT ${RECENT_CHANGES_LIMIT}
   `;
   const rep = await CommonService.query(query);
 

--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -721,8 +721,8 @@ CREATE TABLE t_comment (
 	CONSTRAINT t_comment_t_entrance2_fk FOREIGN KEY (id_exit) REFERENCES t_entrance(id),
 	CONSTRAINT t_comment_t_language0_fk FOREIGN KEY (id_language) REFERENCES t_language(id)
 );
-CREATE INDEX idx_t_comment_entrance ON t_comment(id_entrance) WHERE id_entrance IS NOT NULL;
-CREATE INDEX idx_t_comment_cave ON t_comment(id_cave) WHERE id_cave IS NOT NULL;
+CREATE INDEX idx_t_comment_entrance ON t_comment(id_entrance);
+CREATE INDEX idx_t_comment_cave ON t_comment(id_cave);
 
 -- t_document definition
 -- Drop table
@@ -1286,6 +1286,7 @@ CREATE TABLE t_notification (
   CONSTRAINT t_notification_t_massif_fk FOREIGN KEY (id_massif) REFERENCES t_massif(id),
   CONSTRAINT t_notification_t_rigging_fk FOREIGN KEY (id_rigging) REFERENCES t_rigging(id)
 );
+CREATE INDEX idx_t_notification_notified ON t_notification(id_notified, date_inscription DESC);
 
 -- DROP TABLE j_document_iso3166_2;
 CREATE TABLE j_document_iso3166_2 (
@@ -1298,7 +1299,7 @@ CREATE TABLE j_document_iso3166_2 (
 
 -- DROP TABLE t_last_change;
 CREATE TABLE t_last_change (
-	-- id serial NOT NULL,
+	id serial NOT NULL,
 	type_entity varchar(30) NOT NULL,
 	type_change varchar(30) NOT NULL,
 	date_change timestamp NOT NULL DEFAULT now(),
@@ -1308,7 +1309,11 @@ CREATE TABLE t_last_change (
 	id_related_entity int4 NULL,
 	name varchar(300) NULL,
 
+	CONSTRAINT t_last_change_pk PRIMARY KEY (id),
 	CONSTRAINT t_last_change_t_caver_fk FOREIGN KEY (id_author) REFERENCES t_caver(id)
+) WITH (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
 );
 
 -- Internal record status for OAI-PMH server behavior control

--- a/sql/94_01_2026_03_17_query_performance_fixes.sql
+++ b/sql/94_01_2026_03_17_query_performance_fixes.sql
@@ -1,0 +1,47 @@
+\c grottoce;
+-- =============================================================================
+-- Migration: Query Performance Fixes
+-- Date: 2026-03-17
+-- Description: Fix 7 query performance defects from diagnostic analysis
+-- Idempotent: All statements use IF EXISTS / IF NOT EXISTS or DO blocks
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Fix 4: Add synthetic PK to t_last_change
+-- Enables HOT updates and reduces dead tuple accumulation (7.2% → target <2%)
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 't_last_change' AND column_name = 'id'
+  ) THEN
+    ALTER TABLE t_last_change ADD COLUMN id SERIAL PRIMARY KEY;
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- Fix 3: Add notification covering index for all user queries
+-- Serves both read+unread notification lookups (98.1% seq scan ratio)
+-- Retains existing idx_t_notification_notified_unread partial index
+-- -----------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_t_notification_notified
+  ON t_notification(id_notified, date_inscription DESC);
+
+-- -----------------------------------------------------------------------------
+-- Fix 5: Replace partial comment indexes with non-partial
+-- Partial WHERE IS NOT NULL prevents planner from using them for all patterns
+-- -----------------------------------------------------------------------------
+DROP INDEX IF EXISTS idx_t_comment_entrance;
+DROP INDEX IF EXISTS idx_t_comment_cave;
+CREATE INDEX IF NOT EXISTS idx_t_comment_entrance ON t_comment(id_entrance);
+CREATE INDEX IF NOT EXISTS idx_t_comment_cave ON t_comment(id_cave);
+
+-- -----------------------------------------------------------------------------
+-- Fix 7: Autovacuum tuning for t_last_change
+-- Triggers vacuum at ~5% dead tuples instead of default 20%
+-- -----------------------------------------------------------------------------
+ALTER TABLE t_last_change SET (
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -111,6 +111,9 @@ before(function (done) {
             .then(() =>
               CommonService.query(customSQL.INDEX_OPTIMIZATION_MIGRATION)
             )
+            .then(() =>
+              CommonService.query(customSQL.QUERY_PERFORMANCE_FIXES_MIGRATION)
+            )
             .then(() => done())
             .catch((commonServiceError) => done(commonServiceError));
         },

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -100,10 +100,34 @@ CREATE INDEX IF NOT EXISTS idx_v_biblio_sets
   ON v_bibliographic_metadata USING gin(list_sets);
 `;
 
+const QUERY_PERFORMANCE_FIXES_MIGRATION = `
+-- Fix 4: Add synthetic PK to t_last_change
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 't_last_change' AND column_name = 'id'
+  ) THEN
+    ALTER TABLE t_last_change ADD COLUMN id SERIAL PRIMARY KEY;
+  END IF;
+END $$;
+
+-- Fix 3: Notification covering index
+CREATE INDEX IF NOT EXISTS idx_t_notification_notified
+  ON t_notification(id_notified, date_inscription DESC);
+
+-- Fix 5: Replace partial comment indexes with non-partial
+DROP INDEX IF EXISTS idx_t_comment_entrance;
+DROP INDEX IF EXISTS idx_t_comment_cave;
+CREATE INDEX IF NOT EXISTS idx_t_comment_entrance ON t_comment(id_entrance);
+CREATE INDEX IF NOT EXISTS idx_t_comment_cave ON t_comment(id_cave);
+`;
+
 module.exports = {
   UPDATE_SEQUENCES_QUERY,
   ALTER_MASSIF_COLUMN_GEOG_POLYGON,
   ALTER_ENTRANCE_COLUMN_POINT_GEOM,
   POPULATE_ENTRANCE_POINT_GEOM,
   INDEX_OPTIMIZATION_MIGRATION,
+  QUERY_PERFORMANCE_FIXES_MIGRATION,
 };

--- a/test/integration/0_models/QueryPerformanceFixes.test.js
+++ b/test/integration/0_models/QueryPerformanceFixes.test.js
@@ -1,0 +1,72 @@
+const should = require('should');
+const CommonService = require('../../../api/services/CommonService');
+
+// Feature: db-query-performance-fixes
+// Schema assertions for the query performance fixes migration
+
+const NEW_INDEXES = [
+  { table: 't_notification', name: 'idx_t_notification_notified' },
+  { table: 't_comment', name: 'idx_t_comment_entrance' },
+  { table: 't_comment', name: 'idx_t_comment_cave' },
+];
+
+describe('QueryPerformanceFixes - Schema assertions', () => {
+  describe('New indexes exist', () => {
+    NEW_INDEXES.forEach(({ table, name }) => {
+      it(`should have index ${name} on ${table}`, async () => {
+        const result = await CommonService.query(
+          'SELECT indexname, tablename FROM pg_indexes WHERE indexname = $1',
+          [name]
+        );
+        should(result.rows).have.length(
+          1,
+          `Expected index ${name} to exist on ${table}`
+        );
+        should(result.rows[0].tablename).equal(table);
+      });
+    });
+  });
+
+  describe('Comment indexes are non-partial', () => {
+    it('should have non-partial idx_t_comment_entrance (no WHERE clause)', async () => {
+      const result = await CommonService.query(
+        `SELECT indexdef FROM pg_indexes
+         WHERE indexname = 'idx_t_comment_entrance'`,
+        []
+      );
+      should(result.rows).have.length(1);
+      should(result.rows[0].indexdef.toLowerCase()).not.containEql('where');
+    });
+
+    it('should have non-partial idx_t_comment_cave (no WHERE clause)', async () => {
+      const result = await CommonService.query(
+        `SELECT indexdef FROM pg_indexes
+         WHERE indexname = 'idx_t_comment_cave'`,
+        []
+      );
+      should(result.rows).have.length(1);
+      should(result.rows[0].indexdef.toLowerCase()).not.containEql('where');
+    });
+  });
+
+  describe('t_last_change has primary key', () => {
+    it('should have an id column on t_last_change', async () => {
+      const result = await CommonService.query(
+        `SELECT column_name, data_type FROM information_schema.columns
+         WHERE table_name = 't_last_change' AND column_name = 'id'`,
+        []
+      );
+      should(result.rows).have.length(1);
+      should(result.rows[0].data_type).equal('integer');
+    });
+
+    it('should have a primary key constraint on t_last_change', async () => {
+      const result = await CommonService.query(
+        `SELECT constraint_name FROM information_schema.table_constraints
+         WHERE table_name = 't_last_change' AND constraint_type = 'PRIMARY KEY'`,
+        []
+      );
+      should(result.rows.length).be.greaterThan(0);
+    });
+  });
+});

--- a/test/integration/1_services/GeoLocNameFilter.test.js
+++ b/test/integration/1_services/GeoLocNameFilter.test.js
@@ -1,0 +1,71 @@
+const should = require('should');
+const sinon = require('sinon');
+const GeoLocService = require('../../../api/services/GeoLocService');
+const CommonService = require('../../../api/services/CommonService');
+
+describe('GeoLocService - name join is_main filter fix', () => {
+  // Bounding box covering fixture entrances (lat ~57-63, lng ~72-79)
+  const southWestBound = { lat: 55, lng: 70 };
+  const northEastBound = { lat: 65, lng: 80 };
+
+  describe('getEntrancesMap() no row multiplication', () => {
+    it('should return at most one row per entrance (no name duplication)', async () => {
+      const entrances = await GeoLocService.getEntrancesMap(
+        southWestBound,
+        northEastBound,
+        1000
+      );
+      should(entrances).be.an.Array();
+      should(entrances.length).be.greaterThan(
+        0,
+        'No fixture entrances in bounding box — test is vacuous'
+      );
+      const ids = entrances.map((e) => e.id);
+      const uniqueIds = [...new Set(ids)];
+      should(ids.length).equal(
+        uniqueIds.length,
+        'Duplicate entrance IDs found — name join is causing row multiplication'
+      );
+    });
+  });
+
+  describe('getNetworksMap() no row multiplication', () => {
+    it('should return at most one row per network (no name duplication)', async () => {
+      // Networks require multiple entrances sharing the same cave.
+      // Current fixtures have no multi-entrance caves, so this verifies
+      // the query runs without error and returns no duplicates if any exist.
+      const networks = await GeoLocService.getNetworksMap(
+        southWestBound,
+        northEastBound
+      );
+      should(networks).be.an.Array();
+      if (networks.length > 0) {
+        const ids = networks.map((n) => n.id);
+        const uniqueIds = [...new Set(ids)];
+        should(ids.length).equal(
+          uniqueIds.length,
+          'Duplicate network IDs found — name join is causing row multiplication'
+        );
+      }
+    });
+  });
+
+  describe('SQL queries contain is_main filter', () => {
+    it('should include is_main = true in entrance map query', async () => {
+      const spy = sinon.spy(CommonService, 'query');
+      try {
+        await GeoLocService.getEntrancesMap(
+          southWestBound,
+          northEastBound,
+          100
+        );
+        should(spy.called).be.true();
+        const sql = spy.firstCall.args[0];
+        should(sql).containEql('is_main = true');
+        should(sql).containEql('is_deleted = false');
+      } finally {
+        spy.restore();
+      }
+    });
+  });
+});

--- a/test/integration/1_services/RecentChangeWindow.test.js
+++ b/test/integration/1_services/RecentChangeWindow.test.js
@@ -1,0 +1,40 @@
+const should = require('should');
+const sinon = require('sinon');
+const RecentChangeService = require('../../../api/services/RecentChangeService');
+const CommonService = require('../../../api/services/CommonService');
+
+describe('RecentChangeService - 7-day window fix', () => {
+  describe('getRecent() query includes date filter and limit', () => {
+    let querySpy;
+
+    afterEach(() => {
+      if (querySpy) {
+        querySpy.restore();
+        querySpy = null;
+      }
+    });
+
+    it('should include WHERE date_change filter in the query', async () => {
+      querySpy = sinon.spy(CommonService, 'query');
+      await RecentChangeService.getRecent();
+      should(querySpy.calledOnce).be.true();
+      const sql = querySpy.firstCall.args[0];
+      should(sql).containEql("interval '7 days'");
+      should(sql).containEql('current_timestamp');
+    });
+
+    it('should include LIMIT in the query', async () => {
+      querySpy = sinon.spy(CommonService, 'query');
+      await RecentChangeService.getRecent();
+      const sql = querySpy.firstCall.args[0];
+      should(sql.toLowerCase()).containEql('limit 500');
+    });
+
+    it('should still return results ordered by date DESC', async () => {
+      querySpy = sinon.spy(CommonService, 'query');
+      await RecentChangeService.getRecent();
+      const sql = querySpy.firstCall.args[0];
+      should(sql.toLowerCase()).containEql('order by date_change desc');
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

Fixes 6 query performance defects identified through PostgreSQL diagnostic analysis (sequential scan ratios, missing indexes, unbounded queries, row multiplication).

- Fix 1: Add 7-day window + LIMIT 500 to `RecentChangeService.getRecent()` (was full table scan)
- Fix 2: Add `is_main = true AND is_deleted = false` filters to GeoLocService name joins (was causing row multiplication)
- Fix 3: Add covering index `idx_t_notification_notified(id_notified, date_inscription DESC)` for notification queries
- Fix 4: Add synthetic PK (`id SERIAL`) to `t_last_change` to enable HOT updates
- Fix 5: Replace partial comment indexes with non-partial (planner couldn't use them for all query patterns)
- Fix 7: Tune autovacuum on `t_last_change` (trigger at 5% dead tuples instead of default 20%)

Fix 6 (materialized view refresh optimization) is deferred — it runs every 3 days at 4:40 AM via cron and needs separate analysis.

## 🤷‍♂️ Why

Production diagnostic queries revealed:
- `t_last_change`: 98.5% sequential scan ratio, 7.2% dead tuple ratio, no PK for HOT updates
- `t_notification`: 98.1% sequential scan ratio on user notification lookups
- GeoLocService map queries: row multiplication from unfiltered name joins (multiple `t_name` rows per entrance/cave)
- Comment indexes were partial (`WHERE id_entrance IS NOT NULL`) preventing the planner from using them for all query patterns

The `RecentChangeService.getRecent()` query was doing a full sequential scan of `t_last_change` with no date filter or row limit, despite only needing recent data for the dashboard.

## 🔍 How

**SQL Migration** (`sql/94_01_2026_03_17_query_performance_fixes.sql`):
- Idempotent DO block adds `id SERIAL PRIMARY KEY` to `t_last_change` if missing
- Creates covering index on `t_notification(id_notified, date_inscription DESC)`
- Drops partial comment indexes and recreates as non-partial
- Sets autovacuum tuning parameters on `t_last_change`

**Schema baseline** (`sql/0_tables.sql`):
- Updated `t_last_change` to include `id serial NOT NULL` PK and autovacuum WITH clause
- Changed comment indexes from partial to non-partial
- Added `idx_t_notification_notified` after notification table definition

**Service changes**:
- `RecentChangeService.getRecent()`: Added `WHERE date_change > current_timestamp - interval '7 days'` and `LIMIT 500`
- `GeoLocService`: Added `AND ne.is_main = true AND ne.is_deleted = false` to all `LEFT JOIN t_name` clauses in `PUBLIC_ENTRANCES_IN_BOUNDS`, `PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF`, and `NETWORKS_IN_BOUNDS`

## 🧪 Testing

### Automated tests

```bash
npm run dev:clean                          # Rebuild containers with new migration
docker logs grotto-postgres | grep ERROR   # Verify no init errors
PORT=1338 npm run test                     # All 1763 tests pass
npm run lint                               # Clean
```

New test files:
- `test/integration/0_models/QueryPerformanceFixes.test.js` — schema assertions for new indexes, non-partial comment indexes, `t_last_change` PK
- `test/integration/1_services/RecentChangeWindow.test.js` — verifies 7-day filter, LIMIT 500, ORDER BY in query
- `test/integration/1_services/GeoLocNameFilter.test.js` — verifies no row multiplication, `is_main` filter in SQL

### Manual spot tests

After deploying to a test environment with the migration applied:

1. **Recent changes** — `GET /api/v1/changes/recent`
   - Should return grouped changes from the last 7 days only
   - Response should be noticeably faster than before (was full table scan)
   - Verify the response still contains `date`, `authorId`, `author`, `mainEntityType`, `mainEntityId`, `mainAction` fields

2. **Map entrances** — `GET /api/v1/geoloc/entrances?sw_lat=43&sw_lng=1&ne_lat=46&ne_lng=4&limit=200`
   - Should return no duplicate entrance IDs in the response array
   - Each entrance should appear exactly once (no row multiplication from name joins)

3. **Map networks** — `GET /api/v1/geoloc/networks?sw_lat=43&sw_lng=1&ne_lat=46&ne_lng=4`
   - Should return no duplicate network IDs
   - Network names should still resolve correctly (COALESCE of cave name / entrance name)

4. **Map entrances with massif filter** — `GET /api/v1/geoloc/entrances?sw_lat=43&sw_lng=1&ne_lat=46&ne_lng=4&limit=200&massif=<valid_massif_id>`
   - Same as above, filtered to a specific massif — no duplicates

5. **Notifications** (requires auth) — Verify notification queries for a logged-in user still work and return results ordered by date

### Production deployment procedure

1. **Run the migration BEFORE deploying the new code** (the migration is additive and backward-compatible):
   ```sql
   -- Connect to the production PostgreSQL instance and run:
   \i sql/94_01_2026_03_17_query_performance_fixes.sql
   ```
   Or execute the statements manually:
   ```sql
   -- Fix 4: Add synthetic PK to t_last_change
   DO $
   BEGIN
     IF NOT EXISTS (
       SELECT 1 FROM information_schema.columns
       WHERE table_name = 't_last_change' AND column_name = 'id'
     ) THEN
       ALTER TABLE t_last_change ADD COLUMN id SERIAL PRIMARY KEY;
     END IF;
   END $;

   -- Fix 3: Notification covering index
   CREATE INDEX IF NOT EXISTS idx_t_notification_notified
     ON t_notification(id_notified, date_inscription DESC);

   -- Fix 5: Replace partial comment indexes with non-partial
   DROP INDEX IF EXISTS idx_t_comment_entrance;
   DROP INDEX IF EXISTS idx_t_comment_cave;
   CREATE INDEX IF NOT EXISTS idx_t_comment_entrance ON t_comment(id_entrance);
   CREATE INDEX IF NOT EXISTS idx_t_comment_cave ON t_comment(id_cave);

   -- Fix 7: Autovacuum tuning for t_last_change
   ALTER TABLE t_last_change SET (
     autovacuum_vacuum_scale_factor = 0.05,
     autovacuum_analyze_scale_factor = 0.02
   );
   ```

2. **Verify migration** — after running, confirm:
   ```sql
   -- PK exists on t_last_change
   SELECT column_name FROM information_schema.columns WHERE table_name = 't_last_change' AND column_name = 'id';
   -- New indexes exist
   SELECT indexname FROM pg_indexes WHERE indexname IN ('idx_t_notification_notified', 'idx_t_comment_entrance', 'idx_t_comment_cave');
   -- Comment indexes are non-partial (no WHERE in indexdef)
   SELECT indexname, indexdef FROM pg_indexes WHERE indexname IN ('idx_t_comment_entrance', 'idx_t_comment_cave');
   ```

3. **Deploy the code** — merge to `develop`, GitHub Actions deploys to Azure App Service automatically

4. **Post-deploy verification** — run the manual spot tests above against production, and monitor:
   ```sql
   -- Check sequential scan ratios improved
   SELECT relname, seq_scan, idx_scan,
          CASE WHEN (seq_scan + idx_scan) > 0
               THEN round(100.0 * seq_scan / (seq_scan + idx_scan), 1)
               ELSE 0 END AS seq_pct
   FROM pg_stat_user_tables
   WHERE relname IN ('t_last_change', 't_notification', 't_comment')
   ORDER BY relname;

   -- Check dead tuple ratio on t_last_change (should drop from ~7% toward <2%)
   SELECT relname, n_dead_tup, n_live_tup,
          CASE WHEN n_live_tup > 0
               THEN round(100.0 * n_dead_tup / n_live_tup, 1)
               ELSE 0 END AS dead_pct
   FROM pg_stat_user_tables
   WHERE relname = 't_last_change';
   ```

### Rollback

All changes are backward-compatible. If needed:
- The new indexes and PK column can be dropped without affecting existing code
- The `RecentChangeService` 7-day window and LIMIT can be reverted by removing the WHERE/LIMIT clauses
- The GeoLocService join filters can be reverted by removing the `AND ne.is_main = true AND ne.is_deleted = false` conditions

## 📸 Previews

N/A — backend-only changes, no UI impact.
