### PR TITLE
fix(document): set multer defParamCharset to utf8 and repair corrupted filenames

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -122,7 +122,16 @@ module.exports.http = {
     fileMiddleware: (function () {
       const inMemoryStorage = multer.memoryStorage();
       // File size is 100 Mo (Mb)
-      const upload = multer({ storage: inMemoryStorage, fileSize: 100000000 });
+      //
+      // defParamCharset: 'utf8' fixes mojibake for non-ASCII filenames.
+      // It only affects the legacy `filename=` parameter in Content-Disposition
+      // headers (RFC 2047). Modern browsers using RFC 5987 `filename*=UTF-8''…`
+      // are already decoded correctly by busboy regardless of this setting.
+      const upload = multer({
+        storage: inMemoryStorage,
+        fileSize: 100000000,
+        defParamCharset: 'utf8',
+      });
       return upload.fields([{ name: 'files' }]);
     })(),
 

--- a/sql/93_02_fix_filename_encoding.sql
+++ b/sql/93_02_fix_filename_encoding.sql
@@ -1,0 +1,50 @@
+\c grottoce;
+
+-- Fix Latin-1/UTF-8 mojibake in t_file.filename
+--
+-- Multer's default defParamCharset was 'latin1', causing UTF-8 filenames
+-- to be misinterpreted as Latin-1 before storage. This migration re-encodes
+-- the corrupted bytes back to proper UTF-8.
+--
+-- How it works:
+--   convert_to(filename, 'LATIN1') — treats each character as a Latin-1 code
+--     point and emits the corresponding byte (reversing the original mis-decode)
+--   convert_from(..., 'UTF8') — re-interprets those bytes as UTF-8
+--
+-- Safety:
+--   - ASCII-only filenames are unchanged (ASCII is identical in both encodings)
+--   - The WHERE clause makes this idempotent (no-op on already-fixed rows)
+--   - Rows with characters outside Latin-1 range (e.g. CJK already stored
+--     correctly) will fail convert_to(..., 'LATIN1'), so we skip them
+--     gracefully using a PL/pgSQL block with EXCEPTION handling.
+
+BEGIN;
+
+DO $$
+DECLARE
+  rec RECORD;
+  fixed_name TEXT;
+BEGIN
+  FOR rec IN
+    SELECT id, filename
+    FROM t_file
+    WHERE filename ~ '[^\x00-\x7F]'
+  LOOP
+    BEGIN
+      fixed_name := convert_from(convert_to(rec.filename, 'LATIN1'), 'UTF8');
+      -- 200-char guard matches t_file.filename varchar(200) / Waterline maxLength: 200.
+      -- In practice, UTF-8 re-encoding produces shorter strings (multi-byte mojibake
+      -- chars collapse back to single code points), so this is a safety net, not a filter.
+      IF fixed_name IS DISTINCT FROM rec.filename
+         AND length(fixed_name) <= 200
+      THEN
+        UPDATE t_file SET filename = fixed_name WHERE id = rec.id;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      -- Skip rows where conversion fails (characters outside Latin-1 range)
+      RAISE NOTICE 'Skipping t_file id=% filename=%: %', rec.id, rec.filename, SQLERRM;
+    END;
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/test/integration/1_services/FileService.encoding.property.test.js
+++ b/test/integration/1_services/FileService.encoding.property.test.js
@@ -1,0 +1,362 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const FileService = require('../../../api/services/FileService');
+
+/**
+ * Bug Condition Exploration — Non-ASCII Filename Mojibake
+ *
+ * Demonstrates that multer's default `defParamCharset: 'latin1'` causes
+ * UTF-8 filenames to be misinterpreted as Latin-1, producing mojibake.
+ *
+ * The bug lives in the multer middleware layer (config/http.js), not in
+ * FileService itself. FileService is a passthrough — it stores whatever
+ * `file.originalname` it receives. When multer decodes UTF-8 bytes as
+ * Latin-1, the garbled string flows through FileService into the database.
+ *
+ * These tests use concrete counterexamples to surface the encoding problem.
+ *
+ * Validates: Requirements 1.1, 1.2, 2.1, 2.2
+ */
+describe('FileService — Property 1: Bug Condition — Non-ASCII Filename Mojibake', () => {
+  // -------------------------------------------------------------------------
+  // Test 1: Pure encoding demonstration (no DB)
+  // Shows that UTF-8 bytes decoded as Latin-1 produce mojibake.
+  // -------------------------------------------------------------------------
+  describe('UTF-8 bytes decoded as Latin-1 produce mojibake', () => {
+    const cases = [
+      { original: 'Entrée.pdf', expectedMojibake: 'EntrÃ©e.pdf' },
+      { original: 'Höhle.pdf', expectedMojibake: 'HÃ¶hle.pdf' },
+      { original: 'über.pdf', expectedMojibake: 'Ã¼ber.pdf' },
+      { original: 'café.pdf', expectedMojibake: 'cafÃ©.pdf' },
+    ];
+
+    cases.forEach(({ original, expectedMojibake }) => {
+      it(`should garble "${original}" into "${expectedMojibake}" when decoded as Latin-1`, () => {
+        // Simulate what multer does: take UTF-8 string, get its bytes,
+        // then decode those bytes as Latin-1
+        const utf8Bytes = Buffer.from(original, 'utf8');
+        const mojibake = utf8Bytes.toString('latin1');
+
+        // The mojibake should NOT equal the original
+        should(mojibake).not.equal(
+          original,
+          `Latin-1 decoding of UTF-8 bytes should produce mojibake, but got the original back`
+        );
+
+        // The mojibake should match the expected garbled string
+        should(mojibake).equal(
+          expectedMojibake,
+          `Expected mojibake "${expectedMojibake}" but got "${mojibake}"`
+        );
+
+        // The mojibake string is longer because multi-byte UTF-8 chars
+        // expand to multiple Latin-1 characters
+        should(mojibake.length).be.above(
+          original.length,
+          'Mojibake string should be longer than the original'
+        );
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: FileService stores whatever originalname it receives
+  // Shows that the service is a passthrough — no encoding correction.
+  // -------------------------------------------------------------------------
+  describe('FileService stores whatever originalname it receives (passthrough)', () => {
+    // idDocument=1 exists in test/fixtures/tdocument.json (fixture: "Spelunca [COLLECTION]")
+    const idDocument = 1;
+
+    it('should store a mojibake filename as-is when multer provides it', async () => {
+      // Simulate multer's Latin-1 decoding of a UTF-8 filename
+      const originalUtf8 = 'Entrée.pdf';
+      const mojibake = Buffer.from(originalUtf8, 'utf8').toString('latin1');
+
+      const file = {
+        originalname: mojibake, // multer would provide this garbled name
+        buffer: Buffer.from('test'),
+        size: 100,
+      };
+
+      let createdFile;
+      try {
+        createdFile = await FileService.document.create(file, idDocument, true);
+
+        // FileService stores the mojibake without correction
+        should(createdFile.fileName).equal(
+          mojibake,
+          'FileService should store the mojibake filename as-is'
+        );
+
+        // The stored filename is NOT the correct Unicode original
+        should(createdFile.fileName).not.equal(
+          originalUtf8,
+          'Stored filename should not match the original UTF-8 name (bug present)'
+        );
+      } finally {
+        if (createdFile) {
+          await TFile.destroyOne(createdFile.id);
+        }
+      }
+    });
+
+    it('should store a correct UTF-8 filename as-is when provided directly', async () => {
+      const originalUtf8 = 'Entrée.pdf';
+
+      const file = {
+        originalname: originalUtf8, // correct UTF-8 name (as if multer decoded properly)
+        buffer: Buffer.from('test'),
+        size: 100,
+      };
+
+      let createdFile;
+      try {
+        createdFile = await FileService.document.create(file, idDocument, true);
+
+        // FileService stores the correct name when given the correct name
+        should(createdFile.fileName).equal(
+          originalUtf8,
+          'FileService should store the correct UTF-8 filename when provided'
+        );
+      } finally {
+        if (createdFile) {
+          await TFile.destroyOne(createdFile.id);
+        }
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: Mojibake filename in DB does NOT equal the original Unicode name
+  // This is the core bug demonstration — the round-trip is broken.
+  // -------------------------------------------------------------------------
+  describe('mojibake filename stored in DB does not equal original Unicode', () => {
+    // idDocument=1 exists in test/fixtures/tdocument.json (fixture: "Spelunca [COLLECTION]")
+    const idDocument = 1;
+
+    const nonAsciiFilenames = [
+      'Entrée.pdf',
+      'Höhle.pdf',
+      'über.pdf',
+      'café.pdf',
+      'señor.pdf',
+    ];
+
+    nonAsciiFilenames.forEach((originalUtf8) => {
+      it(`should demonstrate broken round-trip for "${originalUtf8}"`, async () => {
+        // Simulate multer's Latin-1 decoding
+        const mojibake = Buffer.from(originalUtf8, 'utf8').toString('latin1');
+
+        const file = {
+          originalname: mojibake,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+
+          // The stored filename is the mojibake, not the original
+          should(createdFile.fileName).equal(mojibake);
+          should(createdFile.fileName).not.equal(
+            originalUtf8,
+            `Round-trip broken: stored "${createdFile.fileName}" instead of "${originalUtf8}"`
+          );
+
+          // Verify by reading back from DB
+          const dbRecord = await TFile.findOne(createdFile.id);
+          should(dbRecord.fileName).not.equal(
+            originalUtf8,
+            `DB record contains mojibake "${dbRecord.fileName}" instead of "${originalUtf8}"`
+          );
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      });
+    });
+  });
+});
+
+/**
+ * Property 2: Preservation — ASCII-Only Filename and Record Field Integrity
+ *
+ * Verifies that ASCII-only filenames are stored correctly and that all
+ * non-filename fields (path, isValidated, fileFormat, URL) behave as expected.
+ * These tests MUST PASS on unfixed code — passing confirms baseline behavior
+ * that the encoding fix must preserve.
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4
+ */
+describe('FileService — Property 2: Preservation — ASCII-Only Filename and Record Field Integrity', () => {
+  // Arbitrary: ASCII-only filenames without dots or empty strings
+  const asciiFilename = fc.stringMatching(/^[a-zA-Z0-9_-]{1,50}$/);
+
+  // idDocument=1 exists in test/fixtures/tdocument.json (fixture: "Spelunca [COLLECTION]")
+  const idDocument = 1;
+
+  it('should store ASCII-only filenames exactly as provided', function () {
+    this.timeout(30000);
+    return fc.assert(
+      fc.asyncProperty(asciiFilename, async (name) => {
+        const fullName = `${name}.pdf`;
+        const file = {
+          originalname: fullName,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+          should(createdFile.fileName).equal(
+            fullName,
+            `fileName should be stored exactly as "${fullName}"`
+          );
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should generate path matching {digits}-{filename_underscored}', function () {
+    this.timeout(30000);
+    return fc.assert(
+      fc.asyncProperty(asciiFilename, async (name) => {
+        const fullName = `${name}.pdf`;
+        const file = {
+          originalname: fullName,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+          const expectedUnderscored = fullName.replace(/ /g, '_');
+          const escapedFilename = expectedUnderscored.replace(
+            /[.*+?^${}()|[\]\\]/g,
+            '\\$&'
+          );
+          const pathPattern = new RegExp(`^\\d+-${escapedFilename}$`);
+          should(createdFile.path).match(
+            pathPattern,
+            `path "${createdFile.path}" should match pattern {digits}-{filename_underscored}`
+          );
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should default isValidated to true', function () {
+    this.timeout(10000);
+    return fc.assert(
+      fc.asyncProperty(asciiFilename, async (name) => {
+        const fullName = `${name}.pdf`;
+        const file = {
+          originalname: fullName,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+          should(createdFile.isValidated).equal(
+            true,
+            'isValidated should default to true'
+          );
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      }),
+      { numRuns: 20 }
+    );
+  });
+
+  it('should set fileFormat to a number', function () {
+    this.timeout(10000);
+    return fc.assert(
+      fc.asyncProperty(asciiFilename, async (name) => {
+        const fullName = `${name}.pdf`;
+        const file = {
+          originalname: fullName,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+          should(createdFile.fileFormat).be.a.Number();
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      }),
+      { numRuns: 20 }
+    );
+  });
+
+  it('should produce a getUrl containing the Azure documents base URL', function () {
+    this.timeout(10000);
+    return fc.assert(
+      fc.asyncProperty(asciiFilename, async (name) => {
+        const fullName = `${name}.pdf`;
+        const file = {
+          originalname: fullName,
+          buffer: Buffer.from('test'),
+          size: 100,
+        };
+        let createdFile;
+        try {
+          createdFile = await FileService.document.create(
+            file,
+            idDocument,
+            true
+          );
+          const url = FileService.document.getUrl(createdFile.path);
+          should(url).containEql(
+            'grottocenter.blob.core.windows.net/documents/'
+          );
+        } finally {
+          if (createdFile) {
+            await TFile.destroyOne(createdFile.id);
+          }
+        }
+      }),
+      { numRuns: 20 }
+    );
+  });
+});

--- a/test/integration/4_routes/Documents/create-with-encoding.test.js
+++ b/test/integration/4_routes/Documents/create-with-encoding.test.js
@@ -1,0 +1,55 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+/**
+ * E2E test verifying that the multer `defParamCharset: 'utf8'` fix
+ * correctly preserves non-ASCII filenames through the middleware stack.
+ *
+ * This test sends an actual multipart HTTP request with a UTF-8 filename
+ * through the full Sails middleware pipeline (multer → controller → service → DB),
+ * closing the gap identified in code review (review item #4).
+ */
+describe('Document create — non-ASCII filename encoding (E2E)', () => {
+  let userToken;
+  const createdDocIds = [];
+
+  before(async () => {
+    userToken = await AuthTokenService.getRawBearerUserToken();
+  });
+
+  after(async () => {
+    // Clean up created documents (cascades to t_file via FK)
+    await Promise.all(createdDocIds.map((id) => TDocument.destroy({ id })));
+  });
+
+  it('should preserve a UTF-8 filename through the multipart upload pipeline', async () => {
+    const utf8Filename = 'Entrée.pdf';
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/documents')
+      .field('description', 'Encoding test document')
+      .field('documentMainLanguage[id]', 'fra')
+      .field('documentType[id]', '1')
+      .field('editor[id]', '2')
+      .field('isNewDocument', 'true')
+      .field('title', 'Encoding Test')
+      .field('titleAndDescriptionLanguage[id]', 'fra')
+      .attach('files', Buffer.from('test-content'), utf8Filename)
+      .set('Authorization', userToken)
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    createdDocIds.push(res.body.document.id);
+
+    // Look up the file record that was created for this document
+    const files = await TFile.find({ document: res.body.document.id });
+    should(files).have.length(1);
+
+    // The stored filename must match the original UTF-8 name, not mojibake
+    should(files[0].fileName).equal(
+      utf8Filename,
+      `Expected "${utf8Filename}" but got "${files[0].fileName}" — defParamCharset fix may not be working`
+    );
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Fix non-ASCII filename encoding (mojibake) in file uploads
- Repair existing corrupted filenames in the database
- Closes #1503

## 🤷‍♂️ Why

Multer's default `defParamCharset` is `'latin1'`, which causes UTF-8 filenames containing accented characters (é, ü, ö, ñ, etc.) to be misinterpreted as Latin-1 before storage. For example, `Entrée.pdf` gets stored as `EntrÃ©e.pdf`.

## 🔍 How

1. **Multer config** (`config/http.js`): Added `defParamCharset: 'utf8'` to the multer options so incoming filenames are decoded as UTF-8 instead of Latin-1.

2. **SQL migration** (`sql/93_02_fix_filename_encoding.sql`): A PL/pgSQL block iterates over `t_file` rows containing non-ASCII characters and applies `convert_from(convert_to(filename, 'LATIN1'), 'UTF8')` to reverse the mojibake. Rows where conversion fails (e.g., CJK characters already stored correctly) are skipped gracefully. The migration is idempotent.

3. **Property-based tests** (`test/integration/1_services/FileService.encoding.property.test.js`):
   - Bug condition exploration tests (11 concrete cases) demonstrating the mojibake problem
   - Preservation tests (5 fast-check PBT tests) verifying ASCII-only filenames and record field integrity are unaffected

## 🧪 Testing

All 1774 existing tests pass, plus 16 new tests (11 bug condition + 5 preservation).

```bash
PORT=1338 npm run test
```

## 🚀 Deployment Procedure

1. **Deploy the code** — the multer `defParamCharset: 'utf8'` change takes effect immediately for new uploads
2. **Run the SQL migration** against the production database:
   ```bash
   psql -U <user> -h <host> -d grottoce -f sql/93_02_fix_filename_encoding.sql
   ```
   This repairs existing corrupted filenames. It is idempotent and safe to run multiple times.
3. **Frontend workaround** — the `TextDecoder` re-decode workaround in grottocenter-front can be removed after this backend fix is deployed

## 📸 Previews

N/A — backend-only change.
