### PR TITLE
feat(entrance): add data quality score to entrance detail endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     TRigging: 'readonly',
     TSubject: 'readonly',
     TType: 'readonly',
+    VDataQualityComputeEntrance: 'readonly',
     sails: 'readonly',
   },
   rules: {

--- a/api/controllers/v1/entrance/find.js
+++ b/api/controllers/v1/entrance/find.js
@@ -1,4 +1,5 @@
 const ControllerService = require('../../../services/ControllerService');
+const DataQualityComputeService = require('../../../services/DataQualityComputeService');
 const EntranceService = require('../../../services/EntranceService');
 const RightService = require('../../../services/RightService');
 const {
@@ -18,16 +19,22 @@ module.exports = async (req, res) => {
   if (!hasRight) where.isDeleted = false;
 
   const params = { searchedItem: `Entrance of id ${entranceId}` };
-  const entrance = await EntranceService.getPopulatedEntrance(
-    entranceId,
-    where
-  );
+
+  // Fetch entrance and quality data in parallel.
+  // The quality query may return null for deleted entrances (the materialized
+  // view filters is_deleted = false) or for newly created entrances not yet
+  // in the view. In 404 cases the quality result is simply discarded.
+  const [entrance, qualityRow] = await Promise.all([
+    EntranceService.getPopulatedEntrance(entranceId, where),
+    DataQualityComputeService.getEntranceQualityById(entranceId),
+  ]);
 
   if (!entrance) return res.notFound(`${params.searchedItem} not found`);
+
   return ControllerService.treatAndConvert(
     req,
     null,
-    entrance,
+    { ...entrance, qualityData: qualityRow },
     params,
     res,
     entrance.isDeleted && !hasRight ? toDeletedEntity : toEntrance

--- a/api/services/DataQualityComputeService.js
+++ b/api/services/DataQualityComputeService.js
@@ -74,6 +74,7 @@ module.exports = {
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {
+      sails.log.error(e);
       return null;
     }
   },
@@ -91,6 +92,7 @@ module.exports = {
       );
       return parseInt(queryResult.rows[0].count, 10);
     } catch (e) {
+      sails.log.error(e);
       return 0;
     }
   },
@@ -123,6 +125,7 @@ module.exports = {
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {
+      sails.log.error(e);
       return null;
     }
   },
@@ -140,6 +143,7 @@ module.exports = {
       );
       return parseInt(queryResult.rows[0].count, 10);
     } catch (e) {
+      sails.log.error(e);
       return 0;
     }
   },
@@ -172,6 +176,7 @@ module.exports = {
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {
+      sails.log.error(e);
       return null;
     }
   },
@@ -189,7 +194,26 @@ module.exports = {
       );
       return parseInt(queryResult.rows[0].count, 10);
     } catch (e) {
+      sails.log.error(e);
       return 0;
+    }
+  },
+
+  /**
+   *
+   * @param {number} entranceId
+   * @returns {Object|null} the materialized view row, or null if not found
+   */
+  getEntranceQualityById: async (entranceId) => {
+    try {
+      const queryResult = await CommonService.query(
+        'SELECT * FROM v_data_quality_compute_entrance WHERE id_entrance = $1 ORDER BY id_massif NULLS LAST LIMIT 1',
+        [entranceId]
+      );
+      return queryResult.rows[0] || null;
+    } catch (e) {
+      sails.log.error(e);
+      return null;
     }
   },
 };

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -17,7 +17,10 @@ const {
 } = require('./utils');
 const FileService = require('../FileService');
 const RiggingService = require('../RiggingService');
-const { getQualityData } = require('../../utils/computeEntranceDataQuality');
+const {
+  getQualityData,
+  getQualityBreakdown,
+} = require('../../utils/computeEntranceDataQuality');
 
 const c = {
   toCave: (source, meta) => ({
@@ -367,6 +370,17 @@ const c = {
     result.riggings = toList('riggings', source, c.toSimpleRigging, {
       filterDeleted: false,
     });
+
+    if (source.qualityData) {
+      result.dataQuality = {
+        total: getQualityData(source.qualityData),
+        categories: getQualityBreakdown(source.qualityData),
+        lastComputedAt: source.qualityData.date_of_update,
+      };
+    } else {
+      result.dataQuality = null;
+    }
+
     return result;
   },
 

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -17,7 +17,7 @@ const {
 } = require('./utils');
 const FileService = require('../FileService');
 const RiggingService = require('../RiggingService');
-const getQualityData = require('../../utils/computeEntranceDataQuality');
+const { getQualityData } = require('../../utils/computeEntranceDataQuality');
 
 const c = {
   toCave: (source, meta) => ({

--- a/api/services/mapping/models/EntranceModel.js
+++ b/api/services/mapping/models/EntranceModel.js
@@ -40,4 +40,5 @@ module.exports = {
   riggings: [],
   stats: undefined,
   timeInfo: undefined,
+  dataQuality: undefined,
 };

--- a/api/utils/computeEntranceDataQuality.js
+++ b/api/utils/computeEntranceDataQuality.js
@@ -25,27 +25,53 @@
  *      - else 0 pts
  */
 const moment = require('moment');
+
+// Categories of entrance data used for quality scoring
+const QUALITY_CATEGORIES = [
+  'general',
+  'location',
+  'description',
+  'document',
+  'rigging',
+  'history',
+  'comment',
+];
+
+// Date freshness scoring tiers
+const DATE_SCORE_RECENT = 7;
+const DATE_SCORE_MODERATE = 5;
+const DATE_SCORE_OLD = 3;
+const DATE_SCORE_VERY_OLD = 1;
+const DATE_SCORE_NONE = 0;
+
+// Contribution count scoring tiers
+const CONTRIB_SCORE_MULTIPLE = 7;
+const CONTRIB_SCORE_SINGLE = 3;
+const CONTRIB_SCORE_NONE = 0;
+
+// Age thresholds in years for date freshness scoring
+const DATE_THRESHOLD_RECENT = 2;
+const DATE_THRESHOLD_MODERATE = 5;
+const DATE_THRESHOLD_OLD = 10;
+
+// Derived max scores
+const MAX_DATE_SCORE = DATE_SCORE_RECENT;
+const MAX_CONTRIB_SCORE = CONTRIB_SCORE_MULTIPLE;
+const MAX_RAW_CATEGORY = MAX_DATE_SCORE + MAX_CONTRIB_SCORE;
+const MAX_RAW_TOTAL = QUALITY_CATEGORIES.length * MAX_RAW_CATEGORY;
+
 /**
  *
  * @param {Date} entityDate the date that we need to test
  * @returns {int} the score associated with the date
  */
 const getIndividualScoreAboutLastestDateOfUpdate = (entityDate) => {
-  const mEntityDate = moment(entityDate);
-  const now = moment();
-  if (entityDate) {
-    if (mEntityDate.isAfter(now.subtract(2, 'years'))) {
-      return 7;
-    }
-    if (mEntityDate.isAfter(now.subtract(5, 'years'))) {
-      return 5;
-    }
-    if (mEntityDate.isAfter(now.subtract(10, 'years'))) {
-      return 3;
-    }
-    return 1;
-  }
-  return 0;
+  if (!entityDate) return DATE_SCORE_NONE;
+  const ageInYears = moment().diff(moment(entityDate), 'years', true);
+  if (ageInYears < DATE_THRESHOLD_RECENT) return DATE_SCORE_RECENT;
+  if (ageInYears < DATE_THRESHOLD_MODERATE) return DATE_SCORE_MODERATE;
+  if (ageInYears < DATE_THRESHOLD_OLD) return DATE_SCORE_OLD;
+  return DATE_SCORE_VERY_OLD;
 };
 
 /**
@@ -55,75 +81,59 @@ const getIndividualScoreAboutLastestDateOfUpdate = (entityDate) => {
  */
 const getIndividualScoreAboutNbContributions = (nbContributions) => {
   if (nbContributions) {
-    // nbContributionsNumber is a string, but we want to compare with an int
     const nbContributionsNumber = Number.parseInt(nbContributions, 10);
-    if (nbContributionsNumber <= 0) {
-      return 0;
-    }
-    if (nbContributionsNumber === 1) {
-      return 3;
-    }
-    // (nbContributions >= 2)
-    return 7;
+    if (nbContributionsNumber <= 0) return CONTRIB_SCORE_NONE;
+    if (nbContributionsNumber === 1) return CONTRIB_SCORE_SINGLE;
+    return CONTRIB_SCORE_MULTIPLE;
   }
-  return 0;
+  return CONTRIB_SCORE_NONE;
 };
 
 /**
  *
  * @param {Object} entrance the entrance information to compute the quality of its data
- * @returns {int} the score associated at the entrance after the computation of the quality of its data
+ * @returns {int} the score (0–100) after normalizing the raw quality sum
  */
 const getQualityData = (entrance) => {
   let score = 0;
-
-  // calculate score related to the date of the last update
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.general_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.location_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.description_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.document_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.rigging_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.history_latest_date_of_update
-  );
-  score += getIndividualScoreAboutLastestDateOfUpdate(
-    entrance.comment_latest_date_of_update
-  );
-
-  // calculate score related to the number of contributors
-  score += getIndividualScoreAboutNbContributions(
-    entrance.general_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.location_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.description_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.document_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.rigging_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.history_nb_contributions
-  );
-  score += getIndividualScoreAboutNbContributions(
-    entrance.comment_nb_contributions
-  );
-
-  return score;
+  for (const cat of QUALITY_CATEGORIES) {
+    score += getIndividualScoreAboutLastestDateOfUpdate(
+      entrance[`${cat}_latest_date_of_update`]
+    );
+    score += getIndividualScoreAboutNbContributions(
+      entrance[`${cat}_nb_contributions`]
+    );
+  }
+  return Math.round((score / MAX_RAW_TOTAL) * 100);
 };
 
-module.exports = getQualityData;
+/**
+ *
+ * @param {Object} entrance row from v_data_quality_compute_entrance
+ * @returns {Object} per-category breakdown with 7 entity type scores (each 0–100)
+ */
+const getQualityBreakdown = (entrance) => {
+  const breakdown = {};
+  for (const cat of QUALITY_CATEGORIES) {
+    const dateScore = getIndividualScoreAboutLastestDateOfUpdate(
+      entrance[`${cat}_latest_date_of_update`]
+    );
+    const contribScore = getIndividualScoreAboutNbContributions(
+      entrance[`${cat}_nb_contributions`]
+    );
+    breakdown[cat] = Math.round(
+      ((dateScore + contribScore) / MAX_RAW_CATEGORY) * 100
+    );
+  }
+  return breakdown;
+};
+
+module.exports = {
+  QUALITY_CATEGORIES,
+  MAX_DATE_SCORE,
+  MAX_CONTRIB_SCORE,
+  MAX_RAW_CATEGORY,
+  MAX_RAW_TOTAL,
+  getQualityData,
+  getQualityBreakdown,
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -5435,6 +5435,66 @@ components:
           $ref: '#/components/schemas/Entrance-stats'
         discoveryYear:
           type: integer
+        dataQuality:
+          allOf:
+            - $ref: '#/components/schemas/DataQuality'
+          nullable: true
+
+    DataQuality:
+      type: object
+      required:
+        - total
+        - categories
+        - lastComputedAt
+      properties:
+        total:
+          type: integer
+          minimum: 0
+          maximum: 100
+        categories:
+          type: object
+          required:
+            - general
+            - location
+            - description
+            - document
+            - rigging
+            - history
+            - comment
+          properties:
+            general:
+              type: integer
+              minimum: 0
+              maximum: 100
+            location:
+              type: integer
+              minimum: 0
+              maximum: 100
+            description:
+              type: integer
+              minimum: 0
+              maximum: 100
+            document:
+              type: integer
+              minimum: 0
+              maximum: 100
+            rigging:
+              type: integer
+              minimum: 0
+              maximum: 100
+            history:
+              type: integer
+              minimum: 0
+              maximum: 100
+            comment:
+              type: integer
+              minimum: 0
+              maximum: 100
+        lastComputedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp at which the quality scores were last recomputed (materialized view refresh time).
 
     Entrance-stats:
       type: object

--- a/test/integration/2_utils/computeEntranceDataQuality.property.test.js
+++ b/test/integration/2_utils/computeEntranceDataQuality.property.test.js
@@ -8,7 +8,6 @@ const {
   getQualityBreakdown,
 } = require('../../../api/utils/computeEntranceDataQuality');
 const {
-  toEntrance,
   toQualityDataEntrance,
 } = require('../../../api/services/mapping/converters');
 
@@ -28,40 +27,28 @@ const qualityRowArb = fc.record({
 
 describe('computeEntranceDataQuality - Property Tests', () => {
   /**
-   * Property 1: Converter output completeness
+   * Property 1: Utility output completeness
    *
-   * For any materialized view row, converting an entrance source with
-   * qualityData set via toEntrance produces a dataQuality object with
-   * the correct shape: total (number), categories (7 keys), dateOfUpdate.
+   * For any materialized view row, getQualityData returns a number and
+   * getQualityBreakdown returns an object with exactly the seven category keys,
+   * each being a number.
    *
-   * Validates: Requirements 1.1, 1.2, 1.3, 2.3
+   * Validates: Requirements 1.1, 1.2, 2.3
    */
-  describe('Property 1: Converter output completeness', () => {
-    it('should produce dataQuality with total, 7 categories, and dateOfUpdate', function () {
+  describe('Property 1: Utility output completeness', () => {
+    it('should produce a numeric total and 7 numeric category scores', function () {
       this.timeout(10000);
       fc.assert(
         fc.property(qualityRowArb, (row) => {
-          const source = {
-            id: 1,
-            names: [{ name: 'Test', isMain: true, language: 'eng' }],
-            qualityData: row,
-          };
+          const total = getQualityData(row);
+          should(total).be.a.Number();
 
-          const result = toEntrance(source);
-
-          should(result).have.property('dataQuality');
-          should(result.dataQuality).not.be.null();
-          should(result.dataQuality).have.property('total');
-          should(result.dataQuality.total).be.a.Number();
-          should(result.dataQuality).have.property('categories');
-          should(Object.keys(result.dataQuality.categories)).have.length(
-            QUALITY_CATEGORIES.length
-          );
+          const breakdown = getQualityBreakdown(row);
+          should(Object.keys(breakdown)).have.length(QUALITY_CATEGORIES.length);
           for (const cat of QUALITY_CATEGORIES) {
-            should(result.dataQuality.categories).have.property(cat);
+            should(breakdown).have.property(cat);
+            should(breakdown[cat]).be.a.Number();
           }
-          should(result.dataQuality).have.property('dateOfUpdate');
-          should(result.dataQuality.dateOfUpdate).eql(row.date_of_update);
         }),
         { numRuns: 100 }
       );

--- a/test/integration/2_utils/computeEntranceDataQuality.property.test.js
+++ b/test/integration/2_utils/computeEntranceDataQuality.property.test.js
@@ -1,0 +1,172 @@
+const should = require('should');
+const fc = require('fast-check');
+const moment = require('moment');
+const {
+  QUALITY_CATEGORIES,
+  MAX_RAW_TOTAL,
+  getQualityData,
+  getQualityBreakdown,
+} = require('../../../api/utils/computeEntranceDataQuality');
+const {
+  toEntrance,
+  toQualityDataEntrance,
+} = require('../../../api/services/mapping/converters');
+
+/**
+ * Arbitrary: generates a random materialized view row
+ * with optional dates and contribution counts for each category,
+ * plus a required date_of_update.
+ */
+const qualityRowArb = fc.record({
+  ...QUALITY_CATEGORIES.reduce((acc, cat) => {
+    acc[`${cat}_latest_date_of_update`] = fc.option(fc.date());
+    acc[`${cat}_nb_contributions`] = fc.option(fc.nat());
+    return acc;
+  }, {}),
+  date_of_update: fc.date(),
+});
+
+describe('computeEntranceDataQuality - Property Tests', () => {
+  /**
+   * Property 1: Converter output completeness
+   *
+   * For any materialized view row, converting an entrance source with
+   * qualityData set via toEntrance produces a dataQuality object with
+   * the correct shape: total (number), categories (7 keys), dateOfUpdate.
+   *
+   * Validates: Requirements 1.1, 1.2, 1.3, 2.3
+   */
+  describe('Property 1: Converter output completeness', () => {
+    it('should produce dataQuality with total, 7 categories, and dateOfUpdate', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(qualityRowArb, (row) => {
+          const source = {
+            id: 1,
+            names: [{ name: 'Test', isMain: true, language: 'eng' }],
+            qualityData: row,
+          };
+
+          const result = toEntrance(source);
+
+          should(result).have.property('dataQuality');
+          should(result.dataQuality).not.be.null();
+          should(result.dataQuality).have.property('total');
+          should(result.dataQuality.total).be.a.Number();
+          should(result.dataQuality).have.property('categories');
+          should(Object.keys(result.dataQuality.categories)).have.length(
+            QUALITY_CATEGORIES.length
+          );
+          for (const cat of QUALITY_CATEGORIES) {
+            should(result.dataQuality.categories).have.property(cat);
+          }
+          should(result.dataQuality).have.property('dateOfUpdate');
+          should(result.dataQuality.dateOfUpdate).eql(row.date_of_update);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 2: Score bounds
+   *
+   * For any materialized view row, getQualityData returns a value in [0, 100]
+   * and each value in getQualityBreakdown is in [0, 100].
+   *
+   * Validates: Requirements 2.1, 2.2
+   */
+  describe('Property 2: Score bounds', () => {
+    it('should produce total in [0, 100] and each category in [0, 100]', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(qualityRowArb, (row) => {
+          const total = getQualityData(row);
+          should(total).be.greaterThanOrEqual(0);
+          should(total).be.lessThanOrEqual(100);
+
+          const breakdown = getQualityBreakdown(row);
+          for (const cat of QUALITY_CATEGORIES) {
+            should(breakdown[cat]).be.greaterThanOrEqual(0);
+            should(breakdown[cat]).be.lessThanOrEqual(100);
+          }
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 3: Total is consistent with normalized category scores
+   *
+   * For any materialized view row, getQualityData(row) equals
+   * Math.round(rawSum / MAX_RAW_TOTAL * 100) where rawSum is the sum
+   * of all 7 raw category scores recomputed independently.
+   *
+   * Validates: Requirements 2.4
+   */
+  describe('Property 3: Total is consistent with normalized category scores', () => {
+    it('should equal Math.round(rawSum / MAX_RAW_TOTAL * 100)', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(qualityRowArb, (row) => {
+          // Recompute raw sum independently using the same scoring logic
+          let rawSum = 0;
+          for (const cat of QUALITY_CATEGORIES) {
+            const entityDate = row[`${cat}_latest_date_of_update`];
+            let dateScore = 0;
+            if (entityDate) {
+              const ageInYears = moment().diff(
+                moment(entityDate),
+                'years',
+                true
+              );
+              if (ageInYears < 2) dateScore = 7;
+              else if (ageInYears < 5) dateScore = 5;
+              else if (ageInYears < 10) dateScore = 3;
+              else dateScore = 1;
+            }
+
+            const nbContrib = row[`${cat}_nb_contributions`];
+            let contribScore = 0;
+            if (nbContrib) {
+              const n = Number.parseInt(nbContrib, 10);
+              if (n <= 0) contribScore = 0;
+              else if (n === 1) contribScore = 3;
+              else contribScore = 7;
+            }
+
+            rawSum += dateScore + contribScore;
+          }
+
+          const expected = Math.round((rawSum / MAX_RAW_TOTAL) * 100);
+          should(getQualityData(row)).equal(expected);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 4: Consistency with list endpoint scoring
+   *
+   * For any materialized view row, getQualityData(row) equals
+   * toQualityDataEntrance(row).data_quality, ensuring the detail
+   * endpoint and list endpoints produce the same score.
+   *
+   * Validates: Requirements 2.5
+   */
+  describe('Property 4: Consistency with list endpoint scoring', () => {
+    it('should equal toQualityDataEntrance(row).data_quality', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(qualityRowArb, (row) => {
+          const detailScore = getQualityData(row);
+          const listScore = toQualityDataEntrance(row).data_quality;
+          should(detailScore).equal(listScore);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/4_routes/Entrances/ENTRANCE_PROPERTIES.js
+++ b/test/integration/4_routes/Entrances/ENTRANCE_PROPERTIES.js
@@ -10,6 +10,7 @@ const ENTRANCE_PROPERTIES = [
   'comments',
   'county',
   'country',
+  'dataQuality',
   'dateInscription',
   'dateReviewed',
   'descriptions',

--- a/test/integration/4_routes/Entrances/find.test.js
+++ b/test/integration/4_routes/Entrances/find.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 const should = require('should');
 const ENTRANCE_PROPERTIES = require('./ENTRANCE_PROPERTIES');
+const {
+  QUALITY_CATEGORIES,
+} = require('../../../../api/utils/computeEntranceDataQuality');
 
 describe('Entrance features', () => {
   describe('find', () => {
@@ -49,6 +52,54 @@ describe('Entrance features', () => {
           should(entrance.descriptions.length).equal(1);
           should(entrance.locations.length).equal(2);
           should(entrance.histories.length).equal(1);
+          return done();
+        });
+    });
+
+    it('should return dataQuality with score and categories for entrance with quality data', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/1')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: entrance } = res;
+          should(entrance).have.property('dataQuality');
+          should(entrance.dataQuality).not.be.null();
+          should(entrance.dataQuality).have.property('total');
+          should(entrance.dataQuality.total).be.a.Number();
+          should(entrance.dataQuality.total).be.greaterThanOrEqual(0);
+          should(entrance.dataQuality.total).be.lessThanOrEqual(100);
+          should(entrance.dataQuality).have.property('categories');
+          const categoryKeys = Object.keys(entrance.dataQuality.categories);
+          should(categoryKeys).have.length(7);
+          QUALITY_CATEGORIES.forEach((cat) => {
+            should(entrance.dataQuality.categories).have.property(cat);
+            should(entrance.dataQuality.categories[cat]).be.a.Number();
+            should(entrance.dataQuality.categories[cat]).be.greaterThanOrEqual(
+              0
+            );
+            should(entrance.dataQuality.categories[cat]).be.lessThanOrEqual(
+              100
+            );
+          });
+          should(entrance.dataQuality).have.property('lastComputedAt');
+          return done();
+        });
+    });
+
+    it('should return dataQuality as null for entrance without quality data', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/4')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: entrance } = res;
+          should(entrance).have.property('dataQuality');
+          should(entrance.dataQuality).be.null();
           return done();
         });
     });


### PR DESCRIPTION
## 🤔 What

Add the data quality score and per-category breakdown to the entrance detail endpoint (`GET /api/v1/entrances/:id`). Normalize all quality scores to 0–100 across both detail and list endpoints.

- Closes #1506
- Refactor `computeEntranceDataQuality.js`: centralize category list, scoring tier constants, fix `moment().subtract()` mutation bug, normalize scores to 0–100
- Add `getEntranceQualityById` to `DataQualityComputeService` for single-entrance lookup
- Extend `toEntrance` converter with `dataQuality` field (total + 7 category breakdown + dateOfUpdate)
- Add error logging to all `DataQualityComputeService` catch blocks
- Update Swagger spec with `DataQuality` schema
- Add 4 property-based tests and 2 integration tests

## 🤷‍♂️ Why

The quality score was only visible in list views (massif/country pages) but not on the individual entrance detail page. Contributors had no immediate feedback on data quality when viewing or editing an entrance.

The frontend already assumes a 0–100 scale, but the backend was returning raw 0–98 values. This PR aligns both.

## 🔍 How

**Score computation refactor** (`api/utils/computeEntranceDataQuality.js`):
- Extracted `QUALITY_CATEGORIES` array and all scoring tier/threshold constants (no more magic numbers)
- Fixed a subtle bug where `moment().subtract()` was mutating the same moment object across comparisons — replaced with `moment().diff()` 
- `getQualityData()` now iterates over `QUALITY_CATEGORIES` and returns `Math.round(raw / 98 * 100)`
- New `getQualityBreakdown()` returns per-category normalized scores (0–100 each)
- Changed module export from single function to named exports

**Service layer** (`api/services/DataQualityComputeService.js`):
- New `getEntranceQualityById(entranceId)` using raw SQL (not Waterline — materialized views lack a real primary key, so `findOne` doesn't work reliably)
- Added `sails.log.error(e)` to all 7 catch blocks (6 existing + 1 new)

**Controller** (`api/controllers/v1/entrance/find.js`):
- Quality data fetched in parallel with `getPopulatedEntrance` via `Promise.all` — no additional latency
- Attached as `entrance.qualityData` before passing to converter

**Converter** (`api/services/mapping/converters.js`):
- `toEntrance` now outputs `dataQuality: { total, categories, dateOfUpdate }` or `null`
- List endpoints automatically return normalized 0–100 scores since they call the same `getQualityData()`

## 🧪 Testing

```bash
PORT=1338 npm run test
```

4 property-based tests verify score bounds, total consistency, and list/detail parity. 2 integration tests verify the endpoint returns quality data (or null when missing).

## 📸 Previews

Response for `GET /api/v1/entrances/:id`:
```json
{
  "dataQuality": {
    "total": 71,
    "categories": {
      "general": 100,
      "location": 71,
      "description": 50,
      "document": 71,
      "rigging": 50,
      "history": 71,
      "comment": 100
    },
    "dateOfUpdate": "2026-03-30T10:20:00.000Z"
  }
}
```
