### PR TITLE
fix(search): validate sort parameter in advanced-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,31 @@ Grottocenter API implements a Role-Based Access Control (RBAC) system with 5 use
 
 For detailed information about roles, permissions, and implementation, see [here](PERMISSION_SYSTEM.md).
 
+### Sortable fields
+
+The advanced search endpoints (`POST /api/v1/advanced-search` and `POST /api/v1/advanced-search/export`) accept a `sort` parameter in the format `field:asc` or `field:desc`. Only fields that are sortable in the target entity's Typesense schema are accepted; invalid fields return a 400 error.
+
+The source of truth for sortable fields is the `search.schema.fields` array in each entity module under `api/dbSync/entities/`. A field is sortable when:
+
+- it has `sort: true` in its schema definition, or
+- its type is numeric or boolean (`int32`, `int64`, `float`, `bool`, and their array variants), which Typesense makes sortable by default
+
+To list all sortable fields for a given entity:
+
+```bash
+node -e "
+const SORTABLE_BY_DEFAULT = ['int32','int64','float','bool','int32[]','int64[]','float[]','bool[]'];
+const entities = ['organization','person','massif','cave','entrance','document'];
+entities.forEach(e => {
+  const mod = require('./api/dbSync/entities/' + e);
+  const sortable = mod.search.schema.fields
+    .filter(f => f.sort === true || SORTABLE_BY_DEFAULT.includes(f.type))
+    .map(f => f.name);
+  console.log(mod.search.schema.name + ': ' + sortable.join(', '));
+});
+"
+```
+
 ### Git
 
 #### Workflow

--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -97,12 +97,24 @@ module.exports = async (req, res) => {
   let hasSentHeader = false;
   let page = 1;
   for (;;) {
-    // eslint-disable-next-line no-await-in-loop
-    const results = await SearchService.collectionSearch({
-      ...params,
-      page,
-      size: BATCH_SIZE,
-    }).catch((err) => err);
+    let results;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      results = await SearchService.collectionSearch({
+        ...params,
+        page,
+        size: BATCH_SIZE,
+      });
+    } catch (err) {
+      if (err.code === 'E_SORT_VALIDATION') {
+        if (!hasSentHeader) {
+          res.badRequest({ error: err.message });
+          return;
+        }
+        break;
+      }
+      results = err;
+    }
 
     if (!results || !results.hits) {
       sails.log.error('Export to CSV error', params, page, results);

--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -6,15 +6,23 @@ module.exports = async (req, res) => {
   let matchAllFields = req.param('matchAllFields') ?? true;
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
 
-  const results = await SearchService.collectionSearch({
-    query: req.param('query'),
-    entity: req.param('entity') ?? '',
-    sort: req.param('sort'),
-    filter: req.param('filter') ?? {},
-    isLogicalCompareAnd: !!matchAllFields,
-    page: req.param('page') ?? 1,
-    size: req.param('size') ?? 10,
-  });
+  let results;
+  try {
+    results = await SearchService.collectionSearch({
+      query: req.param('query'),
+      entity: req.param('entity') ?? '',
+      sort: req.param('sort'),
+      filter: req.param('filter') ?? {},
+      isLogicalCompareAnd: !!matchAllFields,
+      page: req.param('page') ?? 1,
+      size: req.param('size') ?? 10,
+    });
+  } catch (error) {
+    if (error.code === 'E_SORT_VALIDATION') {
+      return res.badRequest({ error: error.message });
+    }
+    throw error;
+  }
 
   return ControllerService.treatAndConvert(
     req,

--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -104,6 +104,51 @@ async function multiCollectionsSearch({
   });
 }
 
+function validateSort(entity, sort) {
+  const parts = sort.split(':');
+  if (parts.length !== 2 || !parts[0] || !['asc', 'desc'].includes(parts[1])) {
+    const err = new Error(
+      `Invalid sort format '${sort}'. Expected 'field:asc' or 'field:desc'.`
+    );
+    err.code = 'E_SORT_VALIDATION';
+    throw err;
+  }
+
+  const [fieldName] = parts;
+  const { fields } = allEntities[entity].schema;
+  const fieldDef = fields.find((f) => f.name === fieldName);
+
+  if (!fieldDef) {
+    const err = new Error(
+      `Field '${fieldName}' does not exist in '${entity}' schema.`
+    );
+    err.code = 'E_SORT_VALIDATION';
+    throw err;
+  }
+
+  // Typesense allows sorting on numeric and boolean fields by default.
+  // Only string fields require explicit `sort: true` in the schema.
+  const numericAndBoolTypes = [
+    'int32',
+    'int64',
+    'float',
+    'bool',
+    'int32[]',
+    'int64[]',
+    'float[]',
+    'bool[]',
+  ];
+  const isSortableByDefault = numericAndBoolTypes.includes(fieldDef.type);
+
+  if (!isSortableByDefault && fieldDef.sort !== true) {
+    const err = new Error(
+      `Field '${fieldName}' is not sortable in '${entity}' schema.`
+    );
+    err.code = 'E_SORT_VALIDATION';
+    throw err;
+  }
+}
+
 async function collectionSearch({
   query,
   entity = [],
@@ -115,6 +160,7 @@ async function collectionSearch({
   fields,
 } = {}) {
   if (!allEntitiesKeys.includes(entity)) return null;
+  if (sort && sort.trim()) validateSort(entity, sort);
   const q = query || '*';
   const { filterBy, hasPrefixFilter } = buildFilter(
     filter,
@@ -172,6 +218,9 @@ async function fieldSearch({
 }
 
 module.exports = {
+  allEntities,
+  allEntitiesKeys,
+
   isAlive,
 
   updateDocument,

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3734,7 +3734,11 @@ paths:
                     $ref: '#/components/schemas/Quicksearch-type'
                 sort:
                   type: string
-                  description: On what field to sort on, format "field:direction", direction can be "asc" or "desc", for example "depth:desc"
+                  description: |
+                    Sort field and direction in the format "field:asc" or "field:desc".
+                    The field must exist and be sortable in the target entity's schema.
+                    Returns 400 if the field is invalid or not sortable.
+                  example: "cave.depth:desc"
                 filter:
                   type: object
                   description: Filter to specify the request, the keys are field in the entities
@@ -3757,6 +3761,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Search'
+        '400':
+          description: Invalid sort parameter (unknown field, non-sortable field, or bad format)
         '404':
           description: Resource not found
 
@@ -3784,7 +3790,10 @@ paths:
                     $ref: '#/components/schemas/Quicksearch-type'
                 sort:
                   type: string
-                  description: On what field to sort on, format "field:direction", direction can be "asc" or "desc", for example "depth:desc"
+                  description: |
+                    Sort field and direction in the format "field:asc" or "field:desc".
+                    The field must exist and be sortable in the target entity's schema.
+                  example: "cave.depth:desc"
                 filter:
                   type: object
                   description: Filter to specify the request, the keys are field in the entities

--- a/test/integration/1_services/SearchService.property.test.js
+++ b/test/integration/1_services/SearchService.property.test.js
@@ -1,0 +1,352 @@
+const should = require('should');
+const sinon = require('sinon');
+const fc = require('fast-check');
+const SearchService = require('../../../api/services/SearchService');
+const typesense = require('../../../config/typesense');
+
+const { allEntities, allEntitiesKeys } = SearchService;
+
+/**
+ * Helper: get all field names for an entity's schema
+ */
+function getFieldNames(entityName) {
+  return allEntities[entityName].schema.fields.map((f) => f.name);
+}
+
+// Typesense types that are sortable by default (no explicit sort: true needed)
+const SORTABLE_BY_DEFAULT_TYPES = [
+  'int32',
+  'int64',
+  'float',
+  'bool',
+  'int32[]',
+  'int64[]',
+  'float[]',
+  'bool[]',
+];
+
+/**
+ * Helper: get sortable field names for an entity's schema.
+ * Numeric and boolean fields are sortable by default in Typesense;
+ * string fields require explicit `sort: true`.
+ */
+function getSortableFieldNames(entityName) {
+  return allEntities[entityName].schema.fields
+    .filter(
+      (f) => f.sort === true || SORTABLE_BY_DEFAULT_TYPES.includes(f.type)
+    )
+    .map((f) => f.name);
+}
+
+/**
+ * Helper: get non-sortable field names.
+ * Only string fields without `sort: true` are truly non-sortable.
+ */
+function getNonSortableFieldNames(entityName) {
+  return allEntities[entityName].schema.fields
+    .filter(
+      (f) => f.sort !== true && !SORTABLE_BY_DEFAULT_TYPES.includes(f.type)
+    )
+    .map((f) => f.name);
+}
+
+// --- Arbitraries for bug condition inputs ---
+
+// 1. Non-existent field with valid direction
+// Prefix with 'zzz_' to guarantee the generated name cannot match any real field
+const nonExistentFieldArb = fc
+  .constantFrom(...allEntitiesKeys)
+  .chain((entity) =>
+    fc.stringMatching(/^[a-z]{2,15}$/).map((field) => ({
+      entity,
+      sort: `zzz_${field}:asc`,
+      category: 'non-existent-field',
+    }))
+  );
+
+// 2. Non-sortable field with valid direction
+const nonSortableFieldArb = fc
+  .constantFrom(...allEntitiesKeys)
+  .filter((entity) => getNonSortableFieldNames(entity).length > 0)
+  .chain((entity) => {
+    const nonSortable = getNonSortableFieldNames(entity);
+    return fc.constantFrom(...nonSortable).chain((field) =>
+      fc.constantFrom('asc', 'desc').map((dir) => ({
+        entity,
+        sort: `${field}:${dir}`,
+        category: 'non-sortable-field',
+      }))
+    );
+  });
+
+// 3. Invalid format — missing direction (no colon)
+const missingDirectionArb = fc
+  .constantFrom(...allEntitiesKeys)
+  .chain((entity) => {
+    const sortable = getSortableFieldNames(entity);
+    if (sortable.length === 0) {
+      // Fallback: use any field name
+      const allFields = getFieldNames(entity);
+      return fc.constantFrom(...allFields).map((field) => ({
+        entity,
+        sort: field,
+        category: 'missing-direction',
+      }));
+    }
+    return fc.constantFrom(...sortable).map((field) => ({
+      entity,
+      sort: field,
+      category: 'missing-direction',
+    }));
+  });
+
+// 4. Invalid direction (not asc/desc)
+const invalidDirectionArb = fc
+  .constantFrom(...allEntitiesKeys)
+  .chain((entity) => {
+    const sortable = getSortableFieldNames(entity);
+    if (sortable.length === 0) {
+      const allFields = getFieldNames(entity);
+      return fc.constantFrom(...allFields).chain((field) =>
+        fc
+          .constantFrom('up', 'down', 'ascending', 'descending', 'ASC', 'DESC')
+          .map((dir) => ({
+            entity,
+            sort: `${field}:${dir}`,
+            category: 'invalid-direction',
+          }))
+      );
+    }
+    return fc.constantFrom(...sortable).chain((field) =>
+      fc
+        .constantFrom('up', 'down', 'ascending', 'descending', 'ASC', 'DESC')
+        .map((dir) => ({
+          entity,
+          sort: `${field}:${dir}`,
+          category: 'invalid-direction',
+        }))
+    );
+  });
+
+// Combined arbitrary covering all bug condition variants
+const bugConditionArb = fc.oneof(
+  nonExistentFieldArb,
+  nonSortableFieldArb,
+  missingDirectionArb,
+  invalidDirectionArb
+);
+
+/**
+ * Property 1: Bug Condition — Invalid Sort Field Causes Unhandled Typesense Error
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3
+ *
+ * For any collectionSearch() input where isBugCondition(input) is true,
+ * the function should throw a validation error with a descriptive message
+ * and typesense.search should NOT be called.
+ *
+ * EXPECTED: This test FAILS on unfixed code because the current implementation
+ * passes invalid sort directly to Typesense without validation.
+ */
+describe('SearchService - Property 1: Bug Condition', () => {
+  let searchStub;
+
+  beforeEach(() => {
+    searchStub = sinon.stub(typesense, 'search').resolves({ hits: [] });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('Property 1: invalid sort inputs should throw a validation error and not call Typesense', function () {
+    this.timeout(30000);
+    return fc.assert(
+      fc.asyncProperty(bugConditionArb, async (input) => {
+        // Reset stub call count for each generated case
+        searchStub.resetHistory();
+
+        let threw = false;
+        let errorMessage = '';
+        try {
+          await SearchService.collectionSearch({
+            query: 'test',
+            entity: input.entity,
+            sort: input.sort,
+          });
+        } catch (err) {
+          threw = true;
+          errorMessage = err.message || '';
+        }
+
+        // Assert: should have thrown a validation error
+        should(threw).be.true(
+          `Expected collectionSearch to throw for entity="${input.entity}" sort="${input.sort}" (${input.category}), but it did not throw`
+        );
+
+        // Assert: error message should be descriptive
+        should(errorMessage.length).be.greaterThan(
+          0,
+          `Expected a descriptive error message for entity="${input.entity}" sort="${input.sort}" (${input.category})`
+        );
+
+        // Assert: typesense.search should NOT have been called
+        should(searchStub.called).be.false(
+          `Expected typesense.search to NOT be called for entity="${input.entity}" sort="${input.sort}" (${input.category}), but it was called`
+        );
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 2: Preservation — Valid Sort and No-Sort Behavior Unchanged
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4
+ *
+ * These tests capture the current VALID behavior of collectionSearch()
+ * so we can verify it is preserved after the fix.
+ * All three properties MUST PASS on the unfixed code.
+ */
+describe('SearchService - Property 2: Preservation', () => {
+  let searchStub;
+
+  beforeEach(() => {
+    searchStub = sinon.stub(typesense, 'search').resolves({ hits: [] });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  /**
+   * Property 2a — Valid sort preserved
+   *
+   * For all valid entity + sortable field + valid direction (asc/desc) combinations,
+   * collectionSearch calls typesense.search with sort_by equal to
+   * `${field}:${direction},_text_match:desc`.
+   *
+   * **Validates: Requirements 3.1**
+   */
+  it('Property 2a: valid sort inputs produce correct sort_by param', function () {
+    this.timeout(30000);
+
+    // Build arbitrary: pick random entity, then a sortable field from its schema,
+    // then a valid direction
+    const validSortArb = fc
+      .constantFrom(...allEntitiesKeys)
+      .chain((entity) => {
+        const sortable = getSortableFieldNames(entity);
+        if (sortable.length === 0) {
+          return fc.constant(null);
+        }
+        return fc
+          .constantFrom(...sortable)
+          .chain((field) =>
+            fc
+              .constantFrom('asc', 'desc')
+              .map((direction) => ({ entity, field, direction }))
+          );
+      })
+      .filter((v) => v !== null);
+
+    return fc.assert(
+      fc.asyncProperty(validSortArb, async (input) => {
+        searchStub.resetHistory();
+
+        await SearchService.collectionSearch({
+          query: 'test',
+          entity: input.entity,
+          sort: `${input.field}:${input.direction}`,
+        });
+
+        // typesense.search should have been called exactly once
+        should(searchStub.calledOnce).be.true(
+          `Expected typesense.search to be called once for entity="${input.entity}" sort="${input.field}:${input.direction}"`
+        );
+
+        // Verify sort_by param matches expected format
+        const params = searchStub.getCall(0).args[1];
+        should(params).have.property('sort_by');
+        should(params.sort_by).equal(
+          `${input.field}:${input.direction},_text_match:desc`,
+          `Expected sort_by="${input.field}:${input.direction},_text_match:desc" for entity="${input.entity}"`
+        );
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 2b — No-sort preserved
+   *
+   * For all valid entities with no sort param, collectionSearch calls
+   * typesense.search without a sort_by key.
+   *
+   * **Validates: Requirements 3.2**
+   */
+  it('Property 2b: no-sort inputs omit sort_by param', function () {
+    this.timeout(30000);
+
+    const entityArb = fc.constantFrom(...allEntitiesKeys);
+
+    return fc.assert(
+      fc.asyncProperty(entityArb, async (entity) => {
+        searchStub.resetHistory();
+
+        await SearchService.collectionSearch({
+          query: 'test',
+          entity,
+        });
+
+        // typesense.search should have been called exactly once
+        should(searchStub.calledOnce).be.true(
+          `Expected typesense.search to be called once for entity="${entity}" with no sort`
+        );
+
+        // Verify sort_by is absent from params
+        const params = searchStub.getCall(0).args[1];
+        should(params).not.have.property(
+          'sort_by',
+          `Expected no sort_by param for entity="${entity}" when sort is not provided`
+        );
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  /**
+   * Property 2c — Invalid entity preserved
+   *
+   * For entity names not in allEntitiesKeys, collectionSearch returns null
+   * without calling typesense.search.
+   *
+   * **Validates: Requirements 3.3**
+   */
+  it('Property 2c: invalid entity returns null without calling Typesense', function () {
+    this.timeout(30000);
+
+    const invalidEntityArb = fc
+      .string({ minLength: 1, maxLength: 30 })
+      .filter((s) => !allEntitiesKeys.includes(s));
+
+    return fc.assert(
+      fc.asyncProperty(invalidEntityArb, async (entity) => {
+        searchStub.resetHistory();
+
+        const result = await SearchService.collectionSearch({
+          query: 'test',
+          entity,
+        });
+
+        // Should return null
+        should(result).be.null();
+
+        // typesense.search should NOT have been called
+        should(searchStub.called).be.false();
+      }),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Add sort parameter validation in the advanced search endpoint (`POST /api/v1/advanced-search`)
- Invalid sort fields now return 400 Bad Request instead of crashing with 500

## 🤷‍♂️ Why

Production logs showed a 500 Internal Server Error when a user sorted entrances by `depth:desc`. The entrances Typesense collection has `cave.depth` (nested) but no top-level `depth` field. The sort parameter was passed directly to Typesense without validation, causing an `ObjectNotFound` error that bubbled up as a 500.

## 🔍 How

- Added a `validateSort(entity, sort)` helper in `SearchService.js` that checks:
  1. Sort format is `field:asc` or `field:desc`
  2. The field exists in the target entity's Typesense schema
  3. The field is marked as sortable (`sort: true`)
- Called `validateSort` in `collectionSearch()` before building Typesense query params
- Added try/catch in the `advanced-search.js` controller to catch `E_SORT_VALIDATION` errors and return `res.badRequest()` with a descriptive message
- Non-validation errors (e.g., Typesense connectivity) still propagate as 500

## 🧪 Testing

- Added property-based tests in `test/integration/1_services/SearchService.property.test.js`:
  - **Property 1 (Bug Condition)**: Generates random invalid sort inputs (non-existent fields, non-sortable fields, bad format/direction) and verifies validation errors are thrown
  - **Property 2a (Preservation)**: Verifies all valid entity + sortable field + direction combos produce correct `sort_by` params
  - **Property 2b (Preservation)**: Verifies no-sort requests omit `sort_by`
  - **Property 2c (Preservation)**: Verifies invalid entity names return `null`

```bash
PORT=1338 npm run test -- --grep "SearchService - Property"
```

## 📸 Previews

N/A — backend-only change.
