### PR TITLE
fix(auth): reject IDs exceeding PostgreSQL integer range in validateId policy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,7 @@ jobs:
       - run: npm ci
       - run: npm run build:info
       - run: npm run lint
-      - run: npm test
-      - run: npm run-script coverage
+      - run: npm run coverage
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
         with:

--- a/api/policies/validateId.js
+++ b/api/policies/validateId.js
@@ -2,15 +2,39 @@
  * validateId
  *
  * @module      :: Policy
- * @description :: Validates that the 'id' parameter is a positive integer.
- *                 Prevents Waterline errors when ID is 0 or negative.
+ * @description :: Validates that all integer ID parameters in the route are
+ *                 positive integers within PostgreSQL's 32-bit integer range.
+ *                 Prevents database adapter errors from out-of-range values.
  * @docs        :: http://sailsjs.org/#!documentation/policies
  *
  */
+const MAX_PG_INTEGER = 2147483647;
+
+const isValidId = (value) => {
+  const num = Number(value);
+  return Number.isInteger(num) && num > 0 && num <= MAX_PG_INTEGER;
+};
+
 module.exports = (req, res, next) => {
-  const id = Number(req.params.id || req.param('id'));
-  if (!Number.isInteger(id) || id <= 0) {
-    return res.notFound(`Invalid ID: ${req.params.id || req.param('id')}`);
+  // Validate all route params that look like IDs
+  const params = req.params || {};
+  const idParams = Object.entries(params).filter(
+    ([k]) => k === 'id' || k.endsWith('Id')
+  );
+
+  for (const [, value] of idParams) {
+    if (!isValidId(value)) {
+      return res.notFound(`Invalid ID: ${value}`);
+    }
   }
+
+  // Fallback: also check req.param('id') for query-based IDs
+  if (idParams.length === 0) {
+    const id = req.param('id');
+    if (id !== undefined && !isValidId(id)) {
+      return res.notFound(`Invalid ID: ${id}`);
+    }
+  }
+
   return next();
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -53,7 +53,7 @@ module.exports.policies = {
   'v1/caver/count': true,
   'v1/caver/users-count': true,
   'v1/caver/find': ['validateId'],
-  'v1/caver/get-subscriptions': true,
+  'v1/caver/get-subscriptions': ['validateId'],
   'v1/caver/add-explored-cave': 'tokenAuth',
   'v1/caver/create': 'tokenAuth',
   'v1/caver/get-groups': 'tokenAuth',

--- a/test/integration/5_policies/validateId.test.js
+++ b/test/integration/5_policies/validateId.test.js
@@ -87,4 +87,79 @@ describe('validateId policy', () => {
     should(next.calledOnce).be.true();
     should(res.notFound.called).be.false();
   });
+
+  it('should return notFound for ID exceeding PostgreSQL integer max', () => {
+    req.params.id = '36600000000';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(res.notFound.calledWith('Invalid ID: 36600000000')).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should return notFound for very large ID values', () => {
+    req.params.id = '246000000000000';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should accept the maximum valid PostgreSQL integer', () => {
+    req.params.id = '2147483647';
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
+
+  it('should reject one above the PostgreSQL integer max', () => {
+    req.params.id = '2147483648';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should validate named ID params like caverId', () => {
+    req.params.caverId = '36600000000';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should call next() for valid named ID params', () => {
+    req.params.caverId = '123';
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
+
+  it('should validate multiple named ID params', () => {
+    req.params.entranceId = '5';
+    req.params.documentId = '99999999999';
+
+    validateId(req, res, next);
+
+    should(res.notFound.calledOnce).be.true();
+    should(next.called).be.false();
+  });
+
+  it('should call next() when all named ID params are valid', () => {
+    req.params.entranceId = '5';
+    req.params.documentId = '10';
+
+    validateId(req, res, next);
+
+    should(next.calledOnce).be.true();
+    should(res.notFound.called).be.false();
+  });
 });


### PR DESCRIPTION
## 🤔 What

- Harden the `validateId` policy to reject IDs exceeding PostgreSQL's 32-bit integer max (`2,147,483,647`)
- Extend validation to all route params ending in `Id` (e.g. `caverId`, `entranceId`), not just `id`
- Add `validateId` policy to `v1/caver/get-subscriptions` which was missing it
- Remove redundant `npm test` step from CI build workflow (tests were running twice)

## 🤷‍♂️ Why

Production traces show 500 errors when users hit endpoints with out-of-range IDs like `36600000000` or `246000000000000`. These pass the existing positive-integer check but blow up at the PostgreSQL adapter level with `value "X" is out of range for type integer`. This turns what should be a clean 404 into a noisy 500.

Affected endpoints observed in production:
- `GET /api/v1/organizations/:id`
- `GET /api/v1/cavers/:id`
- `GET /api/v1/cavers/:caverId/subscriptions`

The CI workflow was also running the full test suite twice — once via `npm test` and again via `npm run coverage` — since both invoke the same mocha command. The coverage step already runs the tests under `nyc`, so the standalone test step was redundant.

## 🔍 How

- `api/policies/validateId.js`: Added `MAX_PG_INTEGER` upper bound check. The policy now scans all route params matching `id` or `*Id` pattern and validates each one. Falls back to `req.param('id')` for query-based IDs when no route params match.
- `config/policies.js`: Added `['validateId']` to `v1/caver/get-subscriptions` which previously had `true` (no validation).
- `test/integration/5_policies/validateId.test.js`: Added 8 new test cases covering overflow values, boundary values (max int, max int + 1), and named ID params (`caverId`, multi-param routes).
- `.github/workflows/build.yaml`: Removed the `npm test` step, keeping only `npm run coverage` which runs tests and generates the coverage report in a single pass.

## 🧪 Testing

```bash
PORT=1338 npm run test -- --grep "validateId"
```

All 15 tests pass (7 existing + 8 new).

## 📸 Previews

N/A — backend-only change, no UI impact.
