### PR TITLE
fix(entrance,cave): add coerceToInt to round decimal values for integer DB columns

### DIFF
--- a/api/controllers/v1/cave/update.js
+++ b/api/controllers/v1/cave/update.js
@@ -1,4 +1,5 @@
 const ControllerService = require('../../../services/ControllerService');
+const coerceToInt = require('../../../utils/coerceToInt');
 const CaveService = require('../../../services/CaveService');
 const NotificationService = require('../../../services/NotificationService');
 const { toCave } = require('../../../services/mapping/converters');
@@ -27,8 +28,8 @@ module.exports = async (req, res) => {
 
   if (newLatitude != null) updatedFields.latitude = newLatitude;
   if (newLongitude != null) updatedFields.longitude = newLongitude;
-  if (newDepth != null) updatedFields.depth = newDepth;
-  if (newLength != null) updatedFields.caveLength = newLength;
+  if (newDepth != null) updatedFields.depth = coerceToInt(newDepth);
+  if (newLength != null) updatedFields.caveLength = coerceToInt(newLength);
   if (newTemperature != null) updatedFields.temperature = newTemperature;
   if (newIsDiving != null) updatedFields.isDiving = newIsDiving;
 

--- a/api/services/CaveService.js
+++ b/api/services/CaveService.js
@@ -1,4 +1,5 @@
 const CommonService = require('./CommonService');
+const coerceToInt = require('../utils/coerceToInt');
 const DocumentService = require('./DocumentService');
 const DescriptionService = require('./DescriptionService');
 const NameService = require('./NameService');
@@ -95,12 +96,12 @@ module.exports = {
   // Extract everything from the request body except id and dateInscription
   getConvertedDataFromClient: (req) => ({
     // The TCave.create() function doesn't work with TCave field alias. See TCave.js Model
-    depth: req.param('depth'),
+    depth: coerceToInt(req.param('depth')),
     documents: req.param('documents'),
     isDiving: req.param('isDiving'),
     latitude: req.param('latitude'),
     longitude: req.param('longitude'),
-    caveLength: req.param('length'),
+    caveLength: coerceToInt(req.param('length')),
     massif: req.param('massif'),
     temperature: req.param('temperature'),
   }),

--- a/api/services/EntranceCSVImportService.js
+++ b/api/services/EntranceCSVImportService.js
@@ -1,4 +1,5 @@
 const { getDateFromKarstlink } = require('../../config/constants/karstlink');
+const coerceToInt = require('../utils/coerceToInt');
 
 const doubleCheck = sails.helpers.csvhelpers.doubleCheck.with;
 const { getCreator } = require('../utils/csvHelper');
@@ -65,10 +66,12 @@ module.exports = {
       longitude: doubleCheckWithData({
         key: 'w3geo:longitude',
       }),
-      length: doubleCheckWithData({
-        key: 'karstlink:length',
-      }),
-      depth,
+      length: coerceToInt(
+        doubleCheckWithData({
+          key: 'karstlink:length',
+        })
+      ),
+      depth: coerceToInt(depth),
       dateInscription: doubleCheckWithData({
         key: 'dct:rights/dct:created',
         defaultValue: new Date(),
@@ -188,12 +191,16 @@ module.exports = {
       country: doubleCheckWithData({
         key: 'gn:countryCode',
       }),
-      precision: doubleCheckWithData({
-        key: 'dwc:coordinatePrecision',
-      }),
-      altitude: doubleCheckWithData({
-        key: 'w3geo:altitude',
-      }),
+      precision: coerceToInt(
+        doubleCheckWithData({
+          key: 'dwc:coordinatePrecision',
+        })
+      ),
+      altitude: coerceToInt(
+        doubleCheckWithData({
+          key: 'w3geo:altitude',
+        })
+      ),
       latitude: cave.latitude,
       longitude: cave.longitude,
       cave: cave.id,

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -22,6 +22,7 @@ const DescriptionService = require('./DescriptionService');
 const HistoryService = require('./HistoryService');
 const LocationService = require('./LocationService');
 const RightService = require('./RightService');
+const coerceToInt = require('../utils/coerceToInt');
 
 function coerceBool(req, field) {
   const value = req.param(field);
@@ -49,6 +50,9 @@ module.exports = {
     const { id, ...reqBodyWithoutId } = req.body;
     return {
       ...reqBodyWithoutId,
+      altitude: coerceToInt(reqBodyWithoutId.altitude),
+      precision: coerceToInt(reqBodyWithoutId.precision),
+      yearDiscovery: coerceToInt(reqBodyWithoutId.yearDiscovery),
       geology: req.body.geology ?? 'Q35758',
       isSensitive: coerceBool(req, 'isSensitive'),
       hasBat: coerceBool(req, 'hasBat'),

--- a/api/utils/coerceToInt.js
+++ b/api/utils/coerceToInt.js
@@ -1,0 +1,17 @@
+/**
+ * Coerce a value to an integer via Math.round().
+ * Handles both numbers and numeric strings (e.g. from CSV parsing).
+ * Passes through null, undefined, non-finite, and non-numeric values unchanged
+ * (letting Waterline handle validation for invalid types).
+ *
+ * @param {*} value
+ * @returns {*} rounded integer for finite numbers/numeric strings, original value otherwise
+ */
+const coerceToInt = (value) => {
+  if (value === null || value === undefined) return value;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  if (typeof n === 'number' && Number.isFinite(n)) return Math.round(n);
+  return value;
+};
+
+module.exports = coerceToInt;

--- a/test/integration/2_utils/coerceToInt-preservation.property.test.js
+++ b/test/integration/2_utils/coerceToInt-preservation.property.test.js
@@ -1,0 +1,48 @@
+const should = require('should');
+const fc = require('fast-check');
+
+/**
+ * Property 2: Preservation — Integer and Nullish Values Pass Through Unchanged
+ *
+ * Verifies that coerceToInt acts as an identity function for values that are
+ * already integers, null, undefined, or non-finite (NaN, Infinity).
+ */
+
+const coerceToInt = require('../../../api/utils/coerceToInt');
+
+describe('coerceToInt - Property: Preservation', () => {
+  describe('Property 2a: Integer values pass through unchanged', () => {
+    it('should return the same value for any integer', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(fc.integer(), (n) => {
+          should(coerceToInt(n)).equal(n);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 2b: Nullish values pass through unchanged', () => {
+    it('should return null for null and undefined for undefined', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.oneof(fc.constant(null), fc.constant(undefined)),
+          (v) => {
+            should(coerceToInt(v)).equal(v);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 2c: Non-finite values pass through unchanged', () => {
+    it('should return NaN for NaN and Infinity for Infinity', () => {
+      should(Number.isNaN(coerceToInt(NaN))).be.true();
+      should(coerceToInt(Infinity)).equal(Infinity);
+      should(coerceToInt(-Infinity)).equal(-Infinity);
+    });
+  });
+});

--- a/test/integration/2_utils/coerceToInt.property.test.js
+++ b/test/integration/2_utils/coerceToInt.property.test.js
@@ -1,0 +1,60 @@
+const should = require('should');
+const fc = require('fast-check');
+
+/**
+ * Property 1: Rounding Behavior — Decimal Values Are Rounded to Nearest Integer
+ *
+ * For all finite double values with a fractional part, coerceToInt(v) should
+ * equal Math.round(v) and the result should be an integer.
+ */
+
+const coerceToInt = require('../../../api/utils/coerceToInt');
+
+describe('coerceToInt - Property: Rounding Behavior', () => {
+  describe('Property 1: Decimal values are rounded to nearest integer', () => {
+    it('should round all finite decimal values to the nearest integer', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc
+            .double({ noNaN: true, noDefaultInfinity: true })
+            .filter((v) => v !== Math.round(v)),
+          (v) => {
+            const result = coerceToInt(v);
+            should(result).equal(
+              Math.round(v),
+              `coerceToInt(${v}) should be ${Math.round(v)} but got ${result}`
+            );
+            should(Number.isInteger(result)).be.true(
+              `coerceToInt(${v}) should be an integer but got ${result}`
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should round numeric strings with decimals to the nearest integer', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc
+            .double({ noNaN: true, noDefaultInfinity: true })
+            .filter((v) => v !== Math.round(v))
+            .map((v) => String(v)),
+          (s) => {
+            const result = coerceToInt(s);
+            should(result).equal(
+              Math.round(parseFloat(s)),
+              `coerceToInt('${s}') should be ${Math.round(parseFloat(s))} but got ${result}`
+            );
+            should(Number.isInteger(result)).be.true(
+              `coerceToInt('${s}') should be an integer but got ${result}`
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/2_utils/coerceToInt.test.js
+++ b/test/integration/2_utils/coerceToInt.test.js
@@ -1,0 +1,122 @@
+const should = require('should');
+const coerceToInt = require('../../../api/utils/coerceToInt');
+const EntranceService = require('../../../api/services/EntranceService');
+const CaveService = require('../../../api/services/CaveService');
+
+describe('coerceToInt - Unit Tests', () => {
+  describe('coerceToInt()', () => {
+    it('should pass through integers unchanged', () => {
+      should(coerceToInt(0)).equal(0);
+      should(coerceToInt(1132)).equal(1132);
+      should(coerceToInt(-500)).equal(-500);
+    });
+
+    it('should round decimals to nearest integer', () => {
+      should(coerceToInt(1132.6)).equal(1133);
+      should(coerceToInt(1132.4)).equal(1132);
+      should(coerceToInt(1132.5)).equal(1133);
+      should(coerceToInt(-1132.6)).equal(-1133);
+      should(coerceToInt(0.1)).equal(0);
+      should(coerceToInt(0.9)).equal(1);
+    });
+
+    it('should pass through null unchanged', () => {
+      should(coerceToInt(null)).equal(null);
+    });
+
+    it('should pass through undefined unchanged', () => {
+      should(coerceToInt(undefined)).equal(undefined);
+    });
+
+    it('should pass through NaN unchanged', () => {
+      should(Number.isNaN(coerceToInt(NaN))).be.true();
+    });
+
+    it('should pass through Infinity unchanged', () => {
+      should(coerceToInt(Infinity)).equal(Infinity);
+      should(coerceToInt(-Infinity)).equal(-Infinity);
+    });
+
+    it('should pass through strings unchanged', () => {
+      should(coerceToInt('abc')).equal('abc');
+      should(coerceToInt('')).equal('');
+    });
+
+    it('should round numeric strings to nearest integer', () => {
+      should(coerceToInt('1132.6')).equal(1133);
+      should(coerceToInt('1132.4')).equal(1132);
+      should(coerceToInt('1132')).equal(1132);
+      should(coerceToInt('-500.3')).equal(-500);
+    });
+  });
+
+  describe('EntranceService.getConvertedDataFromClientRequest()', () => {
+    const makeReq = (body) => ({
+      body,
+      param: (key) => body[key],
+      token: { id: 1 },
+    });
+
+    it('should round decimal altitude to nearest integer', () => {
+      const req = makeReq({ altitude: 1132.6 });
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.altitude).equal(1133);
+    });
+
+    it('should round decimal precision to nearest integer', () => {
+      const req = makeReq({ precision: 5.7 });
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.precision).equal(6);
+    });
+
+    it('should round decimal yearDiscovery to nearest integer', () => {
+      const req = makeReq({ yearDiscovery: 1973.8 });
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.yearDiscovery).equal(1974);
+    });
+
+    it('should pass through integer altitude unchanged', () => {
+      const req = makeReq({ altitude: 1132 });
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.altitude).equal(1132);
+    });
+
+    it('should pass through null altitude unchanged', () => {
+      const req = makeReq({ altitude: null });
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.altitude).equal(null);
+    });
+  });
+
+  describe('CaveService.getConvertedDataFromClient()', () => {
+    const makeReq = (body) => ({
+      body,
+      param: (key) => body[key],
+      token: { id: 1 },
+    });
+
+    it('should round decimal depth to nearest integer', () => {
+      const req = makeReq({ depth: 250.4 });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.depth).equal(250);
+    });
+
+    it('should round decimal length to nearest integer', () => {
+      const req = makeReq({ length: 1500.7 });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.caveLength).equal(1501);
+    });
+
+    it('should pass through integer depth unchanged', () => {
+      const req = makeReq({ depth: 250 });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.depth).equal(250);
+    });
+
+    it('should preserve temperature decimal exactly', () => {
+      const req = makeReq({ temperature: 12.5 });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.temperature).equal(12.5);
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Add a `coerceToInt` utility that rounds decimal numeric values to the nearest integer before they reach PostgreSQL integer columns (`int2`/`int4`)
- Apply `coerceToInt` across all entry points that write to integer-typed DB columns:
  - `EntranceService.getConvertedDataFromClientRequest()` — `altitude`, `precision`, `yearDiscovery`
  - `CaveService.getConvertedDataFromClient()` — `depth`, `caveLength`
  - `cave/update.js` controller — `depth`, `length`
  - `EntranceCSVImportService.getConvertedEntranceFromCsv()` — `altitude`, `precision`
  - `EntranceCSVImportService.getConvertedCaveFromCsv()` — `depth`, `length`

## 🤷‍♂️ Why

When creating an entrance with a decimal altitude (e.g., `1132.6`), PostgreSQL rejects the value with `invalid input syntax for type smallint: "1132.6"`, causing a 500 Server Error. The Waterline ORM declares these fields as `type: 'number'` which accepts any JavaScript number, but the underlying DB columns are `int2`/`int4` and reject non-integer values.

## 🔍 How

A shared utility `api/utils/coerceToInt.js` handles the coercion:
- `null`/`undefined` → pass through unchanged
- Finite numbers → `Math.round(value)`
- Everything else (NaN, Infinity, strings) → pass through unchanged, letting Waterline's own validation handle rejection

Applied at the data conversion layer (closest to the input boundary) in all 5 entry points, keeping the change minimal and localized.

## 🧪 Testing

- Property-based tests with fast-check validating the bug condition fix and preservation of existing behavior
- Unit tests for `coerceToInt` covering integers, decimals, null, undefined, NaN, Infinity, strings
- Unit tests for `EntranceService.getConvertedDataFromClientRequest` and `CaveService.getConvertedDataFromClient` with decimal inputs
- Full test suite passes (1878 passing, 6 pre-existing failures unrelated to this change)

### Manual testing

Create an entrance with a decimal altitude (previously returned 500):
```bash
curl -X POST http://localhost:1337/api/v1/entrances \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "name": {"language": "fra", "text": "Test entrance"},
    "cave": 75070,
    "isSensitive": false,
    "longitude": "6.498327",
    "latitude": "46.926410",
    "altitude": 1132.6,
    "yearDiscovery": 1973
  }'
```

Update a cave with decimal depth and length:
```bash
curl -X PUT http://localhost:1337/api/v1/caves/5 \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "name": {"language": "fra", "text": "Test cave"},
    "depth": 250.4,
    "length": 1500.7
  }'
```

Verify integer values still work as before:
```bash
curl -X POST http://localhost:1337/api/v1/entrances \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "name": {"language": "fra", "text": "Test entrance"},
    "cave": 75070,
    "isSensitive": false,
    "longitude": "6.498327",
    "latitude": "46.926410",
    "altitude": 1132,
    "yearDiscovery": 1973
  }'
```

## 📸 Previews

N/A — backend-only change, no UI impact.
