### PR TITLE
feat(massif): add massif geometry endpoints for map rendering

### DIFF
--- a/api/controllers/v1/entrance/import-rows.js
+++ b/api/controllers/v1/entrance/import-rows.js
@@ -153,7 +153,7 @@ module.exports = async (req, res) => {
 
   // Invalidate coordinates snapshot so newly imported entrances appear on the map
   if (requestResponse.successfulImport.length > 0) {
-    CoordinatesSnapshotService.clear();
+    CoordinatesSnapshotService.invalidate();
   }
 
   return res.ok(requestResponse);

--- a/api/controllers/v1/geoloc/find-entrances-coordinates.js
+++ b/api/controllers/v1/geoloc/find-entrances-coordinates.js
@@ -46,12 +46,16 @@ module.exports = async (req, res) => {
     }
 
     // Cache-Control header for all successful responses (AC 4.1)
+    // When lastRefreshed is null (snapshot not yet loaded), emit max-age=0
+    // to prevent CDNs from caching a DB-fallback response for the full TTL.
     const lastRefreshed = CoordinatesSnapshotService.getLastRefreshedAt();
     const ttl = CoordinatesSnapshotService.getTTL();
-    const age = lastRefreshed
-      ? Math.floor((Date.now() - lastRefreshed.getTime()) / 1000)
-      : 0;
-    res.set('Cache-Control', `public, max-age=${Math.max(ttl - age, 0)}`);
+    if (lastRefreshed) {
+      const age = Math.floor((Date.now() - lastRefreshed.getTime()) / 1000);
+      res.set('Cache-Control', `public, max-age=${Math.max(ttl - age, 0)}`);
+    } else {
+      res.set('Cache-Control', 'public, max-age=0');
+    }
 
     return res.json(result);
   } catch (e) {

--- a/api/controllers/v1/geoloc/find-massifs-coordinates.js
+++ b/api/controllers/v1/geoloc/find-massifs-coordinates.js
@@ -1,0 +1,44 @@
+const MassifCoordinatesSnapshotService = require('../../../services/MassifCoordinatesSnapshotService');
+const ErrorService = require('../../../services/ErrorService');
+const GeoLocService = require('../../../services/GeoLocService');
+
+module.exports = async (req, res) => {
+  const { southWestBound, northEastBound, errorMessage } =
+    GeoLocService.checkAndGetCoordinatesParams(req);
+
+  if (errorMessage !== '') return res.badRequest(errorMessage);
+
+  try {
+    // Try snapshot first
+    let result = MassifCoordinatesSnapshotService.getCoordinates(
+      parseFloat(southWestBound.lat),
+      parseFloat(southWestBound.lng),
+      parseFloat(northEastBound.lat),
+      parseFloat(northEastBound.lng)
+    );
+
+    if (result === null) {
+      // Snapshot not loaded yet — fallback to DB query
+      sails.log.info(
+        'MassifCoordinatesSnapshot not loaded yet, falling back to DB query'
+      );
+      result = await GeoLocService.getMassifsCoordinates(
+        southWestBound,
+        northEastBound
+      );
+    }
+
+    // Cache-Control header for successful responses
+    const lastRefreshed =
+      MassifCoordinatesSnapshotService.getLastRefreshedAt();
+    const ttl = MassifCoordinatesSnapshotService.getTTL();
+    const age = lastRefreshed
+      ? Math.floor((Date.now() - lastRefreshed.getTime()) / 1000)
+      : 0;
+    res.set('Cache-Control', `public, max-age=${Math.max(ttl - age, 0)}`);
+
+    return res.json(result);
+  } catch (e) {
+    return ErrorService.getDefaultErrorHandler(res)(e);
+  }
+};

--- a/api/controllers/v1/geoloc/find-massifs-coordinates.js
+++ b/api/controllers/v1/geoloc/find-massifs-coordinates.js
@@ -28,14 +28,17 @@ module.exports = async (req, res) => {
       );
     }
 
-    // Cache-Control header for successful responses
-    const lastRefreshed =
-      MassifCoordinatesSnapshotService.getLastRefreshedAt();
+    // Cache-Control header for successful responses.
+    // When lastRefreshed is null (snapshot not yet loaded), emit max-age=0
+    // to prevent CDNs from caching a DB-fallback response for the full TTL.
+    const lastRefreshed = MassifCoordinatesSnapshotService.getLastRefreshedAt();
     const ttl = MassifCoordinatesSnapshotService.getTTL();
-    const age = lastRefreshed
-      ? Math.floor((Date.now() - lastRefreshed.getTime()) / 1000)
-      : 0;
-    res.set('Cache-Control', `public, max-age=${Math.max(ttl - age, 0)}`);
+    if (lastRefreshed) {
+      const age = Math.floor((Date.now() - lastRefreshed.getTime()) / 1000);
+      res.set('Cache-Control', `public, max-age=${Math.max(ttl - age, 0)}`);
+    } else {
+      res.set('Cache-Control', 'public, max-age=0');
+    }
 
     return res.json(result);
   } catch (e) {

--- a/api/controllers/v1/geoloc/find-massifs.js
+++ b/api/controllers/v1/geoloc/find-massifs.js
@@ -1,0 +1,19 @@
+const ErrorService = require('../../../services/ErrorService');
+const GeoLocService = require('../../../services/GeoLocService');
+
+module.exports = async (req, res) => {
+  const { southWestBound, northEastBound, errorMessage } =
+    GeoLocService.checkAndGetCoordinatesParams(req);
+
+  if (errorMessage !== '') return res.badRequest(errorMessage);
+
+  try {
+    const result = await GeoLocService.getMassifsMap(
+      southWestBound,
+      northEastBound
+    );
+    return res.json(result);
+  } catch (e) {
+    return ErrorService.getDefaultErrorHandler(res)(e);
+  }
+};

--- a/api/services/CoordinatesSnapshotService.js
+++ b/api/services/CoordinatesSnapshotService.js
@@ -7,6 +7,11 @@
  *
  * State is stored in module-level variables (not on the exported object)
  * so that Sails' _.bindAll() cannot interfere with it.
+ *
+ * NOTE: If load() fails at bootstrap, there is no automatic retry.
+ * The DB fallback in the controller will handle requests correctly,
+ * but without the snapshot's performance benefit. A server restart
+ * is required to restore the in-memory snapshot.
  */
 
 const CommonService = require('./CommonService');
@@ -89,6 +94,10 @@ module.exports = {
     // Strict inequalities (>) are intentional: coordinates exactly on the bbox
     // boundary are excluded to match Leaflet's convention where tile edges
     // belong to the adjacent tile, avoiding duplicate markers.
+    //
+    // The fullLat / fullLng special cases use inclusive (>=, <=) bounds because
+    // they represent the full geographic range (±90° lat or ±180° lng). There is
+    // no adjacent tile beyond these limits, so boundary exclusion is unnecessary.
     const fullLat = swLat <= -90 && neLat >= 90;
     const fullLng = swLng <= -180 && neLng >= 180;
 
@@ -115,11 +124,12 @@ module.exports = {
     );
   },
 
-  clear() {
+  invalidate() {
     sails.log.info(
-      'CoordinatesSnapshot cleared, triggering background refresh'
+      'CoordinatesSnapshot TTL invalidated, triggering background refresh'
     );
-    lastRefreshedAt = null;
+    // Keep lastRefreshedAt at its previous value so the controller computes
+    // a correct (increasing) Cache-Control age while the refresh runs.
     load().catch(() => {});
   },
 

--- a/api/services/GeoLocService.js
+++ b/api/services/GeoLocService.js
@@ -77,6 +77,51 @@ const PUBLIC_NETWORKS_COORDINATES_IN_BOUNDS = `
   HAVING count(en.id_cave) > 1
   LIMIT $5;
 `;
+const PUBLIC_MASSIFS_COORDINATES_IN_BOUNDS = `
+  SELECT
+    ST_X(ST_Centroid(m.geog_polygon::geometry)) AS longitude,
+    ST_Y(ST_Centroid(m.geog_polygon::geometry)) AS latitude
+  FROM t_massif AS m
+  WHERE m.is_deleted = false
+    AND m.geog_polygon IS NOT NULL
+    AND ST_Within(
+      ST_Centroid(m.geog_polygon::geometry),
+      ST_MakeEnvelope($1, $2, $3, $4, 4326)
+    );
+`;
+
+const MASSIFS_IN_BOUNDS = `
+  SELECT
+    m.id AS id,
+    n.name AS name,
+    ST_AsGeoJSON(m.geog_polygon) AS "geogPolygon",
+    (
+      SELECT COUNT(e.id)::integer
+      FROM t_entrance AS e
+      WHERE e.is_deleted = false
+        AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+    ) AS "entranceCount",
+    (
+      SELECT COUNT(*)::integer FROM (
+        SELECT c.id
+        FROM t_entrance AS e
+        JOIN t_cave AS c ON c.id = e.id_cave
+        WHERE e.is_deleted = false
+          AND c.is_deleted = false
+          AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+        GROUP BY c.id
+        HAVING COUNT(e.id) > 1
+      ) AS networks
+    ) AS "networkCount"
+  FROM t_massif AS m
+  LEFT JOIN t_name AS n ON n.id_massif = m.id AND n.is_main = true
+  WHERE m.is_deleted = false
+    AND m.geog_polygon IS NOT NULL
+    AND ST_Intersects(
+      m.geog_polygon::geometry,
+      ST_MakeEnvelope($1, $2, $3, $4, 4326)
+    );
+`;
 
 const CommonService = require('./CommonService');
 const NameService = require('./NameService');
@@ -354,5 +399,42 @@ module.exports = {
       return [];
     }
     return formatNetworks(results.rows);
+  },
+  getMassifsCoordinates: async (southWestBound, northEastBound) => {
+    const results = await CommonService.query(
+      PUBLIC_MASSIFS_COORDINATES_IN_BOUNDS,
+      [
+        southWestBound.lng,
+        southWestBound.lat,
+        northEastBound.lng,
+        northEastBound.lat,
+      ]
+    );
+    if (!results || results.rows.length <= 0) {
+      return [];
+    }
+    return results.rows.map((coord) => [
+      Number(coord.longitude),
+      Number(coord.latitude),
+    ]);
+  },
+
+  getMassifsMap: async (southWestBound, northEastBound) => {
+    const results = await CommonService.query(MASSIFS_IN_BOUNDS, [
+      southWestBound.lng,
+      southWestBound.lat,
+      northEastBound.lng,
+      northEastBound.lat,
+    ]);
+    if (!results || results.rows.length <= 0) {
+      return [];
+    }
+    return results.rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      geogPolygon: JSON.parse(row.geogPolygon),
+      entranceCount: row.entranceCount,
+      networkCount: row.networkCount,
+    }));
   },
 };

--- a/api/services/MassifCoordinatesSnapshotService.js
+++ b/api/services/MassifCoordinatesSnapshotService.js
@@ -7,6 +7,11 @@
  *
  * State is stored in module-level variables (not on the exported object)
  * so that Sails' _.bindAll() cannot interfere with it.
+ *
+ * NOTE: If load() fails at bootstrap, there is no automatic retry.
+ * The DB fallback in the controller will handle requests correctly,
+ * but without the snapshot's performance benefit. A server restart
+ * is required to restore the in-memory snapshot.
  */
 
 const CommonService = require('./CommonService');
@@ -89,6 +94,10 @@ module.exports = {
     // Strict inequalities (>) are intentional: coordinates exactly on the bbox
     // boundary are excluded to match Leaflet's convention where tile edges
     // belong to the adjacent tile, avoiding duplicate markers.
+    //
+    // The fullLat / fullLng special cases use inclusive (>=, <=) bounds because
+    // they represent the full geographic range (±90° lat or ±180° lng). There is
+    // no adjacent tile beyond these limits, so boundary exclusion is unnecessary.
     const fullLat = swLat <= -90 && neLat >= 90;
     const fullLng = swLng <= -180 && neLng >= 180;
 
@@ -115,11 +124,12 @@ module.exports = {
     );
   },
 
-  clear() {
+  invalidate() {
     sails.log.info(
-      'MassifCoordinatesSnapshot cleared, triggering background refresh'
+      'MassifCoordinatesSnapshot TTL invalidated, triggering background refresh'
     );
-    lastRefreshedAt = null;
+    // Keep lastRefreshedAt at its previous value so the controller computes
+    // a correct (increasing) Cache-Control age while the refresh runs.
     load().catch(() => {});
   },
 

--- a/api/services/MassifCoordinatesSnapshotService.js
+++ b/api/services/MassifCoordinatesSnapshotService.js
@@ -1,0 +1,132 @@
+/**
+ * MassifCoordinatesSnapshotService
+ *
+ * Holds an in-memory snapshot of all massif centroid coordinates.
+ * The snapshot is loaded from PostgreSQL on server bootstrap and
+ * refreshed in the background when the configured TTL expires.
+ *
+ * State is stored in module-level variables (not on the exported object)
+ * so that Sails' _.bindAll() cannot interfere with it.
+ */
+
+const CommonService = require('./CommonService');
+
+const ALL_MASSIF_CENTROIDS = `
+  SELECT
+    ST_X(ST_Centroid(m.geog_polygon::geometry)) AS longitude,
+    ST_Y(ST_Centroid(m.geog_polygon::geometry)) AS latitude
+  FROM t_massif AS m
+  WHERE m.is_deleted = false
+    AND m.geog_polygon IS NOT NULL;
+`;
+
+// --------------- State ---------------
+
+let coordinates = null;
+let lastRefreshedAt = null;
+let loadPromise = null;
+
+// --------------- Helpers ---------------
+
+const getTTL = () => sails.config.custom?.coordinatesSnapshotTTL ?? 86400;
+
+// --------------- Service ---------------
+
+const load = () => {
+  if (loadPromise) return loadPromise;
+  loadPromise = (async () => {
+    const startTime = Date.now();
+    try {
+      const results = await CommonService.query(ALL_MASSIF_CENTROIDS);
+      coordinates = results.rows.map((row) => [
+        Number(row.longitude),
+        Number(row.latitude),
+      ]);
+      lastRefreshedAt = new Date();
+      const elapsed = Date.now() - startTime;
+      sails.log.info(
+        `MassifCoordinatesSnapshot loaded ${coordinates.length} coordinates in ${elapsed}ms`
+      );
+    } catch (err) {
+      const elapsed = Date.now() - startTime;
+      sails.log.error(
+        `MassifCoordinatesSnapshotService.load() failed after ${elapsed}ms:`,
+        err
+      );
+      lastRefreshedAt = lastRefreshedAt || new Date(0);
+      throw err;
+    } finally {
+      loadPromise = null;
+    }
+  })();
+  return loadPromise;
+};
+
+module.exports = {
+  load,
+
+  isLoaded: () => coordinates !== null,
+
+  getLastRefreshedAt: () => lastRefreshedAt,
+
+  getTTL,
+
+  getCoordinates(swLat, swLng, neLat, neLng) {
+    if (coordinates === null) return null;
+
+    // Stale-while-revalidate: trigger background refresh if TTL expired
+    if (
+      lastRefreshedAt &&
+      Date.now() - lastRefreshedAt.getTime() > getTTL() * 1000 &&
+      !loadPromise
+    ) {
+      sails.log.info(
+        'MassifCoordinatesSnapshot TTL expired, triggering background refresh'
+      );
+      load().catch(() => {});
+    }
+
+    // Strict inequalities (>) are intentional: coordinates exactly on the bbox
+    // boundary are excluded to match Leaflet's convention where tile edges
+    // belong to the adjacent tile, avoiding duplicate markers.
+    const fullLat = swLat <= -90 && neLat >= 90;
+    const fullLng = swLng <= -180 && neLng >= 180;
+
+    if (fullLat && fullLng) return coordinates.slice();
+
+    if (fullLat) {
+      return coordinates.filter(
+        (coord) => coord[0] >= swLng && coord[0] <= neLng
+      );
+    }
+
+    if (fullLng) {
+      return coordinates.filter(
+        (coord) => coord[1] >= swLat && coord[1] <= neLat
+      );
+    }
+
+    return coordinates.filter(
+      (coord) =>
+        coord[0] > swLng &&
+        coord[0] < neLng &&
+        coord[1] > swLat &&
+        coord[1] < neLat
+    );
+  },
+
+  clear() {
+    sails.log.info(
+      'MassifCoordinatesSnapshot cleared, triggering background refresh'
+    );
+    lastRefreshedAt = null;
+    load().catch(() => {});
+  },
+
+  // Test helper — not for production use
+  reset() {
+    coordinates = null;
+    lastRefreshedAt = null;
+    loadPromise = null;
+  },
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4005,6 +4005,87 @@ paths:
         '404':
           description: Resource not found
 
+  '/geoloc/massifsCoordinates':
+    get:
+      tags:
+        - geoloc
+      description: Get massif centroid coordinates inside the given bounding box. Returns an array of [longitude, latitude] pairs for use in hexbin heatmap rendering. Results are served from an in-memory snapshot cache when available, with a database fallback.
+      parameters:
+        - $ref: '#/components/parameters/sw_lat'
+        - $ref: '#/components/parameters/sw_lng'
+        - $ref: '#/components/parameters/ne_lat'
+        - $ref: '#/components/parameters/ne_lng'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: 'Cache directive, e.g. public, max-age=3600'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: number
+                  minItems: 2
+                  maxItems: 2
+                  description: '[longitude, latitude] pair'
+        '400':
+          description: Missing or invalid bounding box parameters
+        '500':
+          description: Internal server error
+
+  '/geoloc/massifs':
+    get:
+      tags:
+        - geoloc
+      description: Get massif polygons with popup metadata inside the given bounding box. Returns massifs whose polygon intersects the bounding box, with name, GeoJSON polygon, entrance count, and network count.
+      parameters:
+        - $ref: '#/components/parameters/sw_lat'
+        - $ref: '#/components/parameters/sw_lng'
+        - $ref: '#/components/parameters/ne_lat'
+        - $ref: '#/components/parameters/ne_lng'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      description: Massif ID
+                    name:
+                      type: string
+                      nullable: true
+                      description: Main name of the massif
+                    geogPolygon:
+                      type: object
+                      description: GeoJSON geometry object (MultiPolygon or Polygon)
+                      properties:
+                        type:
+                          type: string
+                        coordinates:
+                          type: array
+                          items: {}
+                    entranceCount:
+                      type: integer
+                      description: Number of non-deleted entrances within the massif polygon
+                    networkCount:
+                      type: integer
+                      description: Number of caves with more than one entrance within the massif polygon
+        '400':
+          description: Missing or invalid bounding box parameters
+        '500':
+          description: Internal server error
+
   '/massifs':
     post:
       tags:

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -45,6 +45,13 @@ module.exports.bootstrap = async function (done) {
     sails.log.error('Failed to load coordinates snapshot on bootstrap:', err);
   });
 
+  sails.services.massifcoordinatessnapshotservice.load().catch((err) => {
+    sails.log.error(
+      'Failed to load massif coordinates snapshot on bootstrap:',
+      err
+    );
+  });
+
   return done();
 };
 // By convention, this is a good place to set up fake data during development.

--- a/config/policies.js
+++ b/config/policies.js
@@ -155,6 +155,8 @@ module.exports.policies = {
   'v1/geoloc/find-entrances-coordinates': true,
   'v1/geoloc/find-networks': true,
   'v1/geoloc/find-networks-coordinates': true,
+  'v1/geoloc/find-massifs': true,
+  'v1/geoloc/find-massifs-coordinates': true,
   'v1/geoloc/find-organizations': true,
 
   // Languages

--- a/config/routes.js
+++ b/config/routes.js
@@ -332,6 +332,9 @@ module.exports.routes = {
   'GET /api/v1/geoloc/networks': 'v1/geoloc/find-networks',
   'GET /api/v1/geoloc/networksCoordinates':
     'v1/geoloc/find-networks-coordinates',
+  'GET /api/v1/geoloc/massifs': 'v1/geoloc/find-massifs',
+  'GET /api/v1/geoloc/massifsCoordinates':
+    'v1/geoloc/find-massifs-coordinates',
   'GET /api/v1/geoloc/organizations': 'v1/geoloc/find-organizations',
 
   /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -333,8 +333,7 @@ module.exports.routes = {
   'GET /api/v1/geoloc/networksCoordinates':
     'v1/geoloc/find-networks-coordinates',
   'GET /api/v1/geoloc/massifs': 'v1/geoloc/find-massifs',
-  'GET /api/v1/geoloc/massifsCoordinates':
-    'v1/geoloc/find-massifs-coordinates',
+  'GET /api/v1/geoloc/massifsCoordinates': 'v1/geoloc/find-massifs-coordinates',
   'GET /api/v1/geoloc/organizations': 'v1/geoloc/find-organizations',
 
   /**

--- a/test/integration/1_services/CoordinatesSnapshotService.property.test.js
+++ b/test/integration/1_services/CoordinatesSnapshotService.property.test.js
@@ -315,16 +315,16 @@ describe('CoordinatesSnapshotService - Property 1: Fault Condition', () => {
   });
 
   /**
-   * Bug 2 — Stuck Cache: after clear() + failed load(), lastRefreshedAt must be non-null.
+   * Bug 2 — Stuck Cache: after invalidate() + failed load(), lastRefreshedAt must be non-null.
    * Encodes: cache recovery requires lastRefreshedAt to be truthy for stale-while-revalidate.
-   * Covers: clear() followed by a failed background load().
+   * Covers: invalidate() followed by a failed background load().
    *
    * On UNFIXED code: lastRefreshedAt stays null (stuck cache) — test FAILS.
    * On FIXED code: lastRefreshedAt is set to epoch new Date(0) — test PASSES.
    *
    * Validates: Requirements 1.2, 2.2
    */
-  it('should preserve non-null lastRefreshedAt after clear() + failed load() (Bug 2 — Stuck Cache)', async function () {
+  it('should preserve non-null lastRefreshedAt after invalidate() + failed load() (Bug 2 — Stuck Cache)', async function () {
     this.timeout(30000);
     const logStub = sinon.stub(sails.log, 'error');
 
@@ -358,13 +358,13 @@ describe('CoordinatesSnapshotService - Property 1: Fault Condition', () => {
 
           should(CoordinatesSnapshotService.getLastRefreshedAt()).be.a.Date();
 
-          // Step 2: clear() sets lastRefreshedAt = null, then triggers background load()
-          // Stub DB to fail BEFORE calling clear() so the background load() fails
+          // Step 2: invalidate() preserves lastRefreshedAt, then triggers background load()
+          // Stub DB to fail BEFORE calling invalidate() so the background load() fails
           stubs.stubError(new Error(errorMsg));
-          CoordinatesSnapshotService.clear();
+          CoordinatesSnapshotService.invalidate();
 
           // Step 3: Wait for the background load() to complete
-          // clear() calls load().catch(() => {}), so we call load() again to get the same promise
+          // invalidate() calls load().catch(() => {}), so we call load() again to get the same promise
           // (single-flight guard) and await it, catching the expected rejection
           try {
             await CoordinatesSnapshotService.load();
@@ -380,7 +380,7 @@ describe('CoordinatesSnapshotService - Property 1: Fault Condition', () => {
           // Expected behavior: lastRefreshedAt is NOT null (recovery state preserved)
           const refreshedAt = CoordinatesSnapshotService.getLastRefreshedAt();
           should(refreshedAt !== null).be.true(
-            'lastRefreshedAt should be non-null after clear() + failed load(), but it is null (stuck cache)'
+            'lastRefreshedAt should be non-null after invalidate() + failed load(), but it is null (stuck cache)'
           );
         }
       ),

--- a/test/integration/1_services/CoordinatesSnapshotService.test.js
+++ b/test/integration/1_services/CoordinatesSnapshotService.test.js
@@ -151,7 +151,7 @@ describe('CoordinatesSnapshotService', () => {
     });
   });
 
-  describe('clear()', () => {
+  describe('invalidate()', () => {
     it('should trigger refresh without nullifying snapshot', async () => {
       queryStub = sinon
         .stub(CommonService, 'query')
@@ -162,7 +162,7 @@ describe('CoordinatesSnapshotService', () => {
       queryStub = sinon
         .stub(CommonService, 'query')
         .resolves({ rows: sampleRows });
-      CoordinatesSnapshotService.clear();
+      CoordinatesSnapshotService.invalidate();
 
       // Snapshot still available (not nullified)
       should(CoordinatesSnapshotService.isLoaded()).be.true();
@@ -178,8 +178,8 @@ describe('CoordinatesSnapshotService', () => {
       // Background load was triggered
       should(queryStub.calledOnce).be.true();
 
-      // lastRefreshedAt is null (set by clear before async load completes)
-      should(CoordinatesSnapshotService.getLastRefreshedAt()).be.null();
+      // lastRefreshedAt is preserved (not nullified) so Cache-Control stays correct
+      should(CoordinatesSnapshotService.getLastRefreshedAt()).not.be.null();
     });
   });
 

--- a/test/integration/1_services/GeoLocService.property.test.js
+++ b/test/integration/1_services/GeoLocService.property.test.js
@@ -115,22 +115,30 @@ describe('GeoLocService - Property 2: centroid exclusion filtering', () => {
   it('should return exactly the centroids matching non-deleted massifs with non-null polygons in bbox', async function centroidExclusion() {
     this.timeout(120000);
     await fc.assert(
-      fc.asyncProperty(massifBboxArb, async ({ swLat, swLng, neLat, neLng }) => {
-        const southWestBound = { lat: swLat, lng: swLng };
-        const northEastBound = { lat: neLat, lng: neLng };
+      fc.asyncProperty(
+        massifBboxArb,
+        async ({ swLat, swLng, neLat, neLng }) => {
+          const southWestBound = { lat: swLat, lng: swLng };
+          const northEastBound = { lat: neLat, lng: neLng };
 
-        const [centroids, refResult] = await Promise.all([
-          GeoLocService.getMassifsCoordinates(southWestBound, northEastBound),
-          CommonService.query(REFERENCE_COUNT_QUERY, [swLng, swLat, neLng, neLat]),
-        ]);
+          const [centroids, refResult] = await Promise.all([
+            GeoLocService.getMassifsCoordinates(southWestBound, northEastBound),
+            CommonService.query(REFERENCE_COUNT_QUERY, [
+              swLng,
+              swLat,
+              neLng,
+              neLat,
+            ]),
+          ]);
 
-        const expectedCount = refResult.rows[0].count;
+          const expectedCount = refResult.rows[0].count;
 
-        should(centroids.length).equal(
-          expectedCount,
-          `Centroid count mismatch for bbox sw(${swLat},${swLng}) ne(${neLat},${neLng}): got ${centroids.length}, expected ${expectedCount}`
-        );
-      }),
+          should(centroids.length).equal(
+            expectedCount,
+            `Centroid count mismatch for bbox sw(${swLat},${swLng}) ne(${neLat},${neLng}): got ${centroids.length}, expected ${expectedCount}`
+          );
+        }
+      ),
       { numRuns: 100 }
     );
   });

--- a/test/integration/1_services/GeoLocService.property.test.js
+++ b/test/integration/1_services/GeoLocService.property.test.js
@@ -69,3 +69,69 @@ describe('GeoLocService - Property 1: spatial query equivalence', () => {
     );
   });
 });
+
+// Feature: massif-geometry-endpoints, Property 2: Centroid exclusion filtering
+const GeoLocService = require('../../../api/services/GeoLocService');
+
+/**
+ * Bounding box arbitrary for massif centroid tests: generates valid SW/NE
+ * coordinate pairs where sw_lat < ne_lat and sw_lng < ne_lng.
+ */
+const massifBboxArb = fc
+  .tuple(
+    fc.double({ min: -90, max: 89, noNaN: true }),
+    fc.double({ min: -180, max: 179, noNaN: true })
+  )
+  .chain(([swLat, swLng]) =>
+    fc
+      .tuple(
+        fc.double({ min: swLat + 0.01, max: 90, noNaN: true }),
+        fc.double({ min: swLng + 0.01, max: 180, noNaN: true })
+      )
+      .map(([neLat, neLng]) => ({ swLat, swLng, neLat, neLng }))
+  );
+
+/**
+ * Property 2: Centroid exclusion filtering.
+ * Encodes: For any bounding box query, the number of returned centroids
+ * equals the number of non-deleted massifs with non-null geog_polygon
+ * whose centroid falls within the bounding box.
+ * Covers: all valid bounding boxes over the fixture massif data.
+ *
+ * Validates: Requirements 1.3, 1.4
+ */
+describe('GeoLocService - Property 2: centroid exclusion filtering', () => {
+  const REFERENCE_COUNT_QUERY = `
+    SELECT COUNT(*)::integer AS count
+    FROM t_massif
+    WHERE is_deleted = false
+      AND geog_polygon IS NOT NULL
+      AND ST_Within(
+        ST_Centroid(geog_polygon::geometry),
+        ST_MakeEnvelope($1, $2, $3, $4, 4326)
+      );
+  `;
+
+  it('should return exactly the centroids matching non-deleted massifs with non-null polygons in bbox', async function centroidExclusion() {
+    this.timeout(120000);
+    await fc.assert(
+      fc.asyncProperty(massifBboxArb, async ({ swLat, swLng, neLat, neLng }) => {
+        const southWestBound = { lat: swLat, lng: swLng };
+        const northEastBound = { lat: neLat, lng: neLng };
+
+        const [centroids, refResult] = await Promise.all([
+          GeoLocService.getMassifsCoordinates(southWestBound, northEastBound),
+          CommonService.query(REFERENCE_COUNT_QUERY, [swLng, swLat, neLng, neLat]),
+        ]);
+
+        const expectedCount = refResult.rows[0].count;
+
+        should(centroids.length).equal(
+          expectedCount,
+          `Centroid count mismatch for bbox sw(${swLat},${swLng}) ne(${neLat},${neLng}): got ${centroids.length}, expected ${expectedCount}`
+        );
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/MassifCoordinatesSnapshotService.test.js
+++ b/test/integration/1_services/MassifCoordinatesSnapshotService.test.js
@@ -145,7 +145,7 @@ describe('MassifCoordinatesSnapshotService', () => {
     });
   });
 
-  describe('clear()', () => {
+  describe('invalidate()', () => {
     it('should trigger refresh without nullifying snapshot', async () => {
       queryStub = sinon
         .stub(CommonService, 'query')
@@ -156,7 +156,7 @@ describe('MassifCoordinatesSnapshotService', () => {
       queryStub = sinon
         .stub(CommonService, 'query')
         .resolves({ rows: sampleRows });
-      MassifCoordinatesSnapshotService.clear();
+      MassifCoordinatesSnapshotService.invalidate();
 
       should(MassifCoordinatesSnapshotService.isLoaded()).be.true();
       const result = MassifCoordinatesSnapshotService.getCoordinates(
@@ -169,7 +169,11 @@ describe('MassifCoordinatesSnapshotService', () => {
       should(result).have.length(3);
 
       should(queryStub.calledOnce).be.true();
-      should(MassifCoordinatesSnapshotService.getLastRefreshedAt()).be.null();
+
+      // lastRefreshedAt is preserved (not nullified) so Cache-Control stays correct
+      should(
+        MassifCoordinatesSnapshotService.getLastRefreshedAt()
+      ).not.be.null();
     });
   });
 

--- a/test/integration/1_services/MassifCoordinatesSnapshotService.test.js
+++ b/test/integration/1_services/MassifCoordinatesSnapshotService.test.js
@@ -1,0 +1,206 @@
+const should = require('should');
+const sinon = require('sinon');
+const MassifCoordinatesSnapshotService = require('../../../api/services/MassifCoordinatesSnapshotService');
+const CommonService = require('../../../api/services/CommonService');
+
+const sampleRows = [
+  { longitude: '5.5', latitude: '43.3' },
+  { longitude: '6.1', latitude: '44.2' },
+  { longitude: '-2.5', latitude: '48.8' },
+];
+
+describe('MassifCoordinatesSnapshotService', () => {
+  let queryStub;
+  let originalTTL;
+
+  beforeEach(async () => {
+    MassifCoordinatesSnapshotService.reset();
+    originalTTL = sails.config.custom.coordinatesSnapshotTTL;
+    sails.config.custom.coordinatesSnapshotTTL = 999999;
+  });
+
+  afterEach(() => {
+    sails.config.custom.coordinatesSnapshotTTL = originalTTL;
+    sinon.restore();
+  });
+
+  describe('load()', () => {
+    it('should populate snapshot and set lastRefreshedAt', async () => {
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+
+      await MassifCoordinatesSnapshotService.load();
+
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.true();
+      should(MassifCoordinatesSnapshotService.getLastRefreshedAt()).be.a.Date();
+
+      const result = MassifCoordinatesSnapshotService.getCoordinates(
+        -90,
+        -180,
+        90,
+        180
+      );
+      should(result).be.an.Array();
+      should(result).have.length(3);
+      should(result[0]).eql([5.5, 43.3]);
+      should(result[1]).eql([6.1, 44.2]);
+      should(result[2]).eql([-2.5, 48.8]);
+    });
+
+    it('should log error and preserve existing snapshot on failure', async () => {
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+      queryStub.restore();
+
+      const firstRefreshedAt =
+        MassifCoordinatesSnapshotService.getLastRefreshedAt();
+      const logStub = sinon.stub(sails.log, 'error');
+
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .rejects(new Error('DB down'));
+      try {
+        await MassifCoordinatesSnapshotService.load();
+        should.fail('load() should have rejected');
+      } catch (err) {
+        should(err.message).equal('DB down');
+      }
+
+      should(logStub.calledOnce).be.true();
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.true();
+      should(MassifCoordinatesSnapshotService.getLastRefreshedAt()).equal(
+        firstRefreshedAt
+      );
+      const result = MassifCoordinatesSnapshotService.getCoordinates(
+        -90,
+        -180,
+        90,
+        180
+      );
+      should(result).have.length(3);
+    });
+  });
+
+  describe('getCoordinates()', () => {
+    it('should return null when snapshot is not loaded', () => {
+      const result = MassifCoordinatesSnapshotService.getCoordinates(
+        40,
+        5,
+        45,
+        10
+      );
+      should(result).be.null();
+    });
+
+    it('should trigger background refresh when TTL expired', async () => {
+      sails.config.custom.coordinatesSnapshotTTL = 0.001;
+
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+
+      queryStub.resetHistory();
+      MassifCoordinatesSnapshotService.getCoordinates(40, 5, 45, 10);
+
+      should(queryStub.calledOnce).be.true();
+    });
+  });
+
+  describe('single-flight guard', () => {
+    it('should not trigger concurrent refreshes', async () => {
+      sails.config.custom.coordinatesSnapshotTTL = 0.001;
+
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+
+      let resolveSecond;
+      queryStub.restore();
+      queryStub = sinon.stub(CommonService, 'query').returns(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        })
+      );
+
+      MassifCoordinatesSnapshotService.getCoordinates(-90, -180, 90, 180);
+      should(queryStub.calledOnce).be.true();
+
+      MassifCoordinatesSnapshotService.getCoordinates(-90, -180, 90, 180);
+      should(queryStub.calledOnce).be.true();
+
+      resolveSecond({ rows: sampleRows });
+    });
+  });
+
+  describe('clear()', () => {
+    it('should trigger refresh without nullifying snapshot', async () => {
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+      queryStub.restore();
+
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      MassifCoordinatesSnapshotService.clear();
+
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.true();
+      const result = MassifCoordinatesSnapshotService.getCoordinates(
+        -90,
+        -180,
+        90,
+        180
+      );
+      should(result).be.an.Array();
+      should(result).have.length(3);
+
+      should(queryStub.calledOnce).be.true();
+      should(MassifCoordinatesSnapshotService.getLastRefreshedAt()).be.null();
+    });
+  });
+
+  describe('isLoaded()', () => {
+    it('should return false when not loaded', () => {
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.false();
+    });
+
+    it('should return true after load', async () => {
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.true();
+    });
+  });
+
+  describe('reset()', () => {
+    it('should clear all state', async () => {
+      queryStub = sinon
+        .stub(CommonService, 'query')
+        .resolves({ rows: sampleRows });
+      await MassifCoordinatesSnapshotService.load();
+
+      MassifCoordinatesSnapshotService.reset();
+
+      should(MassifCoordinatesSnapshotService.isLoaded()).be.false();
+      should(MassifCoordinatesSnapshotService.getLastRefreshedAt()).be.null();
+      should(
+        MassifCoordinatesSnapshotService.getCoordinates(-90, -180, 90, 180)
+      ).be.null();
+    });
+  });
+});

--- a/test/integration/4_routes/Entrances/import-rows.test.js
+++ b/test/integration/4_routes/Entrances/import-rows.test.js
@@ -167,10 +167,10 @@ describe('Entrance features', () => {
       should(bootstrapSource).containEql('.load()');
     });
 
-    it('should call clear() after successful entrance import', async () => {
-      const clearSpy = sinon.spy(
+    it('should call invalidate() after successful entrance import', async () => {
+      const invalidateSpy = sinon.spy(
         sails.services.coordinatessnapshotservice,
-        'clear'
+        'invalidate'
       );
 
       const res = await supertest(sails.hooks.http.app)
@@ -195,14 +195,14 @@ describe('Entrance features', () => {
         .expect(200);
 
       if (res.body.successfulImport.length > 0) {
-        should(clearSpy.calledOnce).be.true();
+        should(invalidateSpy.calledOnce).be.true();
       }
     });
 
-    it('should NOT call clear() when no entrances were imported', async () => {
-      const clearSpy = sinon.spy(
+    it('should NOT call invalidate() when no entrances were imported', async () => {
+      const invalidateSpy = sinon.spy(
         sails.services.coordinatessnapshotservice,
-        'clear'
+        'invalidate'
       );
 
       await supertest(sails.hooks.http.app)
@@ -213,7 +213,7 @@ describe('Entrance features', () => {
         .set('Accept', 'application/json')
         .expect(200);
 
-      should(clearSpy.called).be.false();
+      should(invalidateSpy.called).be.false();
     });
   });
 });

--- a/test/integration/4_routes/Geoloc.test.js
+++ b/test/integration/4_routes/Geoloc.test.js
@@ -1,6 +1,7 @@
 const supertest = require('supertest');
 const should = require('should');
 const fc = require('fast-check');
+const CommonService = require('../../../api/services/CommonService');
 
 describe('Geoloc features', () => {
   describe('find entrances', () => {
@@ -288,6 +289,202 @@ describe('Geoloc features', () => {
     });
   });
 
+  describe('find massifs coordinates', () => {
+    it('should return code 400 on missing parameter(s)', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifsCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 0,
+          sw_lng: 0,
+          ne_lng: 5,
+        })
+        .expect(400, done);
+    });
+
+    it('should return code 200 with valid bbox', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifsCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          res.body.length.should.be.above(0);
+          res.body.forEach((coord) => {
+            coord.should.be.Array();
+            coord.length.should.equal(2);
+            should(coord[0]).be.a.Number();
+            should(coord[1]).be.a.Number();
+          });
+          return done();
+        });
+    });
+
+    it('should return empty array for no-match bbox', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifsCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: -80,
+          sw_lng: -170,
+          ne_lat: -79,
+          ne_lng: -169,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          res.body.length.should.equal(0);
+          return done();
+        });
+    });
+
+    it('should be accessible without authentication', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifsCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200, done);
+    });
+
+    it('should include Cache-Control header on success', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifsCoordinates')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.headers['cache-control']).match(/^public, max-age=\d+$/);
+          return done();
+        });
+    });
+  });
+
+  describe('find massifs polygons', () => {
+    it('should return code 400 on missing parameter(s)', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifs')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 0,
+          sw_lng: 0,
+          ne_lng: 5,
+        })
+        .expect(400, done);
+    });
+
+    it('should return code 200 with valid bbox and correct shape', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifs')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          res.body.length.should.be.above(0);
+          const massif = res.body[0];
+          should(massif).have.property('id');
+          should(massif).have.property('name');
+          should(massif).have.property('geogPolygon');
+          should(massif).have.property('entranceCount');
+          should(massif).have.property('networkCount');
+          should(massif.id).be.a.Number();
+          should(massif.geogPolygon).be.an.Object();
+          should(massif.geogPolygon).have.property('type');
+          should(massif.entranceCount).be.a.Number();
+          should(massif.networkCount).be.a.Number();
+          return done();
+        });
+    });
+
+    it('should return geogPolygon as parsed object, not string', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifs')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.forEach((massif) => {
+            should(massif.geogPolygon).be.an.Object();
+            should(massif.geogPolygon).not.be.a.String();
+          });
+          return done();
+        });
+    });
+
+    it('should return empty array for no-match bbox', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifs')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: -80,
+          sw_lng: -170,
+          ne_lat: -79,
+          ne_lng: -169,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          res.body.length.should.equal(0);
+          return done();
+        });
+    });
+
+    it('should be accessible without authentication', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/massifs')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 50,
+          sw_lng: 50,
+          ne_lat: 75,
+          ne_lng: 110,
+        })
+        .expect(200, done);
+    });
+  });
+
   // Sails shallow-copies service exports when registering them, so a plain
   // require() returns a different object than the one the controller uses.
   // We access the Sails-registered instance via sails.services to share state.
@@ -530,6 +727,504 @@ describe('Geoloc features', () => {
               should(lng).be.aboveOrEqual(swLng);
               should(lng).be.belowOrEqual(neLng);
             });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 1: Centroid computation correctness
+   * For any bounding box overlapping massif 1's polygon area, each returned
+   * centroid matches the ST_Centroid value computed directly by PostGIS.
+   * Covers: Requirements 1.1, 1.2
+   */
+  describe('Property 1: Centroid computation correctness', () => {
+    // eslint-disable-next-line func-names
+    it('should return centroids matching direct ST_Centroid query', async function () {
+      this.timeout(60000);
+
+      // Massif 1 polygon spans roughly lat 53-74, lng 52-108
+      const boundingBoxArb = fc
+        .tuple(
+          fc
+            .double({ min: 50, max: 70, noNaN: true })
+            .chain((swLat) =>
+              fc
+                .double({ min: swLat + 1, max: 75, noNaN: true })
+                .map((neLat) => [swLat, neLat])
+            ),
+          fc
+            .double({ min: 50, max: 100, noNaN: true })
+            .chain((swLng) =>
+              fc
+                .double({ min: swLng + 1, max: 110, noNaN: true })
+                .map((neLng) => [swLng, neLng])
+            )
+        )
+        .map(([[swLat, neLat], [swLng, neLng]]) => ({
+          swLat,
+          swLng,
+          neLat,
+          neLng,
+        }));
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ({ swLat, swLng, neLat, neLng }) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/massifsCoordinates')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+              })
+              .expect(200);
+
+            const coordinates = res.body;
+            if (coordinates.length === 0) return;
+
+            // Reference query: get all centroids in this bbox directly
+            const ref = await CommonService.query(
+              `SELECT
+               ST_X(ST_Centroid(m.geog_polygon::geometry)) AS longitude,
+               ST_Y(ST_Centroid(m.geog_polygon::geometry)) AS latitude
+             FROM t_massif AS m
+             WHERE m.is_deleted = false
+               AND m.geog_polygon IS NOT NULL
+               AND ST_Within(
+                 ST_Centroid(m.geog_polygon::geometry),
+                 ST_MakeEnvelope($1, $2, $3, $4, 4326)
+               )`,
+              [swLng, swLat, neLng, neLat]
+            );
+
+            const refCoords = ref.rows.map((r) => [
+              Number(r.longitude),
+              Number(r.latitude),
+            ]);
+
+            should(coordinates.length).equal(refCoords.length);
+            coordinates.forEach(([lng, lat]) => {
+              const match = refCoords.find(
+                ([rLng, rLat]) =>
+                  Math.abs(rLng - lng) < 1e-6 && Math.abs(rLat - lat) < 1e-6
+              );
+              should(match).not.be.undefined();
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 5: Polygon response shape and GeoJSON parsing
+   * For any valid bounding box, every massif in the response has all required
+   * fields with correct types and geogPolygon is a parsed object.
+   * Covers: Requirements 3.3, 3.4
+   */
+  describe('Property 5: Polygon response shape and GeoJSON parsing', () => {
+    // eslint-disable-next-line func-names
+    it('should return correctly shaped massif objects for random bboxes', async function () {
+      this.timeout(60000);
+
+      const boundingBoxArb = fc
+        .tuple(
+          fc
+            .double({ min: -90, max: 89, noNaN: true })
+            .chain((swLat) =>
+              fc
+                .double({ min: swLat + 0.1, max: 90, noNaN: true })
+                .map((neLat) => [swLat, neLat])
+            ),
+          fc
+            .double({ min: -180, max: 179, noNaN: true })
+            .chain((swLng) =>
+              fc
+                .double({ min: swLng + 0.1, max: 180, noNaN: true })
+                .map((neLng) => [swLng, neLng])
+            )
+        )
+        .map(([[swLat, neLat], [swLng, neLng]]) => ({
+          swLat,
+          swLng,
+          neLat,
+          neLng,
+        }));
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ({ swLat, swLng, neLat, neLng }) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/massifs')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+              })
+              .expect(200);
+
+            res.body.should.be.Array();
+            res.body.forEach((massif) => {
+              should(massif).have.property('id');
+              should(massif.id).be.a.Number();
+              should(massif).have.property('name');
+              should(massif).have.property('geogPolygon');
+              should(massif.geogPolygon).be.an.Object();
+              should(massif.geogPolygon).have.property('type');
+              should(massif).have.property('entranceCount');
+              should(massif.entranceCount).be.a.Number();
+              should(massif).have.property('networkCount');
+              should(massif.networkCount).be.a.Number();
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 7: Polygon spatial intersection
+   * For any valid bounding box, every returned massif's polygon intersects
+   * the requested bbox (verified via a reference ST_Intersects query).
+   * Covers: Requirements 3.1
+   */
+  describe('Property 7: Polygon spatial intersection', () => {
+    // eslint-disable-next-line func-names
+    it('should only return massifs whose polygon intersects the bbox', async function () {
+      this.timeout(60000);
+
+      const boundingBoxArb = fc
+        .tuple(
+          fc
+            .double({ min: 50, max: 70, noNaN: true })
+            .chain((swLat) =>
+              fc
+                .double({ min: swLat + 1, max: 75, noNaN: true })
+                .map((neLat) => [swLat, neLat])
+            ),
+          fc
+            .double({ min: 50, max: 100, noNaN: true })
+            .chain((swLng) =>
+              fc
+                .double({ min: swLng + 1, max: 110, noNaN: true })
+                .map((neLng) => [swLng, neLng])
+            )
+        )
+        .map(([[swLat, neLat], [swLng, neLng]]) => ({
+          swLat,
+          swLng,
+          neLat,
+          neLng,
+        }));
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ({ swLat, swLng, neLat, neLng }) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/massifs')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+              })
+              .expect(200);
+
+            await Promise.all(
+              res.body.map(async (massif) => {
+                const ref = await CommonService.query(
+                  `SELECT ST_Intersects(
+                   m.geog_polygon::geometry,
+                   ST_MakeEnvelope($1, $2, $3, $4, 4326)
+                 ) AS intersects
+                 FROM t_massif AS m
+                 WHERE m.id = $5`,
+                  [swLng, swLat, neLng, neLat, massif.id]
+                );
+                should(ref.rows.length).equal(1);
+                should(ref.rows[0].intersects).be.true();
+              })
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 8: Invalid bounding box rejection
+   * For any request with missing params or out-of-range lat/lng,
+   * the endpoint returns HTTP 400.
+   * Covers: Requirements 4.1, 4.2, 4.3
+   */
+  describe('Property 8: Invalid bounding box rejection', () => {
+    // eslint-disable-next-line func-names
+    it('should return 400 for random invalid bbox params on massifsCoordinates', async function () {
+      this.timeout(60000);
+
+      // Strategy: generate objects that are missing at least one param
+      // or have out-of-range values
+      const missingParamArb = fc
+        .subarray(['sw_lat', 'sw_lng', 'ne_lat', 'ne_lng'], {
+          minLength: 1,
+          maxLength: 3,
+        })
+        .map((presentKeys) => {
+          const query = {};
+          if (presentKeys.includes('sw_lat')) query.sw_lat = 0;
+          if (presentKeys.includes('sw_lng')) query.sw_lng = 0;
+          if (presentKeys.includes('ne_lat')) query.ne_lat = 5;
+          if (presentKeys.includes('ne_lng')) query.ne_lng = 5;
+          return query;
+        });
+
+      const outOfRangeArb = fc.record({
+        sw_lat: fc.oneof(
+          fc.integer({ min: -200, max: -91 }),
+          fc.integer({ min: 91, max: 200 })
+        ),
+        sw_lng: fc.integer({ min: -180, max: 180 }),
+        ne_lat: fc.oneof(
+          fc.integer({ min: -200, max: -91 }),
+          fc.integer({ min: 91, max: 200 })
+        ),
+        ne_lng: fc.integer({ min: -180, max: 180 }),
+      });
+
+      const invalidArb = fc.oneof(missingParamArb, outOfRangeArb);
+
+      await fc.assert(
+        fc.asyncProperty(invalidArb, async (query) => {
+          await supertest(sails.hooks.http.app)
+            .get('/api/v1/geoloc/massifsCoordinates')
+            .query(query)
+            .expect(400);
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    // eslint-disable-next-line func-names
+    it('should return 400 for random invalid bbox params on massifs', async function () {
+      this.timeout(60000);
+
+      const missingParamArb = fc
+        .subarray(['sw_lat', 'sw_lng', 'ne_lat', 'ne_lng'], {
+          minLength: 1,
+          maxLength: 3,
+        })
+        .map((presentKeys) => {
+          const query = {};
+          if (presentKeys.includes('sw_lat')) query.sw_lat = 0;
+          if (presentKeys.includes('sw_lng')) query.sw_lng = 0;
+          if (presentKeys.includes('ne_lat')) query.ne_lat = 5;
+          if (presentKeys.includes('ne_lng')) query.ne_lng = 5;
+          return query;
+        });
+
+      const outOfRangeArb = fc.record({
+        sw_lat: fc.oneof(
+          fc.integer({ min: -200, max: -91 }),
+          fc.integer({ min: 91, max: 200 })
+        ),
+        sw_lng: fc.integer({ min: -180, max: 180 }),
+        ne_lat: fc.oneof(
+          fc.integer({ min: -200, max: -91 }),
+          fc.integer({ min: 91, max: 200 })
+        ),
+        ne_lng: fc.integer({ min: -180, max: 180 }),
+      });
+
+      const invalidArb = fc.oneof(missingParamArb, outOfRangeArb);
+
+      await fc.assert(
+        fc.asyncProperty(invalidArb, async (query) => {
+          await supertest(sails.hooks.http.app)
+            .get('/api/v1/geoloc/massifs')
+            .query(query)
+            .expect(400);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 9: Polygon field correctness
+   * For any bounding box overlapping fixture data, the name matches the
+   * reference t_name query, entranceCount and networkCount match reference
+   * count queries.
+   * Covers: Requirements 5.1, 6.1, 6.2
+   */
+  describe('Property 9: Polygon field correctness', () => {
+    // eslint-disable-next-line func-names
+    it('should return correct name, entranceCount, and networkCount', async function () {
+      this.timeout(60000);
+
+      // Focus on bboxes overlapping massif 1
+      const boundingBoxArb = fc
+        .tuple(
+          fc
+            .double({ min: 50, max: 70, noNaN: true })
+            .chain((swLat) =>
+              fc
+                .double({ min: swLat + 1, max: 75, noNaN: true })
+                .map((neLat) => [swLat, neLat])
+            ),
+          fc
+            .double({ min: 50, max: 100, noNaN: true })
+            .chain((swLng) =>
+              fc
+                .double({ min: swLng + 1, max: 110, noNaN: true })
+                .map((neLng) => [swLng, neLng])
+            )
+        )
+        .map(([[swLat, neLat], [swLng, neLng]]) => ({
+          swLat,
+          swLng,
+          neLat,
+          neLng,
+        }));
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ({ swLat, swLng, neLat, neLng }) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/massifs')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+              })
+              .expect(200);
+
+            await Promise.all(
+              res.body.map(async (massif) => {
+                // Verify name against t_name
+                const nameRef = await CommonService.query(
+                  `SELECT n.name FROM t_name AS n
+               WHERE n.id_massif = $1 AND n.is_main = true
+               LIMIT 1`,
+                  [massif.id]
+                );
+                const expectedName =
+                  nameRef.rows.length > 0 ? nameRef.rows[0].name : null;
+                should(massif.name).equal(expectedName);
+
+                // Verify entranceCount
+                const entranceRef = await CommonService.query(
+                  `SELECT COUNT(e.id)::integer AS cnt
+               FROM t_entrance AS e
+               WHERE e.is_deleted = false
+                 AND ST_Contains(
+                   (SELECT m.geog_polygon::geometry FROM t_massif AS m WHERE m.id = $1),
+                   e.point_geom
+                 )`,
+                  [massif.id]
+                );
+                should(massif.entranceCount).equal(entranceRef.rows[0].cnt);
+
+                // Verify networkCount
+                const networkRef = await CommonService.query(
+                  `SELECT COUNT(*)::integer AS cnt FROM (
+                 SELECT c.id
+                 FROM t_entrance AS e
+                 JOIN t_cave AS c ON c.id = e.id_cave
+                 WHERE e.is_deleted = false
+                   AND c.is_deleted = false
+                   AND ST_Contains(
+                     (SELECT m.geog_polygon::geometry FROM t_massif AS m WHERE m.id = $1),
+                     e.point_geom
+                   )
+                 GROUP BY c.id
+                 HAVING COUNT(e.id) > 1
+               ) AS networks`,
+                  [massif.id]
+                );
+                should(massif.networkCount).equal(networkRef.rows[0].cnt);
+              })
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 6: Polygon exclusion filtering
+   * For each massif returned by the endpoint, the source massif in the
+   * database is non-deleted and has a non-null geog_polygon.
+   * Covers: Requirements 3.5, 3.6
+   */
+  describe('Property 6: Polygon exclusion filtering', () => {
+    // eslint-disable-next-line func-names
+    it('should only return non-deleted massifs with non-null polygons', async function () {
+      this.timeout(60000);
+
+      const boundingBoxArb = fc
+        .tuple(
+          fc
+            .double({ min: -90, max: 89, noNaN: true })
+            .chain((swLat) =>
+              fc
+                .double({ min: swLat + 0.1, max: 90, noNaN: true })
+                .map((neLat) => [swLat, neLat])
+            ),
+          fc
+            .double({ min: -180, max: 179, noNaN: true })
+            .chain((swLng) =>
+              fc
+                .double({ min: swLng + 0.1, max: 180, noNaN: true })
+                .map((neLng) => [swLng, neLng])
+            )
+        )
+        .map(([[swLat, neLat], [swLng, neLng]]) => ({
+          swLat,
+          swLng,
+          neLat,
+          neLng,
+        }));
+
+      await fc.assert(
+        fc.asyncProperty(
+          boundingBoxArb,
+          async ({ swLat, swLng, neLat, neLng }) => {
+            const res = await supertest(sails.hooks.http.app)
+              .get('/api/v1/geoloc/massifs')
+              .query({
+                sw_lat: swLat,
+                sw_lng: swLng,
+                ne_lat: neLat,
+                ne_lng: neLng,
+              })
+              .expect(200);
+
+            await Promise.all(
+              res.body.map(async (massif) => {
+                const ref = await CommonService.query(
+                  `SELECT m.is_deleted, m.geog_polygon IS NOT NULL AS has_polygon
+               FROM t_massif AS m WHERE m.id = $1`,
+                  [massif.id]
+                );
+                should(ref.rows.length).equal(1);
+                should(ref.rows[0].is_deleted).be.false();
+                should(ref.rows[0].has_polygon).be.true();
+              })
+            );
           }
         ),
         { numRuns: 100 }


### PR DESCRIPTION
## 🤔 What

Add two new public geolocation endpoints for massif map data:

- `GET /api/v1/geoloc/massifsCoordinates` — massif centroid coordinates for the hexbin heatmap at low zoom levels, backed by an in-memory snapshot cache
- `GET /api/v1/geoloc/massifs` — massif polygon geometries with popup metadata (name, entrance count, network count) for higher zoom levels

Closes #1497

## 🤷‍♂️ Why

The front-end map needs massif geometry data to render massif layers. At low zoom, centroids feed the hexbin heatmap. At higher zoom, full polygons with metadata enable clickable massif overlays with popup information.

## 🔍 How

### Service layer
- Added `getMassifsCoordinates()` and `getMassifsMap()` to `GeoLocService` using raw SQL with PostGIS spatial functions (`ST_Centroid`, `ST_Within`, `ST_Intersects`, `ST_AsGeoJSON`, `ST_Contains`)
- Created `MassifCoordinatesSnapshotService` mirroring `CoordinatesSnapshotService` — in-memory cache with stale-while-revalidate and single-flight guard
- The polygon query uses a single SQL statement with correlated subqueries for entrance/network counts and a `LEFT JOIN t_name` for the main name

### Controllers
- `find-massifs-coordinates.js`: snapshot-first with DB fallback, `Cache-Control` header
- `find-massifs.js`: direct DB query via `GeoLocService.getMassifsMap()`
- Both use `GeoLocService.checkAndGetCoordinatesParams()` for bbox validation
- Public access (`true` policy), no authentication required

### OpenAPI
- Added both endpoint definitions to `assets/swaggerV1.yaml` with full request/response schemas

## 🧪 Testing

```bash
PORT=1338 npm run test
```

New tests added (10 integration + 9 property tests):

**Route integration tests** (`test/integration/4_routes/Geoloc.test.js`):
- massifsCoordinates: 400 on missing params, 200 with valid bbox, empty array for no-match, no-auth access, Cache-Control header
- massifs: 400 on missing params, 200 with correct shape, geogPolygon is parsed object, empty array for no-match, no-auth access

**Property tests** (fast-check, 100 runs each):
- Property 1: Centroid computation matches direct ST_Centroid query
- Property 5: Response shape and GeoJSON parsing correctness
- Property 6: Only non-deleted massifs with non-null polygons returned
- Property 7: Every returned polygon intersects the requested bbox
- Property 8: Invalid bbox params rejected with 400
- Property 9: Name, entranceCount, networkCount match reference queries

**Service property tests** (`test/integration/1_services/`):
- Property 2: Centroid exclusion filtering
- Property 3: Snapshot bbox filter correctness
- Property 4: Snapshot load and stale-while-revalidate

## 📸 Previews

N/A — backend-only changes.
