### PR TITLE
fix(search): return 400 instead of 500 for unknown entity names

### DIFF
--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -9,11 +9,13 @@ module.exports = async (req, res) => {
   let matchAllFields = req.param('matchAllFields') ?? true;
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
 
+  const entity = req.param('entity') ?? '';
+
   let results;
   try {
     results = await SearchService.collectionSearch({
       query: req.param('query'),
-      entity: req.param('entity') ?? '',
+      entity,
       sort: req.param('sort'),
       filter: req.param('filter') ?? {},
       isLogicalCompareAnd: !!matchAllFields,
@@ -23,6 +25,13 @@ module.exports = async (req, res) => {
   } catch (error) {
     if (handleTypesenseError(res, error)) return undefined;
     throw error;
+  }
+
+  if (!results) {
+    const validEntities = SearchService.allEntitiesKeys.join(', ');
+    return res.badRequest(
+      `Unknown entity "${entity}". Valid entities are: ${validEntities}`
+    );
   }
 
   return ControllerService.treatAndConvert(

--- a/api/controllers/v1/search/field-search.js
+++ b/api/controllers/v1/search/field-search.js
@@ -34,6 +34,14 @@ module.exports = async (req, res) => {
     throw error;
   }
 
+  if (!r) {
+    const validEntities = SearchService.allEntitiesKeys.join(', ');
+    res.badRequest(
+      `Unknown entity "${entity}". Valid entities are: ${validEntities}`
+    );
+    return;
+  }
+
   const out = {
     totalDistinct: r.found,
     totalDocuments: r.found_docs,


### PR DESCRIPTION
## 🤔 What

- Fix a 500 crash in `POST /api/v1/field-search` when an unrecognized entity name is provided (e.g. `"cave"` instead of `"caves"`)
- Apply the same guard to `POST /api/v1/advanced-search` which had the same vulnerability

## 🤷‍♂️ Why

`SearchService.fieldSearch` and `collectionSearch` return `null` for entity names not present in the Typesense collection registry. Both controllers accessed properties on the null result (e.g. `r.found`) without a guard, causing a `TypeError: Cannot read properties of null (reading 'found')` and a 500 response.

Production log:
```
TypeError: Cannot read properties of null (reading 'found')
    at module.exports [as v1/search/field-search] (field-search.js:29:22)
```

Triggered by a request with `"entity": "cave"` — the valid name is `"caves"`.

## 🔍 How

Added a null check after the search service call in both controllers. When the result is null, the endpoint now returns a `400 Bad Request` with a message listing the valid entity names, e.g.:

```
Unknown entity "cave". Valid entities are: organizations, cavers, massifs, caves, entrances, documents
```

## 🧪 Testing

```bash
# Should return 400 with valid entity list
curl -X POST http://localhost:1337/api/v1/field-search \
  -H 'Content-Type: application/json' \
  -d '{"entity":"cave","field":"name","query":"test"}'

# Should work normally
curl -X POST http://localhost:1337/api/v1/field-search \
  -H 'Content-Type: application/json' \
  -d '{"entity":"caves","field":"name","query":"test"}'
```
