### PR TITLE
feat(entrance): add numericId and dateLastModif sortable fields to advanced search (#1530)

### DIFF
--- a/api/dbSync/entities/entrance.js
+++ b/api/dbSync/entities/entrance.js
@@ -1,6 +1,7 @@
 const exportUtils = require('../utils');
 const {
   NON_INDEXED_BOOLEAN_FIELDS,
+  computeDateLastModif,
 } = require('../../../config/constants/entrance');
 
 function average(arr) {
@@ -161,8 +162,10 @@ async function* processRows(source) {
 /* eslint-disable no-param-reassign */
 function importFormater(d) {
   d.id = `${d.id}`;
+  d.numericId = parseInt(d.id, 10);
   d.dateInscription = new Date(d.dateInscription).getTime();
   if (d.dateReviewed) d.dateReviewed = new Date(d.dateReviewed).getTime();
+  d.dateLastModif = computeDateLastModif(d.dateInscription, d.dateReviewed);
   if (d.latitude) d.latitude = parseFloat(d.latitude);
   if (d.longitude) d.longitude = parseFloat(d.longitude);
 
@@ -192,8 +195,10 @@ module.exports = {
       enable_nested_fields: true,
       fields: [
         { name: 'id', type: 'string' },
+        { name: 'numericId', type: 'int32', sort: true },
         { name: 'dateInscription', type: 'int64' },
         { name: 'dateReviewed', type: 'int64', optional: true },
+        { name: 'dateLastModif', type: 'int64', sort: true, optional: true },
         { name: 'authorId', type: 'int32' },
         { name: 'author', type: 'string' },
         { name: 'reviewer', type: 'string', optional: true },

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -15,6 +15,7 @@ const CommentService = require('./CommentService');
 const DocumentService = require('./DocumentService');
 const {
   NON_INDEXED_BOOLEAN_FIELDS,
+  computeDateLastModif,
 } = require('../../config/constants/entrance');
 const NameService = require('./NameService');
 const RiggingService = require('./RiggingService');
@@ -272,8 +273,13 @@ module.exports = {
     NON_INDEXED_BOOLEAN_FIELDS.forEach((f) => delete e[f]);
     const entrance = {
       ...e,
+      numericId: e.id,
       dateInscription: e.dateInscription,
       dateReviewed: e.dateReviewed,
+      dateLastModif: computeDateLastModif(
+        new Date(e.dateInscription).getTime(),
+        e.dateReviewed ? new Date(e.dateReviewed).getTime() : null
+      ),
       authorId: e.author.id,
       author: e.author.nickname,
       reviewerId: e.reviewer?.id,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -339,6 +339,7 @@ const c = {
     result.redirectTo = source.redirectTo;
     result.dateInscription = source.dateInscription;
     result.dateReviewed = source.dateReviewed;
+    result.dateLastModif = source.dateLastModif;
     result.altitude = source.altitude;
     result.precision = source.precision;
     result.latitude =

--- a/api/services/mapping/models/EntranceModel.js
+++ b/api/services/mapping/models/EntranceModel.js
@@ -18,6 +18,7 @@ module.exports = {
   countryCode: undefined,
   county: undefined,
   dateInscription: undefined,
+  dateLastModif: undefined,
   dateReviewed: undefined,
   descriptions: [],
   discoveryYear: undefined,

--- a/config/constants/entrance.js
+++ b/config/constants/entrance.js
@@ -12,4 +12,14 @@ const NON_INDEXED_BOOLEAN_FIELDS = [
   'hasRules',
 ];
 
-module.exports = { NON_INDEXED_BOOLEAN_FIELDS };
+/**
+ * Compute the last modification date for an entrance.
+ * @param {number} dateInscription - Epoch milliseconds of inscription date
+ * @param {number|null|undefined} dateReviewed - Epoch milliseconds of review date, or nullish
+ * @returns {number} Epoch milliseconds of the most recent modification
+ */
+function computeDateLastModif(dateInscription, dateReviewed) {
+  return Math.max(dateInscription, dateReviewed ?? dateInscription);
+}
+
+module.exports = { NON_INDEXED_BOOLEAN_FIELDS, computeDateLastModif };

--- a/test/integration/1_services/Converters.test.js
+++ b/test/integration/1_services/Converters.test.js
@@ -372,6 +372,16 @@ describe('Converters Service', () => {
       const result = converters.toEntrance(source);
       should(result.iso3166).equal('FR-75');
     });
+
+    it('should include dateLastModif from source in the result', () => {
+      const source = {
+        id: 1,
+        isSensitive: false,
+        dateLastModif: 1700000000000,
+      };
+      const result = converters.toEntrance(source);
+      should(result.dateLastModif).equal(1700000000000);
+    });
   });
 
   describe('toSimpleEntrance()', () => {

--- a/test/integration/1_services/EntranceSearchSync.property.test.js
+++ b/test/integration/1_services/EntranceSearchSync.property.test.js
@@ -1,0 +1,172 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const { computeDateLastModif } = require('../../../config/constants/entrance');
+
+// Feature: advanced-search-entrance-sorting
+// Property 1: computeDateLastModif returns the most recent date
+// For any dateInscription (positive integer) and for any dateReviewed
+// (positive integer or null), computeDateLastModif returns the greater of
+// the two, falling back to dateInscription when dateReviewed is nullish.
+
+/**
+ * Property 1: computeDateLastModif returns the most recent date
+ * Encodes: the result always equals Math.max(dateInscription, dateReviewed ?? dateInscription).
+ * Covers: all combinations of present and absent dateReviewed values.
+ *
+ * Validates: Requirements 2.2, 2.3
+ */
+describe('EntranceSearchSync - Property 1: computeDateLastModif returns the most recent date', () => {
+  it('should return Math.max(dateInscription, dateReviewed ?? dateInscription)', function () {
+    this.timeout(10000);
+
+    fc.assert(
+      fc.property(
+        fc.nat(),
+        fc.option(fc.nat()),
+        (dateInscription, dateReviewed) => {
+          const result = computeDateLastModif(dateInscription, dateReviewed);
+          const expected = Math.max(
+            dateInscription,
+            dateReviewed ?? dateInscription
+          );
+          should(result).equal(expected);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+const {
+  search: { importFormater },
+} = require('../../../api/dbSync/entities/entrance');
+const { toEntrance } = require('../../../api/services/mapping/converters');
+
+// Property 2: Sync path consistency — numericId and dateLastModif
+// For any entrance with a numeric id, a dateInscription timestamp, and an
+// optional dateReviewed timestamp, the numericId and dateLastModif values
+// produced by importFormater SHALL equal those produced by the updateInSearch
+// document construction, given the same input data.
+
+/**
+ * Property 2: Sync path consistency — numericId and dateLastModif
+ * Encodes: both sync paths produce identical numericId and dateLastModif
+ * for the same entrance data.
+ * Covers: random positive int id, random dateInscription (Date), optional dateReviewed (Date).
+ *
+ * Validates: Requirements 1.2, 1.4, 4.1, 4.2
+ */
+describe('EntranceSearchSync - Property 2: Sync path consistency for numericId and dateLastModif', () => {
+  it('should produce identical numericId and dateLastModif across both sync paths', function () {
+    this.timeout(10000);
+
+    const entranceArb = fc.record({
+      id: fc.integer({ min: 1, max: 2147483647 }),
+      dateInscription: fc.integer({ min: 86400000, max: 4102444800000 }),
+      dateReviewed: fc.option(
+        fc.integer({ min: 86400000, max: 4102444800000 }),
+        { nil: null }
+      ),
+    });
+
+    fc.assert(
+      fc.property(entranceArb, ({ id, dateInscription, dateReviewed }) => {
+        // --- importFormater path ---
+        const dbRow = {
+          id,
+          dateInscription: new Date(dateInscription),
+          dateReviewed: dateReviewed ? new Date(dateReviewed) : null,
+          // Minimal fields to avoid errors in importFormater
+          isSensitive: false,
+          comments: [],
+        };
+        const formatted = importFormater(dbRow);
+
+        // --- simulated updateInSearch path ---
+        const uisNumericId = id;
+        const uisDateLastModif = computeDateLastModif(
+          dateInscription,
+          dateReviewed
+        );
+
+        should(formatted.numericId).equal(
+          uisNumericId,
+          `numericId mismatch: importFormater=${formatted.numericId}, updateInSearch=${uisNumericId}`
+        );
+        should(formatted.dateLastModif).equal(
+          uisDateLastModif,
+          `dateLastModif mismatch: importFormater=${formatted.dateLastModif}, updateInSearch=${uisDateLastModif}`
+        );
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+// Property 3: toEntrance preserves dateLastModif
+// For any source object containing a dateLastModif value, calling
+// toEntrance(source) SHALL produce a result where result.dateLastModif
+// equals source.dateLastModif.
+
+/**
+ * Property 3: toEntrance preserves dateLastModif
+ * Encodes: the converter passes dateLastModif through without modification.
+ * Covers: random dateLastModif values (non-negative integers).
+ *
+ * Validates: Requirements 2.5
+ */
+describe('EntranceSearchSync - Property 3: toEntrance preserves dateLastModif', () => {
+  it('should preserve dateLastModif from source to result', function () {
+    this.timeout(10000);
+
+    fc.assert(
+      fc.property(fc.nat(), (dateLastModif) => {
+        const source = {
+          id: 1,
+          isSensitive: false,
+          dateLastModif,
+        };
+
+        const result = toEntrance(source);
+
+        should(result.dateLastModif).equal(
+          dateLastModif,
+          `dateLastModif should be ${dateLastModif} but got ${result.dateLastModif}`
+        );
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+// Schema smoke tests for numericId and dateLastModif fields
+const {
+  search: { schema: entranceSchema },
+} = require('../../../api/dbSync/entities/entrance');
+const EntranceModel = require('../../../api/services/mapping/models/EntranceModel');
+
+describe('EntranceSearchSync - Schema smoke tests', () => {
+  it('should have numericId field with type int32 and sort true', () => {
+    const field = entranceSchema.fields.find((f) => f.name === 'numericId');
+    should(field).not.be.undefined();
+    should(field.type).equal('int32');
+    should(field.sort).equal(true);
+  });
+
+  it('should have dateLastModif field with type int64, sort true, and optional true', () => {
+    const field = entranceSchema.fields.find((f) => f.name === 'dateLastModif');
+    should(field).not.be.undefined();
+    should(field.type).equal('int64');
+    should(field.sort).equal(true);
+    should(field.optional).equal(true);
+  });
+
+  it('should keep default_sorting_field as dateInscription', () => {
+    should(entranceSchema.default_sorting_field).equal('dateInscription');
+  });
+
+  it('should have dateLastModif property in EntranceModel', () => {
+    should(EntranceModel).have.property('dateLastModif');
+  });
+});

--- a/test/integration/1_services/EntranceService.test.js
+++ b/test/integration/1_services/EntranceService.test.js
@@ -237,6 +237,57 @@ describe('EntranceService', () => {
       process.env.NODE_ENV = originalEnv;
     });
 
+    it('should include numericId matching e.id', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const updateStub = sinon.stub(SearchService, 'updateDocument').resolves();
+
+      const entrance = {
+        id: 42,
+        isSensitive: false,
+        dateInscription: new Date('2024-01-15'),
+        author: { id: 1, nickname: 'Author' },
+        names: [{ name: 'Test', language: 'en' }],
+        iso_3166_2: 'FR-75',
+      };
+
+      await EntranceService.updateInSearch(entrance);
+
+      should(updateStub.calledOnce).be.true();
+      const callArg = updateStub.getCall(0).args[1];
+      should(callArg.numericId).equal(42);
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should include dateLastModif computed from dateInscription and dateReviewed', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const updateStub = sinon.stub(SearchService, 'updateDocument').resolves();
+
+      const dateInscription = new Date('2024-01-15');
+      const dateReviewed = new Date('2024-06-20');
+      const entrance = {
+        id: 7,
+        isSensitive: false,
+        dateInscription,
+        dateReviewed,
+        author: { id: 1, nickname: 'Author' },
+        names: [{ name: 'Test', language: 'en' }],
+        iso_3166_2: 'FR-75',
+      };
+
+      await EntranceService.updateInSearch(entrance);
+
+      should(updateStub.calledOnce).be.true();
+      const callArg = updateStub.getCall(0).args[1];
+      const expected = Math.max(
+        dateInscription.getTime(),
+        dateReviewed.getTime()
+      );
+      should(callArg.dateLastModif).equal(expected);
+      process.env.NODE_ENV = originalEnv;
+    });
+
     it('should map all optional fields correctly', async () => {
       const originalEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'development';


### PR DESCRIPTION
## 🤔 What

- Add `numericId` (int32, sortable) and `dateLastModif` (int64, sortable) fields to the Typesense `entrances` collection
- Expose `dateLastModif` in the API response payload for entrance search results
- Closes #1530

## 🤷‍♂️ Why

The advanced search endpoint for entrances did not support sorting by ID or last modification date. Typesense's built-in `id` field is always a string and cannot be made sortable, so a numeric mirror field is needed. The last modification date was not tracked at all.

## 🔍 How

- **`computeDateLastModif` helper** in `config/constants/entrance.js`: pure function returning `Math.max(dateInscription, dateReviewed ?? dateInscription)`
- **Typesense schema**: two new fields added to the `entrances` collection — `numericId` (int32, sort) and `dateLastModif` (int64, sort, optional)
- **Bulk sync path** (`importFormater` in `api/dbSync/entities/entrance.js`): populates both fields during dbSync
- **Per-entrance sync path** (`updateInSearch` in `api/services/EntranceService.js`): populates both fields on create/update
- **Response mapping**: `dateLastModif` added to `EntranceModel` and passed through in `toEntrance` converter
- The `default_sorting_field` remains `dateInscription`
- The front-end should use `numericId:asc`/`numericId:desc` for ID sorting and `dateLastModif:asc`/`dateLastModif:desc` for last modification date sorting
- After deployment, a dbSync run will re-create the collection with the new schema

## 🧪 Testing

- 3 property-based tests (fast-check) in `test/integration/1_services/EntranceSearchSync.property.test.js`:
  - Property 1: `computeDateLastModif` returns the most recent date
  - Property 2: Sync path consistency for `numericId` and `dateLastModif`
  - Property 3: `toEntrance` preserves `dateLastModif`
- Unit tests added to `EntranceService.test.js` and `Converters.test.js`
- Schema smoke tests verifying field types and sort flags
- Run: `PORT=1338 npm run test -- --grep "EntranceSearchSync|numericId|dateLastModif"`

## 📸 Previews

N/A — backend-only change
