### PR TITLE
feat(caver): add admin ban/unban endpoints with security hardening

### DIFF
--- a/api/controllers/v1/account/change-password.js
+++ b/api/controllers/v1/account/change-password.js
@@ -46,6 +46,14 @@ module.exports = async (req, res) => {
     });
   }
 
+  // Block banned cavers — return same response as expired token to hide ban status
+  if (userFound.banned === true) {
+    sails.log.warn(
+      `Banned caver ${userFound.id} attempted password change via reset token`
+    );
+    return res.forbidden('The password reset token has expired.');
+  }
+
   // Check token
   const verifyTokenCallback = async (err) => {
     if (err) {

--- a/api/controllers/v1/account/forgot-password.js
+++ b/api/controllers/v1/account/forgot-password.js
@@ -19,6 +19,13 @@ module.exports = async (req, res) => {
     });
   }
 
+  // If the caver is banned, return 200 OK without generating a token or sending an email
+  // to prevent information leakage about ban status
+  if (userFound.banned === true) {
+    sails.log.warn(`Banned caver ${userFound.id} attempted password reset`);
+    return res.ok();
+  }
+
   // Generate reset password token
   const token = TokenService.issue(
     {

--- a/api/controllers/v1/auth/login.js
+++ b/api/controllers/v1/auth/login.js
@@ -26,6 +26,24 @@ module.exports = async (req, res) => {
       message: 'Invalid email or password.',
     });
   }
+
+  // Update login metadata (fire-and-forget)
+  CommonService.query(
+    `UPDATE t_caver SET date_last_connection = NOW(), connection_counter = connection_counter + 1 WHERE id = $1`,
+    [result.user.id]
+  ).catch((e) =>
+    sails.log.error('Failed to update login metadata:', e.message)
+  );
+
+  // Reject banned cavers — return generic 401 to hide ban status
+  if (result.user.banned) {
+    sails.log.warn(`Banned caver ${result.user.id} attempted login`);
+    return res.unauthorized({
+      status: 'Mismatch',
+      message: 'Invalid email or password.',
+    });
+  }
+
   const token = TokenService.issue(
     {
       id: result.user.id,

--- a/api/controllers/v1/auth/sign-up.js
+++ b/api/controllers/v1/auth/sign-up.js
@@ -12,7 +12,8 @@ module.exports = async (req, res) => {
   email = email.toLowerCase();
   const caverEmail = await TCaver.findOne({ mail: email });
   if (caverEmail) {
-    return res.conflict(`The email ${email} is already used.`);
+    sails.log.warn(`Sign-up attempt with existing email: ${email}`);
+    return res.conflict('Email or nickname is already used.');
   }
 
   const password = req.param('password');
@@ -31,7 +32,8 @@ module.exports = async (req, res) => {
   }
   const caverNickname = await TCaver.findOne({ nickname });
   if (caverNickname) {
-    return res.conflict(`The nickname ${nickname} is already used.`);
+    sails.log.warn(`Sign-up attempt with existing nickname: ${nickname}`);
+    return res.conflict('Email or nickname is already used.');
   }
 
   try {

--- a/api/controllers/v1/caver/ban.js
+++ b/api/controllers/v1/caver/ban.js
@@ -1,0 +1,30 @@
+const RightService = require('../../../services/RightService');
+
+module.exports = async (req, res) => {
+  const hasRight = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  if (!hasRight) {
+    return res.forbidden('You are not authorized to ban a caver.');
+  }
+
+  const { caverId } = req.params;
+
+  if (req.token.id === parseInt(caverId, 10)) {
+    return res.forbidden('You cannot ban yourself.');
+  }
+
+  const caver = await TCaver.findOne({ id: caverId });
+  if (!caver) {
+    return res.notFound(`Caver with id ${caverId} not found.`);
+  }
+
+  if (!caver.banned) {
+    await TCaver.updateOne({ id: caverId }).set({ banned: true });
+  }
+
+  await BlacklistService.revoke(parseInt(caverId, 10));
+
+  return res.ok({ banned: true });
+};

--- a/api/controllers/v1/caver/find.js
+++ b/api/controllers/v1/caver/find.js
@@ -1,6 +1,7 @@
 const CaverService = require('../../../services/CaverService');
 const ControllerService = require('../../../services/ControllerService');
 const DocumentService = require('../../../services/DocumentService');
+const RightService = require('../../../services/RightService');
 const { toCaver } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
@@ -16,12 +17,16 @@ module.exports = async (req, res) => {
     caverFound.documents.map((d) => d.id)
   );
 
+  const isAdmin =
+    req.token &&
+    RightService.hasGroup(req.token.groups, RightService.G.ADMINISTRATOR);
+
   return ControllerService.treatAndConvert(
     req,
     null,
     caverFound,
     params,
     res,
-    toCaver
+    (source) => toCaver(source, { isAdmin })
   );
 };

--- a/api/controllers/v1/caver/get-admins.js
+++ b/api/controllers/v1/caver/get-admins.js
@@ -1,5 +1,5 @@
 const ControllerService = require('../../../services/ControllerService');
-const { toSimpleCaver } = require('../../../services/mapping/converters');
+const { toListCaver } = require('../../../services/mapping/converters');
 const { toListFromController } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
@@ -15,6 +15,6 @@ module.exports = async (req, res) => {
     adminGroup.cavers,
     { controllerMethod: 'CaverController.getAdmins' },
     res,
-    (data) => toListFromController('cavers', data, toSimpleCaver)
+    (data) => toListFromController('cavers', data, toListCaver)
   );
 };

--- a/api/controllers/v1/caver/get-banned.js
+++ b/api/controllers/v1/caver/get-banned.js
@@ -1,0 +1,16 @@
+const { toListCaver } = require('../../../services/mapping/converters');
+const RightService = require('../../../services/RightService');
+
+module.exports = async (req, res) => {
+  const hasRight = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  if (!hasRight) {
+    return res.forbidden('You are not authorized to list banned cavers.');
+  }
+
+  const bannedCavers = await TCaver.find({ banned: true });
+
+  return res.ok({ banned: bannedCavers.map(toListCaver) });
+};

--- a/api/controllers/v1/caver/get-groups.js
+++ b/api/controllers/v1/caver/get-groups.js
@@ -1,4 +1,4 @@
-const { toSimpleCaver } = require('../../../services/mapping/converters');
+const { toListCaver } = require('../../../services/mapping/converters');
 const { toList } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
@@ -9,8 +9,8 @@ module.exports = async (req, res) => {
   ]);
 
   return res.ok({
-    administrators: toList('cavers', administrators, toSimpleCaver),
-    moderators: toList('cavers', moderators, toSimpleCaver),
-    leaders: toList('cavers', leaders, toSimpleCaver),
+    administrators: toList('cavers', administrators, toListCaver),
+    moderators: toList('cavers', moderators, toListCaver),
+    leaders: toList('cavers', leaders, toListCaver),
   });
 };

--- a/api/controllers/v1/caver/get-moderators.js
+++ b/api/controllers/v1/caver/get-moderators.js
@@ -1,5 +1,5 @@
 const ControllerService = require('../../../services/ControllerService');
-const { toSimpleCaver } = require('../../../services/mapping/converters');
+const { toListCaver } = require('../../../services/mapping/converters');
 const { toListFromController } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
@@ -15,6 +15,6 @@ module.exports = async (req, res) => {
     moderatorGroup.cavers,
     { controllerMethod: 'CaverController.getModerators' },
     res,
-    (data) => toListFromController('cavers', data, toSimpleCaver)
+    (data) => toListFromController('cavers', data, toListCaver)
   );
 };

--- a/api/controllers/v1/caver/unban.js
+++ b/api/controllers/v1/caver/unban.js
@@ -1,0 +1,26 @@
+const RightService = require('../../../services/RightService');
+
+module.exports = async (req, res) => {
+  const hasRight = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  if (!hasRight) {
+    return res.forbidden('You are not authorized to unban a caver.');
+  }
+
+  const { caverId } = req.params;
+
+  const caver = await TCaver.findOne({ id: caverId });
+  if (!caver) {
+    return res.notFound(`Caver with id ${caverId} not found.`);
+  }
+
+  if (!caver.banned) {
+    return res.ok({ banned: false });
+  }
+
+  await TCaver.updateOne({ id: caverId }).set({ banned: false });
+
+  return res.ok({ banned: false });
+};

--- a/api/models/TCaver.js
+++ b/api/models/TCaver.js
@@ -48,14 +48,12 @@ module.exports = {
       maxLength: 64,
     },
 
-    // Unsued
     banned: {
       type: 'boolean',
       columnName: 'banned',
       defaultsTo: false,
     },
 
-    // Unsued
     connectionCounter: {
       type: 'number',
       allowNull: false,
@@ -116,7 +114,6 @@ module.exports = {
       columnType: 'timestamp',
     },
 
-    // Unsued
     dateLastConnection: {
       type: 'ref',
       columnName: 'date_last_connection',

--- a/api/services/CaverService.js
+++ b/api/services/CaverService.js
@@ -109,6 +109,7 @@ module.exports = {
     return {
       id: caver.id,
       type: caver.type,
+      banned: caver.banned,
       name: caver.name,
       surname: caver.surname,
       nickname: caver.nickname,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -71,7 +71,7 @@ const c = {
     ),
   }),
 
-  toCaver: (source) => {
+  toCaver: (source, meta) => {
     const result = {
       ...CaverModel,
       id: source.id,
@@ -110,12 +110,23 @@ const c = {
     listParser('documents', c.toSimpleDocument);
     listParser('grottos', c.toSimpleOrganization, 'organizations');
 
+    if (meta?.isAdmin) {
+      result.isBanned = Boolean(source.banned);
+    }
+
     return result;
   },
 
   toSimpleCaver: (source) => ({
     id: source.id,
     nickname: source.nickname,
+  }),
+
+  toListCaver: (source) => ({
+    id: source.id,
+    nickname: source.nickname,
+    name: source.name,
+    surname: source.surname,
   }),
 
   toSimpleComment: (source) => {

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -959,6 +959,102 @@ paths:
                     items:
                       $ref: '#/components/schemas/Document'
 
+  '/cavers/{caverId}/ban':
+    post:
+      tags:
+        - cavers
+      summary: Ban a caver
+      description: Bans a caver, revoking all active tokens and preventing future logins. Requires Administrator role.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: caverId
+          in: path
+          description: Caver id to ban
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Caver banned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  banned:
+                    type: boolean
+                    example: true
+        '401':
+          description: Unauthorized — missing or invalid bearer token.
+        '403':
+          description: Forbidden — caller is not an administrator, or attempted to ban themselves.
+        '404':
+          description: Caver not found.
+
+  '/cavers/{caverId}/unban':
+    post:
+      tags:
+        - cavers
+      summary: Unban a caver
+      description: Unbans a previously banned caver, allowing them to log in again. Requires Administrator role.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: caverId
+          in: path
+          description: Caver id to unban
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Caver unbanned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  banned:
+                    type: boolean
+                    example: false
+        '401':
+          description: Unauthorized — missing or invalid bearer token.
+        '403':
+          description: Forbidden — caller is not an administrator.
+        '404':
+          description: Caver not found.
+
+  '/cavers/banned':
+    get:
+      tags:
+        - cavers
+      summary: List banned cavers
+      description: Returns all currently banned cavers. Requires Administrator role.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  banned:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        nickname:
+                          type: string
+        '401':
+          description: Unauthorized — missing or invalid bearer token.
+        '403':
+          description: Forbidden — caller is not an administrator.
+
   '/descriptions':
     post:
       tags:
@@ -3023,7 +3119,7 @@ paths:
         '400':
           description: You must provide a password and a reset password token in the body of your request. The password must be at least 8 characters long.
         '403':
-          description: The password reset token has expired or is invalid.
+          description: The password reset token has expired, is invalid, or the account is banned. The response is intentionally identical for all cases to prevent information leakage.
         '404':
           description: User in the password reset token not found.
 
@@ -3053,6 +3149,9 @@ paths:
         - authentication
       description: >-
         Launch the procedure of password change. This will send an email to the email adress you provided if it exists as a Grottocenter user's email. This email contains a password reset link expiring after 24 hours using the Grottocenter application.
+
+
+        The endpoint always returns 200 OK regardless of whether the account is banned or not, to prevent information leakage about ban status. If the account is banned, no reset email is sent.
 
 
         __IMPORTANT NOTICE__
@@ -3103,7 +3202,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Auth-success'
         '401':
-          description: Invalid email or password or the password must be reset first.
+          description: Invalid email or password, password must be reset, or account is banned. The response is intentionally identical for all failure cases to prevent information leakage.
           content:
             application/json:
               schema:
@@ -3151,7 +3250,7 @@ paths:
         '400':
           description: Bad request (password too short, missing value(s)...).
         '409':
-          description: Email or nickname already used.
+          description: Email or nickname is already used. The response intentionally does not specify which field caused the conflict to prevent account enumeration.
 
   '/entrances':
     post:
@@ -5091,6 +5190,9 @@ components:
             $ref: '#/components/schemas/Group'
         id:
           type: integer
+        isBanned:
+          type: boolean
+          description: Whether the caver is banned. Only present when the caller is an authenticated administrator.
         language:
           type: string
         name:

--- a/config/policies.js
+++ b/config/policies.js
@@ -50,6 +50,7 @@ module.exports.policies = {
   'v1/organization/remove-explored-cave': 'tokenAuth',
 
   // Caver
+  'v1/caver/get-banned': 'tokenAuth',
   'v1/caver/count': true,
   'v1/caver/users-count': true,
   'v1/caver/find': ['validateId'],
@@ -64,6 +65,8 @@ module.exports.policies = {
   'v1/caver/get-users': 'tokenAuth',
   'v1/caver/put-on-group': 'tokenAuth',
   'v1/caver/remove-explored-cave': 'tokenAuth',
+  'v1/caver/ban': 'tokenAuth',
+  'v1/caver/unban': 'tokenAuth',
   'v1/caver/remove-from-group': 'tokenAuth',
   'v1/caver/set-groups': 'tokenAuth',
   'v1/caver/add-to-organization': 'tokenAuth',

--- a/config/routes.js
+++ b/config/routes.js
@@ -73,6 +73,7 @@ module.exports.routes = {
   // Caver
   'DELETE /api/v1/cavers/:caverId/groups/:groupId':
     'v1/caver/remove-from-group',
+  'GET /api/v1/cavers/banned': 'v1/caver/get-banned',
   'GET /api/v1/cavers/:id': 'v1/caver/find',
   'GET /api/v1/cavers/:caverId/documents': 'v1/document/find-by-caver-id',
   'GET /api/v1/cavers/:caverId/subscriptions': 'v1/caver/get-subscriptions',
@@ -94,6 +95,8 @@ module.exports.routes = {
     'v1/caver/add-to-organization',
   'DELETE /api/v1/cavers/:caverId/organizations/:organizationId':
     'v1/caver/remove-from-organization',
+  'POST /api/v1/cavers/:caverId/ban': 'v1/caver/ban',
+  'POST /api/v1/cavers/:caverId/unban': 'v1/caver/unban',
   'DELETE /api/v1/cavers/:id': 'v1/caver/delete',
 
   // Entrance

--- a/test/integration/4_routes/Account/change-password-banned.test.js
+++ b/test/integration/4_routes/Account/change-password-banned.test.js
@@ -1,0 +1,89 @@
+const supertest = require('supertest');
+const should = require('should');
+const TokenService = require('../../../../api/services/TokenService');
+
+const NEW_PASSWORD = 'newpassword123';
+const targetCaverId = 3; // user1
+
+describe('Account features', () => {
+  describe('Change password - Banned caver', () => {
+    let originalPasswordHash;
+
+    beforeEach(async () => {
+      const caver = await TCaver.findOne({ id: targetCaverId });
+      originalPasswordHash = caver.password;
+    });
+
+    afterEach(async () => {
+      // Restore banned flag and original password
+      await TCaver.updateOne({ id: targetCaverId }).set({
+        banned: false,
+        password: originalPasswordHash,
+      });
+    });
+
+    it('should return 403 with expired token message when a banned caver changes password via reset token', async () => {
+      const userFound = await TCaver.findOne({ id: targetCaverId });
+      const resetToken = TokenService.issue(
+        { userId: userFound.id },
+        sails.config.custom.passwordResetTokenTTL,
+        'Reset password',
+        TokenService.getResetPasswordTokenSalt(userFound)
+      );
+
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .patch('/api/v1/account/password')
+        .send({ password: NEW_PASSWORD, token: resetToken })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403);
+
+      should(res.body).have.property(
+        'message',
+        'The password reset token has expired.'
+      );
+    });
+
+    it('should NOT change the password for a banned caver', async () => {
+      const userFound = await TCaver.findOne({ id: targetCaverId });
+      const resetToken = TokenService.issue(
+        { userId: userFound.id },
+        sails.config.custom.passwordResetTokenTTL,
+        'Reset password',
+        TokenService.getResetPasswordTokenSalt(userFound)
+      );
+
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      await supertest(sails.hooks.http.app)
+        .patch('/api/v1/account/password')
+        .send({ password: NEW_PASSWORD, token: resetToken })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(403);
+
+      // Verify password hash is unchanged
+      const caverAfter = await TCaver.findOne({ id: targetCaverId });
+      should(caverAfter.password).equal(originalPasswordHash);
+    });
+
+    it('should allow a non-banned caver to change password via valid reset token (returns 204)', async () => {
+      const userFound = await TCaver.findOne({ id: targetCaverId });
+      const resetToken = TokenService.issue(
+        { userId: userFound.id },
+        sails.config.custom.passwordResetTokenTTL,
+        'Reset password',
+        TokenService.getResetPasswordTokenSalt(userFound)
+      );
+
+      await supertest(sails.hooks.http.app)
+        .patch('/api/v1/account/password')
+        .send({ password: NEW_PASSWORD, token: resetToken })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204);
+    });
+  });
+});

--- a/test/integration/4_routes/Account/forgot-password-banned.test.js
+++ b/test/integration/4_routes/Account/forgot-password-banned.test.js
@@ -1,0 +1,92 @@
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+const targetCaverId = 3; // user1
+const targetEmail = 'user1@user1.com';
+
+describe('Account features', () => {
+  describe('Forgot password - Banned caver', () => {
+    beforeEach(() => {
+      // Stub the sendEmail helper to track calls without actually sending
+      // sails.helpers.sendEmail.with({...}).intercept(...) is the call pattern
+      // We replace the entire helper with a stub that returns a chainable object
+      sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sinon.stub().returns({
+          intercept: sinon.stub().resolves(),
+        }),
+      });
+    });
+
+    afterEach(async () => {
+      // Restore banned flag
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+      // Restore the original sendEmail helper
+      sinon.restore();
+    });
+
+    it('should return 204 for a banned caver forgot-password request', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/forgotPassword')
+        .send({ email: targetEmail })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204);
+    });
+
+    it('should not send email for a banned caver', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/forgotPassword')
+        .send({ email: targetEmail })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204);
+
+      // sendEmail.with() should NOT have been called for banned caver
+      should(sails.helpers.sendEmail.with.called).be.false();
+    });
+
+    it('should return 204 for a non-banned caver and send email', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/forgotPassword')
+        .send({ email: targetEmail })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204);
+
+      // sendEmail.with() should have been called for non-banned caver
+      should(sails.helpers.sendEmail.with.called).be.true();
+    });
+
+    it('should return identical response for banned and non-banned cavers', async () => {
+      // Banned request
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+      const bannedRes = await supertest(sails.hooks.http.app)
+        .post('/api/v1/forgotPassword')
+        .send({ email: targetEmail })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      // Non-banned request
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+      const nonBannedRes = await supertest(sails.hooks.http.app)
+        .post('/api/v1/forgotPassword')
+        .send({ email: targetEmail })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      // Status codes should be identical
+      should(bannedRes.status).equal(nonBannedRes.status);
+      // Response bodies should be identical (both empty for 204)
+      should(JSON.stringify(bannedRes.body)).equal(
+        JSON.stringify(nonBannedRes.body)
+      );
+    });
+  });
+});

--- a/test/integration/4_routes/Auth/sign-up-enumeration.test.js
+++ b/test/integration/4_routes/Auth/sign-up-enumeration.test.js
@@ -1,0 +1,78 @@
+const supertest = require('supertest');
+const should = require('should');
+
+describe('Auth features', () => {
+  describe('Sign-up enumeration prevention', () => {
+    const GENERIC_MESSAGE = 'Email or nickname is already used.';
+
+    describe('Duplicate email', () => {
+      const duplicateEmail = 'admin1@admin1.com';
+
+      it('should return 409 with generic conflict message', async () => {
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: duplicateEmail,
+            nickname: 'UniqueNickname123',
+            password: 'securepassword',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(409);
+
+        should(res.body).have.property('message', GENERIC_MESSAGE);
+      });
+
+      it('should NOT contain the specific email address in the response body', async () => {
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: duplicateEmail,
+            nickname: 'UniqueNickname456',
+            password: 'securepassword',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(409);
+
+        const bodyStr = JSON.stringify(res.body);
+        should(bodyStr).not.containEql(duplicateEmail);
+      });
+    });
+
+    describe('Duplicate nickname', () => {
+      const duplicateNickname = 'Admin1';
+
+      it('should return 409 with generic conflict message', async () => {
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: 'unique-email@example.com',
+            nickname: duplicateNickname,
+            password: 'securepassword',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(409);
+
+        should(res.body).have.property('message', GENERIC_MESSAGE);
+      });
+
+      it('should NOT contain the specific nickname in the response body', async () => {
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: 'unique-email2@example.com',
+            nickname: duplicateNickname,
+            password: 'securepassword',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(409);
+
+        const bodyStr = JSON.stringify(res.body);
+        should(bodyStr).not.containEql(duplicateNickname);
+      });
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/ban-unban.property.test.js
+++ b/test/integration/4_routes/Cavers/ban-unban.property.test.js
@@ -1,0 +1,668 @@
+/* eslint-disable no-await-in-loop */
+const supertest = require('supertest');
+const should = require('should');
+const fc = require('fast-check');
+const sinon = require('sinon');
+const AuthTokenService = require('../../AuthTokenService');
+const TokenService = require('../../../../api/services/TokenService');
+
+const targetCaverId = 3; // user1
+const targetEmail = 'user1@user1.com';
+const TEST_PASSWORD = 'testtest';
+
+// Allow fire-and-forget DB write to settle
+const waitForMetadata = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 200);
+  });
+
+describe('Caver features', () => {
+  describe('Ban/Unban Property-Based Tests', () => {
+    let adminToken;
+    let userToken;
+    let moderatorToken;
+    let leaderToken;
+
+    before(function setup() {
+      this.timeout(120000);
+      return (async () => {
+        adminToken = await AuthTokenService.getRawBearerAdminToken();
+        userToken = await AuthTokenService.getRawBearerUserToken();
+        moderatorToken = await AuthTokenService.getRawBearerModeratorToken();
+        leaderToken = await AuthTokenService.getRawBearerLeaderToken();
+      })();
+    });
+
+    afterEach(async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+      sails.services.blacklistservice.getCache().delete(targetCaverId);
+    });
+
+    // Feature: admin-ban-caver, Property 1: Ban/unban round trip
+    // Validates: Requirements 1.1, 2.1
+    it('Property 1: Ban/unban round trip — banning then unbanning results in banned=false', function prop1() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(fc.integer({ min: 1, max: 3 }), async (cycles) => {
+          try {
+            for (let i = 0; i < cycles; i += 1) {
+              const banRes = await supertest(sails.hooks.http.app)
+                .post(`/api/v1/cavers/${targetCaverId}/ban`)
+                .set('Authorization', adminToken)
+                .set('Accept', 'application/json');
+              should(banRes.status).equal(200);
+              should(banRes.body).have.property('banned', true);
+
+              const unbanRes = await supertest(sails.hooks.http.app)
+                .post(`/api/v1/cavers/${targetCaverId}/unban`)
+                .set('Authorization', adminToken)
+                .set('Accept', 'application/json');
+              should(unbanRes.status).equal(200);
+              should(unbanRes.body).have.property('banned', false);
+            }
+
+            const caver = await TCaver.findOne({ id: targetCaverId });
+            should(caver.banned).be.false();
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            sails.services.blacklistservice.getCache().delete(targetCaverId);
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 2: Ban revokes all active tokens
+    // Validates: Requirements 1.1
+    it('Property 2: Ban revokes all active tokens — after ban, tokens issued before are revoked', function prop2() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(fc.integer({ min: 1, max: 3 }), async (cycles) => {
+          try {
+            for (let i = 0; i < cycles; i += 1) {
+              await TCaver.updateOne({ id: targetCaverId }).set({
+                banned: false,
+              });
+              sails.services.blacklistservice.getCache().delete(targetCaverId);
+
+              const iatBeforeBan = Math.floor(Date.now() / 1000) - 10;
+
+              await supertest(sails.hooks.http.app)
+                .post(`/api/v1/cavers/${targetCaverId}/ban`)
+                .set('Authorization', adminToken)
+                .set('Accept', 'application/json')
+                .expect(200);
+
+              const isRevoked = sails.services.blacklistservice.isRevoked(
+                targetCaverId,
+                iatBeforeBan
+              );
+              should(isRevoked).be.true();
+            }
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            sails.services.blacklistservice.getCache().delete(targetCaverId);
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 3: Non-admin ban is rejected
+    // Validates: Requirements 1.2, 1.3
+    it('Property 3: Non-admin ban is rejected — returns 403, banned flag unchanged', function prop3() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom('user', 'moderator', 'leader'),
+          fc.integer({ min: 1, max: 3 }),
+          async (role, cycles) => {
+            const tokenMap = {
+              user: userToken,
+              moderator: moderatorToken,
+              leader: leaderToken,
+            };
+            const token = tokenMap[role];
+
+            try {
+              for (let i = 0; i < cycles; i += 1) {
+                const caverBefore = await TCaver.findOne({
+                  id: targetCaverId,
+                });
+
+                const res = await supertest(sails.hooks.http.app)
+                  .post(`/api/v1/cavers/${targetCaverId}/ban`)
+                  .set('Authorization', token)
+                  .set('Accept', 'application/json');
+                should(res.status).equal(403);
+
+                const caverAfter = await TCaver.findOne({
+                  id: targetCaverId,
+                });
+                should(caverAfter.banned).equal(caverBefore.banned);
+              }
+            } finally {
+              await TCaver.updateOne({ id: targetCaverId }).set({
+                banned: false,
+              });
+            }
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 4: Non-admin unban is rejected
+    // Validates: Requirements 2.2, 2.3
+    it('Property 4: Non-admin unban is rejected — returns 403, banned flag unchanged', function prop4() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom('user', 'moderator', 'leader'),
+          fc.integer({ min: 1, max: 3 }),
+          async (role, cycles) => {
+            const tokenMap = {
+              user: userToken,
+              moderator: moderatorToken,
+              leader: leaderToken,
+            };
+            const token = tokenMap[role];
+
+            try {
+              for (let i = 0; i < cycles; i += 1) {
+                const caverBefore = await TCaver.findOne({
+                  id: targetCaverId,
+                });
+
+                const res = await supertest(sails.hooks.http.app)
+                  .post(`/api/v1/cavers/${targetCaverId}/unban`)
+                  .set('Authorization', token)
+                  .set('Accept', 'application/json');
+                should(res.status).equal(403);
+
+                const caverAfter = await TCaver.findOne({
+                  id: targetCaverId,
+                });
+                should(caverAfter.banned).equal(caverBefore.banned);
+              }
+            } finally {
+              await TCaver.updateOne({ id: targetCaverId }).set({
+                banned: false,
+              });
+            }
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 5: Ban is idempotent
+    // Validates: Requirements 1.5
+    it('Property 5: Ban is idempotent — banning already-banned caver returns 200, stays true', function prop5() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(fc.integer({ min: 1, max: 3 }), async (extraBans) => {
+          try {
+            // Initial ban
+            await supertest(sails.hooks.http.app)
+              .post(`/api/v1/cavers/${targetCaverId}/ban`)
+              .set('Authorization', adminToken)
+              .set('Accept', 'application/json')
+              .expect(200);
+
+            for (let i = 0; i < extraBans; i += 1) {
+              const res = await supertest(sails.hooks.http.app)
+                .post(`/api/v1/cavers/${targetCaverId}/ban`)
+                .set('Authorization', adminToken)
+                .set('Accept', 'application/json');
+              should(res.status).equal(200);
+              should(res.body).have.property('banned', true);
+            }
+
+            const caver = await TCaver.findOne({ id: targetCaverId });
+            should(caver.banned).be.true();
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            sails.services.blacklistservice.getCache().delete(targetCaverId);
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 6: Unban is idempotent
+    // Validates: Requirements 2.5
+    it('Property 6: Unban is idempotent — unbanning non-banned caver returns 200, stays false', function prop6() {
+      this.timeout(30000);
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 3 }),
+          async (extraUnbans) => {
+            try {
+              // Ensure not banned
+              await TCaver.updateOne({ id: targetCaverId }).set({
+                banned: false,
+              });
+
+              for (let i = 0; i < extraUnbans; i += 1) {
+                const res = await supertest(sails.hooks.http.app)
+                  .post(`/api/v1/cavers/${targetCaverId}/unban`)
+                  .set('Authorization', adminToken)
+                  .set('Accept', 'application/json');
+                should(res.status).equal(200);
+                should(res.body).have.property('banned', false);
+              }
+
+              const caver = await TCaver.findOne({ id: targetCaverId });
+              should(caver.banned).be.false();
+            } finally {
+              await TCaver.updateOne({ id: targetCaverId }).set({
+                banned: false,
+              });
+            }
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 7: Banned caver login rejected without token issuance
+    // Validates: Requirements 3.1, 3.2, 3.3
+    it('Property 7: Banned caver login rejected — 401 with generic message, no token in response', function prop7() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/login')
+              .send({ email: targetEmail, password: TEST_PASSWORD })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            if (isBanned) {
+              should(res.status).equal(401);
+              should(res.body).have.property('status', 'Mismatch');
+              should(res.body).not.have.property('token');
+            } else {
+              should(res.status).equal(200);
+              should(res.body).have.property('token');
+            }
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 8: date_last_connection updated
+    // Validates: Requirements 4.1, 4.2
+    it('Property 8: date_last_connection updated — within reasonable window after login', function prop8() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            // Store a DB-side "before" marker and reset date_last_connection
+            await CommonService.query(
+              `UPDATE t_caver SET date_last_connection = NULL WHERE id = $1`,
+              [targetCaverId]
+            );
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            // Record DB time before login
+            const beforeResult = await CommonService.query(
+              `SELECT extract(epoch from NOW()) AS epoch`
+            );
+            const beforeEpoch = parseFloat(beforeResult.rows[0].epoch);
+
+            await supertest(sails.hooks.http.app)
+              .post('/api/v1/login')
+              .send({ email: targetEmail, password: TEST_PASSWORD })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            // Record DB time after login
+            const afterResult = await CommonService.query(
+              `SELECT extract(epoch from NOW()) AS epoch`
+            );
+            const afterEpoch = parseFloat(afterResult.rows[0].epoch);
+
+            // Allow fire-and-forget DB write to settle
+            await waitForMetadata();
+
+            // Read date_last_connection as epoch from DB to avoid timezone parsing issues
+            const result = await CommonService.query(
+              `SELECT extract(epoch from date_last_connection) AS epoch FROM t_caver WHERE id = $1`,
+              [targetCaverId]
+            );
+            should(result.rows[0].epoch).not.be.null();
+            const lastConnEpoch = parseFloat(result.rows[0].epoch);
+            should(lastConnEpoch).be.greaterThanOrEqual(beforeEpoch - 2);
+            should(lastConnEpoch).be.lessThanOrEqual(afterEpoch + 2);
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            await CommonService.query(
+              `UPDATE t_caver SET date_last_connection = NULL WHERE id = $1`,
+              [targetCaverId]
+            );
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 9: connection_counter incremented
+    // Validates: Requirements 5.1, 5.2
+    it('Property 9: connection_counter incremented — counter is N+1 after login', function prop9() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            await CommonService.query(
+              `UPDATE t_caver SET connection_counter = 0 WHERE id = $1`,
+              [targetCaverId]
+            );
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            const beforeResult = await CommonService.query(
+              `SELECT connection_counter FROM t_caver WHERE id = $1`,
+              [targetCaverId]
+            );
+            const counterBefore = beforeResult.rows[0].connection_counter;
+
+            await supertest(sails.hooks.http.app)
+              .post('/api/v1/login')
+              .send({ email: targetEmail, password: TEST_PASSWORD })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            // Allow fire-and-forget DB write to settle
+            await waitForMetadata();
+
+            const afterResult = await CommonService.query(
+              `SELECT connection_counter FROM t_caver WHERE id = $1`,
+              [targetCaverId]
+            );
+            const counterAfter = afterResult.rows[0].connection_counter;
+            should(counterAfter).equal(counterBefore + 1);
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            await CommonService.query(
+              `UPDATE t_caver SET connection_counter = 0, date_last_connection = NULL WHERE id = $1`,
+              [targetCaverId]
+            );
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 10: Forgot-password silently suppresses reset for banned cavers
+    // Validates: Requirements 6.1, 6.2, 6.3
+    it('Property 10: Forgot-password silently suppresses reset for banned cavers — 204 regardless, email only if not banned', function prop10() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            sinon.stub(sails.helpers, 'sendEmail').value({
+              with: sinon.stub().returns({
+                intercept: sinon.stub().resolves(),
+              }),
+            });
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/forgotPassword')
+              .send({ email: targetEmail })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(204);
+
+            if (isBanned) {
+              should(sails.helpers.sendEmail.with.called).be.false();
+            } else {
+              should(sails.helpers.sendEmail.with.called).be.true();
+            }
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+            sinon.restore();
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 11: Banned caver password change via reset token is rejected
+    // Validates: Requirements 7.1, 7.3
+    it('Property 11: Banned caver password change via reset token is rejected — 403 with expired message, password unchanged', function prop11() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          let originalPasswordHash;
+          try {
+            // Fetch caver to get password hash and generate a valid reset token
+            const userFound = await TCaver.findOne({ id: targetCaverId });
+            originalPasswordHash = userFound.password;
+
+            const resetToken = TokenService.issue(
+              { userId: userFound.id },
+              sails.config.custom.passwordResetTokenTTL,
+              'Reset password',
+              TokenService.getResetPasswordTokenSalt(userFound)
+            );
+
+            // Set banned flag
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            // Call change-password endpoint with the reset token
+            const res = await supertest(sails.hooks.http.app)
+              .patch('/api/v1/account/password')
+              .send({ password: 'newpassword123', token: resetToken })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            if (isBanned) {
+              // Banned: should be rejected with 403 and expired-token message
+              should(res.status).equal(403);
+              should(res.body).have.property(
+                'message',
+                'The password reset token has expired.'
+              );
+              // Password hash must remain unchanged
+              const caverAfter = await TCaver.findOne({ id: targetCaverId });
+              should(caverAfter.password).equal(originalPasswordHash);
+            } else {
+              // Not banned: should succeed
+              should(res.status).equal(204);
+              // Password hash should have changed
+              const caverAfter = await TCaver.findOne({ id: targetCaverId });
+              should(caverAfter.password).not.equal(originalPasswordHash);
+            }
+          } finally {
+            // Restore banned=false and original password hash
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+              password: originalPasswordHash,
+            });
+          }
+        }),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 12: Sign-up conflict returns generic message
+    // Validates: Requirements 8.1, 8.2
+    it('Property 12: Sign-up conflict returns generic message — 409 with generic text, no specific value leaked', function prop12() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom('email', 'nickname'),
+          fc.integer({ min: 1, max: 99999 }),
+          async (conflictField, suffix) => {
+            let email;
+            let nickname;
+
+            if (conflictField === 'email') {
+              // Use an existing email, generate a unique nickname
+              email = 'admin1@admin1.com';
+              nickname = `UniqueNick${suffix}`;
+            } else {
+              // Use a unique email, use an existing nickname
+              email = `unique${suffix}@test.com`;
+              nickname = 'Admin1';
+            }
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/signup')
+              .send({ email, nickname, password: 'securepassword' })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(409);
+            should(res.body).have.property(
+              'message',
+              'Email or nickname is already used.'
+            );
+
+            // The response body must not contain the specific conflicting value
+            const bodyStr = JSON.stringify(res.body);
+            if (conflictField === 'email') {
+              should(bodyStr).not.containEql('admin1@admin1.com');
+            } else {
+              should(bodyStr).not.containEql('Admin1');
+            }
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 13: Admin-only ban status exposure
+    // Validates: Requirements 9.1, 9.2, 9.3
+    it('Property 13: Admin-only ban status exposure — isBanned visible only to admins and matches banned column', function prop13() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            // Admin caller — should see isBanned matching the banned column
+            const adminRes = await supertest(sails.hooks.http.app)
+              .get(`/api/v1/cavers/${targetCaverId}`)
+              .set('Authorization', adminToken)
+              .set('Accept', 'application/json');
+            should(adminRes.status).equal(200);
+            should(adminRes.body).have.property('isBanned', isBanned);
+
+            // Non-admin authenticated caller — should NOT see isBanned
+            const userRes = await supertest(sails.hooks.http.app)
+              .get(`/api/v1/cavers/${targetCaverId}`)
+              .set('Authorization', userToken)
+              .set('Accept', 'application/json');
+            should(userRes.status).equal(200);
+            should(userRes.body).not.have.property('isBanned');
+
+            // Unauthenticated caller — should NOT see isBanned
+            const anonRes = await supertest(sails.hooks.http.app)
+              .get(`/api/v1/cavers/${targetCaverId}`)
+              .set('Accept', 'application/json');
+            should(anonRes.status).equal(200);
+            should(anonRes.body).not.have.property('isBanned');
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+          }
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    // Feature: admin-ban-caver, Property 14: Admin-only banned cavers listing returns only banned cavers
+    // Validates: Requirements 10.1, 10.2, 10.3, 10.6
+    it('Property 14: Admin-only banned cavers listing returns only banned cavers', function prop14() {
+      this.timeout(120000);
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isBanned) => {
+          try {
+            // Toggle the target caver's banned state
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: isBanned,
+            });
+
+            // Admin caller — should get the banned list
+            const adminRes = await supertest(sails.hooks.http.app)
+              .get('/api/v1/cavers/banned')
+              .set('Authorization', adminToken)
+              .set('Accept', 'application/json');
+            should(adminRes.status).equal(200);
+            should(adminRes.body).have.property('banned');
+            should(adminRes.body.banned).be.an.Array();
+
+            // Every entry must have id and nickname (toSimpleCaver shape)
+            adminRes.body.banned.forEach((entry) => {
+              should(entry).have.property('id');
+              should(entry).have.property('nickname');
+            });
+
+            const targetEntry = adminRes.body.banned.find(
+              (c) => c.id === targetCaverId
+            );
+
+            if (isBanned) {
+              // Target caver should appear in the banned list
+              should(targetEntry).be.ok();
+              should(targetEntry).have.property('id', targetCaverId);
+              should(targetEntry).have.property('nickname');
+            } else {
+              // Target caver should NOT appear in the banned list
+              should(targetEntry).be.undefined();
+            }
+
+            // Non-admin caller — should get 403
+            const userRes = await supertest(sails.hooks.http.app)
+              .get('/api/v1/cavers/banned')
+              .set('Authorization', userToken)
+              .set('Accept', 'application/json');
+            should(userRes.status).equal(403);
+          } finally {
+            await TCaver.updateOne({ id: targetCaverId }).set({
+              banned: false,
+            });
+          }
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/ban.test.js
+++ b/test/integration/4_routes/Cavers/ban.test.js
@@ -1,0 +1,106 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Caver features', () => {
+  describe('Ban', () => {
+    let adminToken;
+    let userToken;
+    const targetCaverId = 3; // user1
+
+    before(async () => {
+      adminToken = await AuthTokenService.getRawBearerAdminToken();
+      userToken = await AuthTokenService.getRawBearerUserToken();
+    });
+
+    afterEach(async () => {
+      // Reset banned flag and clear blacklist cache for target caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+      sails.services.blacklistservice.getCache().delete(targetCaverId);
+    });
+
+    it('should return 401 when no bearer token is provided', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+
+    it('should return 403 when non-admin calls ban', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 403 when admin bans themselves', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/cavers/1/ban') // admin1 id=1
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(403)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.message).containEql('cannot ban yourself');
+          return done();
+        });
+    });
+
+    it('should return 404 when target caver does not exist', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/cavers/999999/ban')
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+
+    it('should return 200 when banning a non-banned caver', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body).have.property('banned', true);
+          return done();
+        });
+    });
+
+    it('should return 200 idempotent when banning an already-banned caver', async () => {
+      // First ban
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      // Second ban (idempotent)
+      const res = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('banned', true);
+    });
+
+    it('should revoke tokens after ban', async () => {
+      sails.services.blacklistservice.getCache().delete(targetCaverId);
+
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/ban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const iatBeforeBan = Math.floor(Date.now() / 1000) - 10;
+      const isRevoked = sails.services.blacklistservice.isRevoked(
+        targetCaverId,
+        iatBeforeBan
+      );
+      should(isRevoked).be.true();
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/find-banned.test.js
+++ b/test/integration/4_routes/Cavers/find-banned.test.js
@@ -1,0 +1,68 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Caver features', () => {
+  describe('find() - isBanned field exposure', () => {
+    let adminToken;
+    let userToken;
+    const targetCaverId = 3; // user1
+
+    before(async () => {
+      adminToken = await AuthTokenService.getRawBearerAdminToken();
+      userToken = await AuthTokenService.getRawBearerUserToken();
+    });
+
+    afterEach(async () => {
+      // Reset banned flag for target caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+    });
+
+    it('should include isBanned=true for a banned caver when called by admin', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/cavers/${targetCaverId}`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('isBanned', true);
+    });
+
+    it('should include isBanned=false for a non-banned caver when called by admin', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/cavers/${targetCaverId}`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('isBanned', false);
+    });
+
+    it('should NOT include isBanned for a non-admin authenticated caver', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/cavers/${targetCaverId}`)
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).not.have.property('isBanned');
+    });
+
+    it('should NOT include isBanned for an unauthenticated caller', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/cavers/${targetCaverId}`)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).not.have.property('isBanned');
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/get-banned.test.js
+++ b/test/integration/4_routes/Cavers/get-banned.test.js
@@ -1,0 +1,77 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Caver features', () => {
+  describe('Get Banned', () => {
+    let adminToken;
+    let userToken;
+    const targetCaverId = 3; // user1
+
+    before(async () => {
+      adminToken = await AuthTokenService.getRawBearerAdminToken();
+      userToken = await AuthTokenService.getRawBearerUserToken();
+    });
+
+    afterEach(async () => {
+      // Restore banned = false on test caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+    });
+
+    it('should return 401 when no bearer token is provided', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/banned')
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+
+    it('should return 403 when non-admin calls get-banned', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/banned')
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 200 with empty banned array when no cavers are banned', async () => {
+      // Ensure no cavers are banned
+      await TCaver.update({ banned: true }).set({ banned: false });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/banned')
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('banned');
+      should(res.body.banned).be.an.Array();
+      should(res.body.banned).have.length(0);
+    });
+
+    it('should return 200 with banned cavers, each having id and nickname', async () => {
+      // Ban the target caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .get('/api/v1/cavers/banned')
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('banned');
+      should(res.body.banned).be.an.Array();
+      should(res.body.banned.length).be.greaterThanOrEqual(1);
+
+      const bannedEntry = res.body.banned.find((c) => c.id === targetCaverId);
+      should(bannedEntry).be.ok();
+      should(bannedEntry).have.property('id', targetCaverId);
+      should(bannedEntry).have.property('nickname');
+
+      // Verify every entry has id and nickname
+      res.body.banned.forEach((entry) => {
+        should(entry).have.property('id');
+        should(entry).have.property('nickname');
+      });
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/login-banned.test.js
+++ b/test/integration/4_routes/Cavers/login-banned.test.js
@@ -1,0 +1,112 @@
+const supertest = require('supertest');
+const should = require('should');
+
+const TEST_PASSWORD = 'testtest';
+const targetCaverId = 3; // user1
+const targetEmail = 'user1@user1.com';
+
+// Allow fire-and-forget DB write to settle
+const waitForMetadata = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 200);
+  });
+
+describe('Caver features', () => {
+  describe('Login - Banned caver', () => {
+    beforeEach(async () => {
+      // Reset connection metadata before each test
+      await CommonService.query(
+        `UPDATE t_caver SET connection_counter = 0, date_last_connection = NULL WHERE id = $1`,
+        [targetCaverId]
+      );
+    });
+
+    afterEach(async () => {
+      // Reset banned flag after each test
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+    });
+
+    it('should return 401 when a banned caver logs in with valid credentials', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/login')
+        .send({ email: targetEmail, password: TEST_PASSWORD })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(401);
+
+      should(res.body).have.property('status', 'Mismatch');
+      should(res.body).not.have.property('token');
+    });
+
+    it('should update date_last_connection for a banned caver after login attempt', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+      const before = new Date();
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/login')
+        .send({ email: targetEmail, password: TEST_PASSWORD })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(401);
+
+      await waitForMetadata();
+      const caver = await TCaver.findOne({ id: targetCaverId });
+      should(caver.dateLastConnection).not.be.null();
+      const lastConn = new Date(caver.dateLastConnection);
+      should(lastConn.getTime()).be.greaterThanOrEqual(before.getTime() - 1000);
+    });
+
+    it('should increment connection_counter for a banned caver after login attempt', async () => {
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/login')
+        .send({ email: targetEmail, password: TEST_PASSWORD })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(401);
+
+      await waitForMetadata();
+      const result = await CommonService.query(
+        `SELECT connection_counter FROM t_caver WHERE id = $1`,
+        [targetCaverId]
+      );
+      should(result.rows[0].connection_counter).equal(1);
+    });
+
+    it('should update date_last_connection for a non-banned caver after successful login', async () => {
+      const before = new Date();
+
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/login')
+        .send({ email: targetEmail, password: TEST_PASSWORD })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      await waitForMetadata();
+      const caver = await TCaver.findOne({ id: targetCaverId });
+      should(caver.dateLastConnection).not.be.null();
+      const lastConn = new Date(caver.dateLastConnection);
+      should(lastConn.getTime()).be.greaterThanOrEqual(before.getTime() - 1000);
+    });
+
+    it('should increment connection_counter for a non-banned caver after successful login', async () => {
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/login')
+        .send({ email: targetEmail, password: TEST_PASSWORD })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      await waitForMetadata();
+      const result = await CommonService.query(
+        `SELECT connection_counter FROM t_caver WHERE id = $1`,
+        [targetCaverId]
+      );
+      should(result.rows[0].connection_counter).equal(1);
+    });
+  });
+});

--- a/test/integration/4_routes/Cavers/unban.test.js
+++ b/test/integration/4_routes/Cavers/unban.test.js
@@ -1,0 +1,74 @@
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Caver features', () => {
+  describe('Unban', () => {
+    let adminToken;
+    let userToken;
+    const targetCaverId = 3; // user1
+
+    before(async () => {
+      adminToken = await AuthTokenService.getRawBearerAdminToken();
+      userToken = await AuthTokenService.getRawBearerUserToken();
+    });
+
+    afterEach(async () => {
+      // Reset banned flag for target caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+    });
+
+    it('should return 401 when no bearer token is provided', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/unban`)
+        .set('Accept', 'application/json')
+        .expect(401, done);
+    });
+
+    it('should return 403 when non-admin calls unban', (done) => {
+      supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/unban`)
+        .set('Authorization', userToken)
+        .set('Accept', 'application/json')
+        .expect(403, done);
+    });
+
+    it('should return 404 when target caver does not exist', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/cavers/999999/unban')
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(404, done);
+    });
+
+    it('should return 200 when unbanning a banned caver', async () => {
+      // First ban the caver
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: true });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/unban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('banned', false);
+
+      // Verify in DB
+      const caver = await TCaver.findOne({ id: targetCaverId });
+      should(caver.banned).be.false();
+    });
+
+    it('should return 200 idempotent when unbanning a non-banned caver', async () => {
+      // Ensure caver is not banned
+      await TCaver.updateOne({ id: targetCaverId }).set({ banned: false });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/cavers/${targetCaverId}/unban`)
+        .set('Authorization', adminToken)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(res.body).have.property('banned', false);
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

Add admin-only ban/unban endpoints, harden all unauthenticated flows against information leakage, expose ban status to admins, and provide a banned cavers listing.

- `POST /api/v1/cavers/:caverId/ban` — sets `banned=true`, revokes all active tokens via BlacklistService
- `POST /api/v1/cavers/:caverId/unban` — sets `banned=false`
- `GET /api/v1/cavers/:id` — now includes `isBanned` field when the caller is an administrator
- `GET /api/v1/cavers/banned` — admin-only endpoint returning all banned cavers (`{ banned: [{ id, nickname, name, surname }] }`)
- Activate the existing `banned`, `date_last_connection`, and `connection_counter` columns on `t_caver`
- Harden login, forgot-password, change-password, and sign-up endpoints
- Introduce `toListCaver` converter (`{ id, nickname, name, surname }`) used by `get-banned`, `get-groups`, `get-admins`, and `get-moderators` — keeps `toSimpleCaver` (`{ id, nickname }`) unchanged for author/reviewer references

## 🤷‍♂️ Why

Administrators currently revoke caver tokens manually via direct database inserts into `t_token_blacklist`. This feature provides a proper REST API for banning cavers, with persistent ban tracking and comprehensive security hardening so that ban status is never leaked to callers. Admins can now see ban status on individual caver profiles and list all banned accounts from a single endpoint.

## 🔍 How

**Ban/Unban endpoints** (`api/controllers/v1/caver/ban.js`, `unban.js`):
- Admin-only (checked via `RightService.hasGroup`), self-ban prevention, idempotent
- Ban sets `banned=true` and calls `BlacklistService.revoke()` to invalidate all pre-ban tokens

**Login hardening** (`api/controllers/v1/auth/login.js`):
- Banned cavers get a generic `401 { status: 'Mismatch', message: 'Invalid email or password.' }` — identical to wrong credentials
- `date_last_connection` and `connection_counter` updated on every successful credential verification (including banned cavers)
- `sails.log.warn` emitted for banned login attempts

**Forgot-password hardening** (`api/controllers/v1/account/forgot-password.js`):
- Banned cavers get a silent `200 OK` with no token generated and no email sent
- `sails.log.warn` emitted

**Change-password hardening** (`api/controllers/v1/account/change-password.js`):
- Banned cavers using a pre-ban reset token get `403 'The password reset token has expired.'` — same as a genuinely expired token
- `sails.log.warn` emitted

**Sign-up enumeration prevention** (`api/controllers/v1/auth/sign-up.js`):
- Duplicate email/nickname conflicts now return a generic `409 'Email or nickname is already used.'` instead of specifying which field
- `sails.log.warn` with the specific detail emitted server-side

**Ban status in caver profile** (`api/controllers/v1/caver/find.js`, `api/services/mapping/converters.js`):
- `GET /api/v1/cavers/:id` conditionally includes `isBanned` (boolean) when the caller is an admin
- Non-admin and unauthenticated callers never see this field
- `CaverService.getCaver` now returns the `banned` field

**List banned cavers** (`api/controllers/v1/caver/get-banned.js`):
- `GET /api/v1/cavers/banned` returns `{ banned: [{ id, nickname, name, surname }] }` — all banned cavers in one response
- Follows the same pattern as `get-groups.js` (no pagination)
- Admin-only access via `RightService.hasGroup`

**New `toListCaver` converter** (`api/services/mapping/converters.js`):
- Returns `{ id, nickname, name, surname }` — richer than `toSimpleCaver` but scoped to listing endpoints
- Used by `get-banned`, `get-groups`, `get-admins`, `get-moderators`
- `toSimpleCaver` (`{ id, nickname }`) remains unchanged for author/reviewer nested references

**Swagger** (`assets/swaggerV1.yaml`): Updated for all modified and new endpoints.

## 🧪 Testing

```bash
PORT=1338 npm run test
```

Integration tests added:
- `test/integration/4_routes/Cavers/ban.test.js`
- `test/integration/4_routes/Cavers/unban.test.js`
- `test/integration/4_routes/Cavers/login-banned.test.js`
- `test/integration/4_routes/Cavers/find-banned.test.js`
- `test/integration/4_routes/Cavers/get-banned.test.js`
- `test/integration/4_routes/Account/forgot-password-banned.test.js`
- `test/integration/4_routes/Account/change-password-banned.test.js`
- `test/integration/4_routes/Auth/sign-up-enumeration.test.js`

Property-based tests (fast-check, 14 properties):
- `test/integration/4_routes/Cavers/ban-unban.property.test.js`

## 📸 Previews

N/A — backend-only changes.
