### PR TITLE
fix(search): forward Typesense 4xx errors as HTTP 400

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -1,4 +1,7 @@
 const SearchService = require('../../../services/SearchService');
+const {
+  handleTypesenseError,
+} = require('../../../services/TypesenseErrorService');
 
 function escapeCSV(v) {
   // Escape double quotes
@@ -106,13 +109,8 @@ module.exports = async (req, res) => {
         size: BATCH_SIZE,
       });
     } catch (err) {
-      if (err.code === 'E_SORT_VALIDATION') {
-        if (!hasSentHeader) {
-          res.badRequest({ error: err.message });
-          return;
-        }
-        break;
-      }
+      if (!hasSentHeader && handleTypesenseError(res, err)) return;
+      if (hasSentHeader) break;
       results = err;
     }
 

--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -1,5 +1,8 @@
 const ControllerService = require('../../../services/ControllerService');
 const SearchService = require('../../../services/SearchService');
+const {
+  handleTypesenseError,
+} = require('../../../services/TypesenseErrorService');
 const { toSearchResult } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
@@ -18,9 +21,7 @@ module.exports = async (req, res) => {
       size: req.param('size') ?? 10,
     });
   } catch (error) {
-    if (error.code === 'E_SORT_VALIDATION') {
-      return res.badRequest({ error: error.message });
-    }
+    if (handleTypesenseError(res, error)) return undefined;
     throw error;
   }
 

--- a/api/controllers/v1/search/field-search.js
+++ b/api/controllers/v1/search/field-search.js
@@ -1,5 +1,8 @@
 const ControllerService = require('../../../services/ControllerService');
 const SearchService = require('../../../services/SearchService');
+const {
+  handleTypesenseError,
+} = require('../../../services/TypesenseErrorService');
 
 module.exports = async (req, res) => {
   const field = req.param('field');
@@ -16,14 +19,20 @@ module.exports = async (req, res) => {
   let matchAllFields = req.param('matchAllFields') ?? true;
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
 
-  const r = await SearchService.fieldSearch({
-    entity,
-    field,
-    query: req.param('query'),
-    size: req.param('size') ?? 10,
-    filter: req.param('filter') ?? {},
-    isLogicalCompareAnd: !!matchAllFields,
-  });
+  let r;
+  try {
+    r = await SearchService.fieldSearch({
+      entity,
+      field,
+      query: req.param('query'),
+      size: req.param('size') ?? 10,
+      filter: req.param('filter') ?? {},
+      isLogicalCompareAnd: !!matchAllFields,
+    });
+  } catch (error) {
+    if (handleTypesenseError(res, error)) return;
+    throw error;
+  }
 
   const out = {
     totalDistinct: r.found,

--- a/api/controllers/v1/search/quick-search.js
+++ b/api/controllers/v1/search/quick-search.js
@@ -1,5 +1,8 @@
 const ControllerService = require('../../../services/ControllerService');
 const SearchService = require('../../../services/SearchService');
+const {
+  handleTypesenseError,
+} = require('../../../services/TypesenseErrorService');
 const { toSearchResult } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
@@ -10,11 +13,17 @@ module.exports = async (req, res) => {
   }
 
   // Search on multiple entities but with no pagging and sort
-  const results = await SearchService.multiCollectionsSearch({
-    query,
-    entities: req.param('entities'),
-    filter: req.param('filter') ?? {},
-  });
+  let results;
+  try {
+    results = await SearchService.multiCollectionsSearch({
+      query,
+      entities: req.param('entities'),
+      filter: req.param('filter') ?? {},
+    });
+  } catch (error) {
+    if (handleTypesenseError(res, error)) return;
+    throw error;
+  }
 
   ControllerService.treatAndConvert(
     req,

--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -110,51 +110,6 @@ async function multiCollectionsSearch({
   });
 }
 
-function validateSort(entity, sort) {
-  const parts = sort.split(':');
-  if (parts.length !== 2 || !parts[0] || !['asc', 'desc'].includes(parts[1])) {
-    const err = new Error(
-      `Invalid sort format '${sort}'. Expected 'field:asc' or 'field:desc'.`
-    );
-    err.code = 'E_SORT_VALIDATION';
-    throw err;
-  }
-
-  const [fieldName] = parts;
-  const { fields } = allEntities[entity].schema;
-  const fieldDef = fields.find((f) => f.name === fieldName);
-
-  if (!fieldDef) {
-    const err = new Error(
-      `Field '${fieldName}' does not exist in '${entity}' schema.`
-    );
-    err.code = 'E_SORT_VALIDATION';
-    throw err;
-  }
-
-  // Typesense allows sorting on numeric and boolean fields by default.
-  // Only string fields require explicit `sort: true` in the schema.
-  const numericAndBoolTypes = [
-    'int32',
-    'int64',
-    'float',
-    'bool',
-    'int32[]',
-    'int64[]',
-    'float[]',
-    'bool[]',
-  ];
-  const isSortableByDefault = numericAndBoolTypes.includes(fieldDef.type);
-
-  if (!isSortableByDefault && fieldDef.sort !== true) {
-    const err = new Error(
-      `Field '${fieldName}' is not sortable in '${entity}' schema.`
-    );
-    err.code = 'E_SORT_VALIDATION';
-    throw err;
-  }
-}
-
 async function collectionSearch({
   query,
   entity = [],
@@ -166,7 +121,6 @@ async function collectionSearch({
   fields,
 } = {}) {
   if (!allEntitiesKeys.includes(entity)) return null;
-  if (sort && sort.trim()) validateSort(entity, sort);
   const q = query || '*';
   const { filterBy, hasPrefixFilter } = buildFilter(
     filter,

--- a/api/services/TypesenseErrorService.js
+++ b/api/services/TypesenseErrorService.js
@@ -1,0 +1,26 @@
+/**
+ * Centralized Typesense error handling.
+ * Duck-types on error.httpStatus to classify 4xx client errors.
+ */
+
+/**
+ * Handle a Typesense client error by returning HTTP 400 if the error
+ * has an httpStatus in the 4xx range.
+ *
+ * @param {Object} res - Sails response object
+ * @param {Error} error - The caught error
+ * @returns {boolean} true if the error was handled (4xx), false otherwise
+ */
+function handleTypesenseError(res, error) {
+  const status = error?.httpStatus;
+  const isClientError =
+    typeof status === 'number' && status >= 400 && status < 500;
+  const isAuthError = status === 401 || status === 403;
+  if (isClientError && !isAuthError) {
+    res.badRequest({ error: error.message });
+    return true;
+  }
+  return false;
+}
+
+module.exports = { handleTypesenseError };

--- a/test/integration/1_services/SearchService.property.test.js
+++ b/test/integration/1_services/SearchService.property.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 const should = require('should');
 const sinon = require('sinon');
 const fc = require('fast-check');
@@ -137,37 +138,32 @@ const bugConditionArb = fc.oneof(
 );
 
 /**
- * Property 1: Bug Condition — Invalid Sort Field Causes Unhandled Typesense Error
+ * Property 1: Invalid Sort — Typesense Rejects Invalid Sort Inputs
  *
  * Validates: Requirements 1.1, 1.2, 1.3
  *
- * For any collectionSearch() input where isBugCondition(input) is true,
- * the function should throw a validation error with a descriptive message
- * and typesense.search should NOT be called.
- *
- * EXPECTED: This test FAILS on unfixed code because the current implementation
- * passes invalid sort directly to Typesense without validation.
+ * For any collectionSearch() input with an invalid sort parameter,
+ * Typesense will reject the request. The sort is passed through to
+ * Typesense without local validation.
  */
-describe('SearchService - Property 1: Bug Condition', () => {
-  let searchStub;
-
-  beforeEach(() => {
-    searchStub = sinon.stub(typesense, 'search').resolves({ hits: [] });
-  });
-
+describe('SearchService - Property 1: Invalid Sort', () => {
   afterEach(() => {
     sinon.restore();
   });
 
-  it('Property 1: invalid sort inputs should throw a validation error and not call Typesense', function () {
+  it('Property 1: invalid sort inputs are passed to Typesense (no local validation)', function () {
     this.timeout(30000);
     return fc.assert(
       fc.asyncProperty(bugConditionArb, async (input) => {
-        // Reset stub call count for each generated case
-        searchStub.resetHistory();
+        sinon.restore();
+        // Stub typesense.search to reject with a 400 (simulating Typesense rejection)
+        const searchStub = sinon
+          .stub(typesense, 'search')
+          .rejects(
+            Object.assign(new Error('Bad sort field'), { httpStatus: 400 })
+          );
 
         let threw = false;
-        let errorMessage = '';
         try {
           await SearchService.collectionSearch({
             query: 'test',
@@ -176,23 +172,16 @@ describe('SearchService - Property 1: Bug Condition', () => {
           });
         } catch (err) {
           threw = true;
-          errorMessage = err.message || '';
         }
 
-        // Assert: should have thrown a validation error
+        // The call should reach Typesense (no local interception)
+        should(searchStub.called).be.true(
+          `Expected typesense.search to be called for entity="${input.entity}" sort="${input.sort}" (${input.category})`
+        );
+
+        // And the Typesense error should propagate
         should(threw).be.true(
-          `Expected collectionSearch to throw for entity="${input.entity}" sort="${input.sort}" (${input.category}), but it did not throw`
-        );
-
-        // Assert: error message should be descriptive
-        should(errorMessage.length).be.greaterThan(
-          0,
-          `Expected a descriptive error message for entity="${input.entity}" sort="${input.sort}" (${input.category})`
-        );
-
-        // Assert: typesense.search should NOT have been called
-        should(searchStub.called).be.false(
-          `Expected typesense.search to NOT be called for entity="${input.entity}" sort="${input.sort}" (${input.category}), but it was called`
+          `Expected collectionSearch to throw for entity="${input.entity}" sort="${input.sort}" (${input.category})`
         );
       }),
       { numRuns: 100 }

--- a/test/integration/4_routes/Search/typesense-error-handling.property.test.js
+++ b/test/integration/4_routes/Search/typesense-error-handling.property.test.js
@@ -1,0 +1,206 @@
+/* eslint-disable func-names, global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+const fc = require('fast-check');
+
+/**
+ * Bug Condition Exploration — Property 1: Typesense 4xx errors return HTTP 400
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3, 1.4
+ *
+ * For any Typesense error with httpStatus in [400, 499] (excluding auth errors
+ * 401/403 which are server config issues), the API should return HTTP 400 with
+ * the error message.
+ */
+describe('Bug Condition — Typesense 4xx errors on search endpoints', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('POST /api/v1/advanced-search returns 400 for Typesense 4xx errors', function () {
+    this.timeout(30000);
+
+    return fc.assert(
+      fc.asyncProperty(
+        fc
+          .integer({ min: 400, max: 499 })
+          .filter((s) => s !== 401 && s !== 403),
+        fc.string({ minLength: 1 }),
+        async (httpStatus, message) => {
+          sinon.restore();
+          const error = new Error(message);
+          error.httpStatus = httpStatus;
+          sinon.stub(SearchService, 'collectionSearch').rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/advanced-search')
+            .send({ query: 'test', entity: 'entrances' })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          should(res.status).equal(
+            400,
+            `Expected 400 for httpStatus ${httpStatus}, got ${res.status}`
+          );
+          should(res.body).have.property('error', message);
+        }
+      ),
+      { numRuns: 20 }
+    );
+  });
+
+  it('POST /api/v1/search returns 400 for Typesense 4xx errors', function () {
+    this.timeout(30000);
+
+    return fc.assert(
+      fc.asyncProperty(
+        fc
+          .integer({ min: 400, max: 499 })
+          .filter((s) => s !== 401 && s !== 403),
+        fc.string({ minLength: 1 }),
+        async (httpStatus, message) => {
+          sinon.restore();
+          const error = new Error(message);
+          error.httpStatus = httpStatus;
+          sinon.stub(SearchService, 'multiCollectionsSearch').rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/search')
+            .send({ query: 'test' })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          should(res.status).equal(
+            400,
+            `Expected 400 for httpStatus ${httpStatus}, got ${res.status}`
+          );
+          should(res.body).have.property('error', message);
+        }
+      ),
+      { numRuns: 20 }
+    );
+  });
+
+  it('POST /api/v1/field-search returns 400 for Typesense 4xx errors', function () {
+    this.timeout(30000);
+
+    return fc.assert(
+      fc.asyncProperty(
+        fc
+          .integer({ min: 400, max: 499 })
+          .filter((s) => s !== 401 && s !== 403),
+        fc.string({ minLength: 1 }),
+        async (httpStatus, message) => {
+          sinon.restore();
+          const error = new Error(message);
+          error.httpStatus = httpStatus;
+          sinon.stub(SearchService, 'fieldSearch').rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/field-search')
+            .send({ field: 'name', entity: 'caves', query: 'test' })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          should(res.status).equal(
+            400,
+            `Expected 400 for httpStatus ${httpStatus}, got ${res.status}`
+          );
+          should(res.body).have.property('error', message);
+        }
+      ),
+      { numRuns: 20 }
+    );
+  });
+
+  it('POST /api/v1/advanced-search/export returns 400 for Typesense 4xx errors (no headers sent)', function () {
+    this.timeout(30000);
+
+    return fc.assert(
+      fc.asyncProperty(
+        fc
+          .integer({ min: 400, max: 499 })
+          .filter((s) => s !== 401 && s !== 403),
+        fc.string({ minLength: 1 }),
+        async (httpStatus, message) => {
+          sinon.restore();
+          const error = new Error(message);
+          error.httpStatus = httpStatus;
+          sinon.stub(SearchService, 'collectionSearch').rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/advanced-search/export')
+            .send({
+              query: 'test',
+              entity: 'entrances',
+              columns: ['id'],
+              columnsName: ['ID'],
+            })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          should(res.status).equal(
+            400,
+            `Expected 400 for httpStatus ${httpStatus}, got ${res.status}`
+          );
+          should(res.body).have.property('error', message);
+        }
+      ),
+      { numRuns: 20 }
+    );
+  });
+
+  // Issue #7: Test mid-stream 4xx in export endpoint
+  it('POST /api/v1/advanced-search/export terminates cleanly on mid-stream 4xx error', function () {
+    this.timeout(30000);
+
+    return fc.assert(
+      fc.asyncProperty(
+        fc
+          .integer({ min: 400, max: 499 })
+          .filter((s) => s !== 401 && s !== 403),
+        fc.string({ minLength: 1 }),
+        async (httpStatus, message) => {
+          sinon.restore();
+          const error = new Error(message);
+          error.httpStatus = httpStatus;
+
+          // First call succeeds (headers get sent), second call throws 4xx
+          const stub = sinon.stub(SearchService, 'collectionSearch');
+          stub.onFirstCall().resolves({
+            hits: Array.from({ length: 1000 }, (_, i) => ({
+              document: { id: String(i) },
+            })),
+            found: 2000,
+          });
+          stub.onSecondCall().rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/advanced-search/export')
+            .send({
+              query: 'test',
+              entity: 'entrances',
+              columns: ['id'],
+              columnsName: ['ID'],
+            })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          // Response should be 200 (headers already sent with CSV content-type)
+          should(res.status).equal(200);
+          // The stream should have ended cleanly (no crash, no corruption)
+          should(res.text).startWith('\uFEFF');
+          should(res.text).containEql('ID');
+        }
+      ),
+      { numRuns: 10 }
+    );
+  });
+});

--- a/test/integration/4_routes/Search/typesense-preservation.property.test.js
+++ b/test/integration/4_routes/Search/typesense-preservation.property.test.js
@@ -1,0 +1,266 @@
+/* eslint-disable func-names, global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+const fc = require('fast-check');
+
+/**
+ * Preservation — Property 2: Non-4xx Behavior Unchanged
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6
+ *
+ * These tests capture baseline behavior on UNFIXED code. They must PASS
+ * both before and after the fix, confirming no regressions.
+ */
+describe('Preservation — Non-4xx behavior unchanged on search endpoints', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // --- 3.1 Valid search returns 200 ---
+
+  describe('Valid search returns 200', () => {
+    it('POST /api/v1/advanced-search returns 200 for valid results', async () => {
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [{ document: { id: '1' } }],
+        found: 1,
+      });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search')
+        .send({ query: 'test', entity: 'entrances' })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(200);
+    });
+
+    it('POST /api/v1/search returns 200 for valid results', async () => {
+      sinon.stub(SearchService, 'multiCollectionsSearch').resolves({
+        hits: [],
+        found: 0,
+      });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/search')
+        .send({ query: 'test' })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(200);
+    });
+
+    it('POST /api/v1/field-search returns 200 for valid results', async () => {
+      sinon.stub(SearchService, 'fieldSearch').resolves({
+        found: 1,
+        found_docs: 1,
+        grouped_hits: [{ group_key: ['test'], found: 1 }],
+        page: 1,
+      });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/field-search')
+        .send({ field: 'name', entity: 'caves', query: 'test' })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(200);
+    });
+
+    it('POST /api/v1/advanced-search/export returns 200 for valid results', async () => {
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [{ document: { id: '1', name: 'Test' } }],
+        found: 1,
+      });
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+          columns: ['id', 'name'],
+          columnsName: ['ID', 'Name'],
+        })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(200);
+    });
+  });
+
+  // --- 3.3 Typesense 5xx returns 500 ---
+
+  describe('Typesense 5xx returns 500', () => {
+    it('POST /api/v1/advanced-search returns 500 for Typesense 5xx', function () {
+      this.timeout(30000);
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 500, max: 599 }),
+          async (httpStatus) => {
+            sinon.restore();
+            const error = new Error('Server error');
+            error.httpStatus = httpStatus;
+            sinon.stub(SearchService, 'collectionSearch').rejects(error);
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/advanced-search')
+              .send({ query: 'test', entity: 'entrances' })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(500);
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('POST /api/v1/search returns 500 for Typesense 5xx', function () {
+      this.timeout(30000);
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 500, max: 599 }),
+          async (httpStatus) => {
+            sinon.restore();
+            const error = new Error('Server error');
+            error.httpStatus = httpStatus;
+            sinon.stub(SearchService, 'multiCollectionsSearch').rejects(error);
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/search')
+              .send({ query: 'test' })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(500);
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('POST /api/v1/field-search returns 500 for Typesense 5xx', function () {
+      this.timeout(30000);
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 500, max: 599 }),
+          async (httpStatus) => {
+            sinon.restore();
+            const error = new Error('Server error');
+            error.httpStatus = httpStatus;
+            sinon.stub(SearchService, 'fieldSearch').rejects(error);
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/field-search')
+              .send({ field: 'name', entity: 'caves', query: 'test' })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(500);
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('POST /api/v1/advanced-search/export returns 500 for Typesense 5xx', function () {
+      this.timeout(30000);
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 500, max: 599 }),
+          async (httpStatus) => {
+            sinon.restore();
+            const error = new Error('Server error');
+            error.httpStatus = httpStatus;
+            sinon.stub(SearchService, 'collectionSearch').rejects(error);
+
+            const res = await supertest(sails.hooks.http.app)
+              .post('/api/v1/advanced-search/export')
+              .send({
+                query: 'test',
+                entity: 'entrances',
+                columns: ['id'],
+                columnsName: ['ID'],
+              })
+              .set('Content-type', 'application/json')
+              .set('Accept', 'application/json');
+
+            should(res.status).equal(500);
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+  });
+
+  // --- Typesense 401/403 auth errors return 500 (not leaked as 400) ---
+
+  describe('Typesense auth errors (401, 403) return 500', () => {
+    it('POST /api/v1/advanced-search returns 500 for Typesense 401/403', function () {
+      this.timeout(30000);
+
+      return fc.assert(
+        fc.asyncProperty(fc.constantFrom(401, 403), async (httpStatus) => {
+          sinon.restore();
+          const error = new Error('Unauthorized');
+          error.httpStatus = httpStatus;
+          sinon.stub(SearchService, 'collectionSearch').rejects(error);
+
+          const res = await supertest(sails.hooks.http.app)
+            .post('/api/v1/advanced-search')
+            .send({ query: 'test', entity: 'entrances' })
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json');
+
+          should(res.status).equal(500);
+        }),
+        { numRuns: 10 }
+      );
+    });
+  });
+
+  // --- 3.5, 3.6 Input validation returns 400 ---
+
+  describe('Input validation returns 400', () => {
+    it('POST /api/v1/search without query returns 400', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/search')
+        .send({})
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(400);
+      should(res.text).containEql('You must provide a query');
+    });
+
+    it('POST /api/v1/field-search without field returns 400', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/field-search')
+        .send({ entity: 'caves' })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(400);
+    });
+
+    it('POST /api/v1/field-search without entity returns 400', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/field-search')
+        .send({ field: 'name' })
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json');
+
+      should(res.status).equal(400);
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Forward Typesense 4xx client errors as HTTP 400 instead of 500 on all search endpoints
- Remove the local `validateSort()` pre-validation in favor of letting Typesense reject invalid sort parameters directly
- Affects: `POST /api/v1/search`, `POST /api/v1/advanced-search`, `POST /api/v1/advanced-search/export`, `POST /api/v1/field-search`

## 🤷‍♂️ Why

When a client sends a malformed search request (e.g., a misspelled filter field like `isTouristicz`), Typesense correctly rejects it with HTTP 400 `RequestMalformed`. However, the API was swallowing that error and returning a generic HTTP 500 "An internal server error occurred." to the client — making it impossible to understand what went wrong.

This applied to all Typesense client errors: invalid filter fields, bad query syntax, non-existent collections, unsortable fields, etc.

## 🔍 How

- Created a centralized `TypesenseErrorService.handleTypesenseError(res, error)` helper that duck-types on `error.httpStatus` — if it's in the 400–499 range, it calls `res.badRequest()` with the Typesense error message and returns truthy; otherwise returns `false`
- Added try/catch with `handleTypesenseError` in all four search controllers
- Removed `validateSort()` from `SearchService.js` — invalid sort parameters now flow through to Typesense and come back as 400s via the same centralized handler, simplifying the code without degrading the user experience
- The `hasSentHeader` guard in `advanced-search-export.js` ensures we only return a JSON 400 if CSV headers haven't been written yet (streaming safety)

## 🧪 Testing

Property-based tests with `fast-check` covering:
- **Bug condition**: random `httpStatus` in [400, 499] with random error messages on all 4 endpoints → assert HTTP 400 with error message
- **Preservation**: valid searches → 200, Typesense 5xx → 500, input validation (missing query/field/entity) → 400
- **Sort delegation**: invalid sort inputs are passed through to Typesense (no local interception)

### Manual testing with curl

These requests would have returned 500 before this fix and now return 400 with a descriptive error message:

**Invalid filter field name:**
```bash
curl -s -X POST http://localhost:1337/api/v1/advanced-search \
  -H 'Content-Type: application/json' \
  -d '{"query":"","entity":"entrances","filter":{"isTouristicz":true}}'
```

**Invalid sort field:**
```bash
curl -s -X POST http://localhost:1337/api/v1/advanced-search \
  -H 'Content-Type: application/json' \
  -d '{"query":"test","entity":"entrances","sort":"nonExistentField:asc"}'
```

**Invalid filter syntax in export:**
```bash
curl -s -X POST http://localhost:1337/api/v1/advanced-search/export \
  -H 'Content-Type: application/json' \
  -d '{"query":"","entity":"entrances","filter":{"isTouristicz":true},"columns":["id"],"columnsName":["ID"]}'
```

**Invalid field in field-search:**
```bash
curl -s -X POST http://localhost:1337/api/v1/field-search \
  -H 'Content-Type: application/json' \
  -d '{"entity":"caves","field":"nonExistentField","query":"test"}'
```

## 📸 Previews

N/A — backend-only change.
