### PR TITLE
1449 signup email verification

### DIFF
--- a/api/controllers/v1/account/forgot-password.js
+++ b/api/controllers/v1/account/forgot-password.js
@@ -26,6 +26,15 @@ module.exports = async (req, res) => {
     return res.ok();
   }
 
+  // instructs the user to verify their email before asking for a password reset
+  if (!userFound.activated) {
+    return res.unauthorized({
+      status: 'NotVerified',
+      message:
+        'Your account is not verified yet. Please check your email for the verification link.',
+    });
+  }
+
   // Generate reset password token
   const token = TokenService.issue(
     {

--- a/api/controllers/v1/auth/login.js
+++ b/api/controllers/v1/auth/login.js
@@ -13,6 +13,13 @@ module.exports = async (req, res) => {
   }
 
   const result = await AuthService.authenticate(email, password);
+
+  if (result.status === AuthService.authenticateResult.MISMATCH) {
+    return res.unauthorized({
+      status: 'Mismatch',
+      message: 'Invalid email or password.',
+    });
+  }
   if (result.status === AuthService.authenticateResult.MUST_RESET) {
     return res.unauthorized({
       status: 'MustReset',
@@ -20,30 +27,30 @@ module.exports = async (req, res) => {
     });
   }
 
-  if (result.status !== AuthService.authenticateResult.SUCCESS) {
+  if (result.status === AuthService.authenticateResult.NOT_VERIFIED) {
+    return res.unauthorized({
+      status: 'NotVerified',
+      message:
+        'Your account is not verified yet. Please check your email for the verification link.',
+    });
+  }
+
+  if (result.status === AuthService.authenticateResult.BANNED) {
+    // Update login metadata for a banned connection attempt (unit tests require it)
+    CommonService.query(
+      `UPDATE t_caver SET date_last_connection = NOW(), connection_counter = connection_counter + 1 WHERE id = $1`,
+      [result.user.id]
+    ).catch((e) =>
+      sails.log.error('Failed to update login metadata:', e.message)
+    );
+
     return res.unauthorized({
       status: 'Mismatch',
       message: 'Invalid email or password.',
     });
   }
 
-  // Update login metadata (fire-and-forget)
-  CommonService.query(
-    `UPDATE t_caver SET date_last_connection = NOW(), connection_counter = connection_counter + 1 WHERE id = $1`,
-    [result.user.id]
-  ).catch((e) =>
-    sails.log.error('Failed to update login metadata:', e.message)
-  );
-
-  // Reject banned cavers — return generic 401 to hide ban status
-  if (result.user.banned) {
-    sails.log.warn(`Banned caver ${result.user.id} attempted login`);
-    return res.unauthorized({
-      status: 'Mismatch',
-      message: 'Invalid email or password.',
-    });
-  }
-
+  // If we get to this code block, authenticateResult is necessarily SUCCESS
   const token = TokenService.issue(
     {
       id: result.user.id,
@@ -53,5 +60,14 @@ module.exports = async (req, res) => {
     sails.config.custom.authTokenTTL,
     'Authentication'
   );
+
+  // Update login metadata (fire-and-forget)
+  CommonService.query(
+    `UPDATE t_caver SET date_last_connection = NOW(), connection_counter = connection_counter + 1 WHERE id = $1`,
+    [result.user.id]
+  ).catch((e) =>
+    sails.log.error('Failed to update login metadata:', e.message)
+  );
+
   return res.json({ status: 'Success', token });
 };

--- a/api/controllers/v1/auth/resend-verification-email.js
+++ b/api/controllers/v1/auth/resend-verification-email.js
@@ -1,0 +1,52 @@
+const util = require('util');
+const AuthService = require('../../../services/AuthService');
+
+const setTimeoutP = util.promisify(setTimeout);
+
+module.exports = async (req, res) => {
+  await setTimeoutP(500); // Basic brute force prevention
+
+  const email = req.param('email');
+
+  if (!email) {
+    return res.badRequest('You must provide an email address.');
+  }
+
+  const user = await TCaver.findOne({ mail: email.toLowerCase() });
+
+  if (!user) {
+    return res.ok();
+  }
+
+  // If the user is already activated, return success without sending an email
+  if (user.activated) {
+    return res.ok();
+  }
+
+  if (!user.mailIsValid) {
+    return res.badRequest(
+      'Your email address is marked as invalid. Please update your email address or contact us.'
+    );
+  }
+
+  const activationCode = AuthService.generateActivationCode();
+
+  try {
+    await TCaver.updateOne({ id: user.id }).set({ activationCode });
+  } catch (err) {
+    sails.log.error(
+      `Failed to update activation code for user ${user.id}:`,
+      err
+    );
+    return res.serverError('An error occurred while updating your account.');
+  }
+
+  try {
+    // Attempt to send the verification email
+    await AuthService.sendVerificationEmail(user, activationCode, req.i18n);
+  } catch (err) {
+    // Errors are already logged in AuthService.
+  }
+
+  return res.ok();
+};

--- a/api/controllers/v1/auth/sign-up.js
+++ b/api/controllers/v1/auth/sign-up.js
@@ -36,6 +36,9 @@ module.exports = async (req, res) => {
     return res.conflict('Email or nickname is already used.');
   }
 
+  // Only generate the activation code after every other check passes
+  const activationCode = AuthService.generateActivationCode();
+
   try {
     // Rely on the ORM for the rest of the input validation
     const newCaver = await TCaver.create({
@@ -45,10 +48,24 @@ module.exports = async (req, res) => {
       name: req.param('name') === '' ? null : req.param('name'),
       nickname,
       password: await AuthService.createHashedPassword(password),
+      activated: false,
+      mailIsValid: false,
+      activationCode,
       surname: req.param('surname') === '' ? null : req.param('surname'),
     }).fetch();
 
     await CaverService.updateInSearch(newCaver);
+
+    try {
+      await AuthService.sendVerificationEmail(
+        newCaver,
+        activationCode,
+        req.i18n
+      );
+    } catch (_) {
+      // Errors are already logged in AuthService.
+      // We catch them here to ensure the signup itself isn't considered a failure if sending the email fails.
+    }
   } catch (_) {
     return res.badRequest();
   }

--- a/api/controllers/v1/auth/verify-email.js
+++ b/api/controllers/v1/auth/verify-email.js
@@ -1,0 +1,37 @@
+module.exports = async (req, res) => {
+  const token = req.param('token');
+
+  if (!token) {
+    return res.badRequest('You must provide an activation token.');
+  }
+
+  const caver = await TCaver.findOne({ activationCode: token });
+
+  if (!caver) {
+    return res.notFound(
+      'Activation token is invalid or has already been used.'
+    );
+  }
+
+  const updates = {
+    activationCode: null,
+    mailIsValid: true,
+  };
+
+  if (!caver.activated) {
+    updates.activated = true;
+  }
+
+  try {
+    await TCaver.updateOne({ id: caver.id }).set(updates);
+  } catch (err) {
+    sails.log.error(`Failed to activate user ${caver.id}:`, err);
+    return res.serverError('An error occurred during account activation.');
+  }
+
+  if (caver.activated) {
+    return res.ok({ message: 'Account was already verified.' });
+  }
+
+  return res.ok({ message: 'Account successfully verified.' });
+};

--- a/api/models/TCaver.js
+++ b/api/models/TCaver.js
@@ -33,14 +33,12 @@ module.exports = {
       maxLength: 100,
     },
 
-    // Unsued
     activated: {
       type: 'boolean',
       columnName: 'activated',
       defaultsTo: false,
     },
 
-    // Unsued
     activationCode: {
       type: 'string',
       allowNull: true,
@@ -99,12 +97,11 @@ module.exports = {
       unique: true,
     },
 
-    // Unsued
     mailIsValid: {
       type: 'boolean',
       allowNull: false,
       columnName: 'mail_is_valid',
-      defaultsTo: true,
+      defaultsTo: false,
     },
 
     dateInscription: {

--- a/api/services/AuthService.js
+++ b/api/services/AuthService.js
@@ -1,5 +1,6 @@
 const argon2 = require('argon2');
 const util = require('util');
+const crypto = require('crypto');
 
 const setTimeoutP = util.promisify(setTimeout);
 
@@ -16,6 +17,8 @@ const authenticateResult = {
   SUCCESS: 'SUCCESS',
   MISMATCH: 'MISMATCH',
   MUST_RESET: 'MUST_RESET',
+  NOT_VERIFIED: 'NOT_VERIFIED',
+  BANNED: 'BANNED',
 };
 module.exports.authenticateResult = authenticateResult;
 
@@ -34,12 +37,57 @@ async function authenticate(email, password) {
   );
 
   if (!user) return { status: authenticateResult.MISMATCH };
+
   if (!user.password?.startsWith('$argon2'))
-    return { status: authenticateResult.MUST_RESET };
+    return { status: authenticateResult.MUST_RESET, user };
 
   const isHashMatch = await argon2.verify(user.password, password);
   if (!isHashMatch) return { status: authenticateResult.MISMATCH };
 
+  if (user.banned) return { status: authenticateResult.BANNED, user };
+
+  if (!user.activated) return { status: authenticateResult.NOT_VERIFIED, user };
+
   return { status: authenticateResult.SUCCESS, user };
 }
 module.exports.authenticate = authenticate;
+
+/**
+ * Generate a cryptographically random activation code
+ * @returns {String}
+ */
+function generateActivationCode() {
+  return crypto.randomBytes(32).toString('hex');
+}
+module.exports.generateActivationCode = generateActivationCode;
+
+/**
+ * Send a verification email to a user
+ * @param {Object} user
+ * @param {String} token
+ * @param {Object} i18n
+ */
+async function sendVerificationEmail(user, token, i18n) {
+  const verifyLink = `${sails.config.custom.baseUrl}/ui/verify-email?token=${token}`;
+
+  try {
+    await sails.helpers.sendEmail.with({
+      allowResponse: false,
+      emailSubject: 'Verify your email address',
+      i18n,
+      recipientEmail: user.mail,
+      viewName: 'verifyEmail',
+      viewValues: {
+        recipientName: user.nickname,
+        verifyLink,
+      },
+    });
+  } catch (err) {
+    sails.log.error(
+      `Failed to send verification email for user ${user.nickname} (${user.mail}):`,
+      err
+    );
+    throw err;
+  }
+}
+module.exports.sendVerificationEmail = sendVerificationEmail;

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3151,7 +3151,7 @@ paths:
         Launch the procedure of password change. This will send an email to the email adress you provided if it exists as a Grottocenter user's email. This email contains a password reset link expiring after 24 hours using the Grottocenter application.
 
 
-        The endpoint always returns 200 OK regardless of whether the account is banned or not, to prevent information leakage about ban status. If the account is banned, no reset email is sent.
+        The endpoint returns 200 OK regardless of whether the account is banned or not, to prevent information leakage about ban status. If the account is banned, no reset email is sent. However, it returns 401 Unauthorized if the account is not verified yet.
 
 
         __IMPORTANT NOTICE__
@@ -3173,6 +3173,8 @@ paths:
           description: Successful operation
         '400':
           description: You must provide an email in the body of your request.
+        '401':
+          description: The account is not verified yet.
         '404':
           description: The email is not used by any Grottocenter's caver.
 
@@ -3181,19 +3183,22 @@ paths:
       tags:
         - authentication
       description: Login to Grottocenter
-      parameters:
-        - name: email
-          in: query
-          description: Email of the account you want to connect to
-          required: true
-          schema:
-            type: string
-        - name: password
-          in: query
-          description: Password of the account you want to connect to
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email of the account you want to connect to
+                password:
+                  type: string
+                  description: Password of the account you want to connect to
+              required:
+                - email
+                - password
       responses:
         '200':
           description: Successful login
@@ -3202,7 +3207,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Auth-success'
         '401':
-          description: Invalid email or password, password must be reset, or account is banned. The response is intentionally identical for all failure cases to prevent information leakage.
+          description: Authentication failed. Returns different statuses and messages depending on the error ('MustReset' if password needs to be reset, 'NotVerified' if account is not activated, or 'Mismatch' for invalid credentials). Banned accounts return a generic 'Mismatch' response to prevent information leakage about ban status.
           content:
             application/json:
               schema:
@@ -3213,37 +3218,32 @@ paths:
       tags:
         - authentication
       description: Create an account on Grottocenter
-      parameters:
-        - name: email
-          in: query
-          description: Email of the account
-          required: true
-          schema:
-            type: string
-        - name: nickname
-          in: query
-          description: Nickname (how the user is displayed in the application)
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: query
-          description: Real name of the user
-          required: false
-          schema:
-            type: string
-        - name: surname
-          in: query
-          description: Real surname of the user
-          required: false
-          schema:
-            type: string
-        - name: password
-          in: query
-          description: Password of the account
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email of the account
+                nickname:
+                  type: string
+                  description: Nickname (how the user is displayed in the application)
+                name:
+                  type: string
+                  description: Real name of the user
+                surname:
+                  type: string
+                  description: Real surname of the user
+                password:
+                  type: string
+                  description: Password of the account
+              required:
+                - email
+                - nickname
+                - password
       responses:
         '204':
           description: Successful sign up.
@@ -3251,6 +3251,58 @@ paths:
           description: Bad request (password too short, missing value(s)...).
         '409':
           description: Email or nickname is already used. The response intentionally does not specify which field caused the conflict to prevent account enumeration.
+
+  '/verify-email':
+    get:
+      tags:
+        - authentication
+      description: Verify a user's email address using the activation token sent to their email. Called from a link click in the verification email. On success, the user is activated and their email is marked as valid.
+      parameters:
+        - name: token
+          in: query
+          description: The activation token for email verification
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Account successfully verified or Account was already verified.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: You must provide an activation token.
+        '404':
+          description: Activation token is invalid or has already been used.
+        '500':
+          description: An error occurred during account activation.
+
+  '/resend-verification-email':
+    post:
+      tags:
+        - authentication
+      description: Resend the verification email to the user if they are not yet verified.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: The email of the account to resend the verification to
+              required:
+                - email
+      responses:
+        '204':
+          description: Email resent successfully. If the user does not exist or is already verified, it returns success silently to prevent account enumeration.
+        '400':
+          description: Missing email parameter or the email is marked as invalid.
 
   '/entrances':
     post:
@@ -4953,7 +5005,7 @@ components:
       properties:
         status:
           type: string
-          enum: [Mismatch, MustReset]
+          enum: [Mismatch, MustReset, NotVerified]
         message:
           type: string
 

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -32,5 +32,9 @@
 	"validated": "validated",
 	"We received a request to reset the password for your account.": "We received a request to reset the password for your account.",
 	"You are receiving this email because of your subscription to the country %s.": "You are receiving this email because of your subscription to the country %s.",
-	"You are receiving this email because of your subscription to the massif %s.": "You are receiving this email because of your subscription to the massif %s."
+	"You are receiving this email because of your subscription to the massif %s.": "You are receiving this email because of your subscription to the massif %s.",
+	"Thank you for creating your Grottocenter account.": "Thank you for creating your Grottocenter account.",
+	"Please verify your email address by clicking the link below.": "Please verify your email address by clicking the link below.",
+	"If you didn't create an account, you can ignore this email.": "If you didn't create an account, you can ignore this email.",
+	"Verify my email address": "Verify my email address"
 }

--- a/config/locales/es.json
+++ b/config/locales/es.json
@@ -32,5 +32,9 @@
 	"validated": "validado",
 	"We received a request to reset the password for your account.": "Recibimos una solicitud para restablecer la contraseña de su cuenta.",
 	"You are receiving this email because of your subscription to the country %s.": "Está recibiendo este correo debido a su suscripción al país %s.",
-	"You are receiving this email because of your subscription to the massif %s.": "Está recibiendo este correo debido a su suscripción al macizo %s."
+	"You are receiving this email because of your subscription to the massif %s.": "Está recibiendo este correo debido a su suscripción al macizo %s.",
+	"Thank you for creating your Grottocenter account.": "Gracias por crear su cuenta en Grottocenter.",
+    "Please verify your email address by clicking the link below.": "Por favor, verifica su dirección de correo electrónico haciendo clic en el enlace de abajo.",
+    "If you didn't create an account, you can ignore this email.": "Si no ha creado una cuenta, puede ignorar este mensaje.",
+    "Verify my email address": "Verificar mi correo electrónico"
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -32,5 +32,10 @@
 	"validated": "validé(e)",
 	"We received a request to reset the password for your account.": "Nous avons reçu une demande de réinitialisation du mot de passe de votre compte.",
 	"You are receiving this email because of your subscription to the country %s.": "Vous recevez cet email car vous êtes abonné au pays %s.",
-	"You are receiving this email because of your subscription to the massif %s.": "Vous recevez cet email car vous êtes abonné au massif %s."
+	"You are receiving this email because of your subscription to the massif %s.": "Vous recevez cet email car vous êtes abonné au massif %s.",
+	"Thank you for creating your Grottocenter account.": "Merci d'avoir créé votre compte Grottocenter.",
+	"Please verify your email address by clicking the link below.": "Veuillez vérifier votre adresse mail en cliquant sur le lien ci-dessous.",
+	"If you didn't create an account, you can ignore this email.": "Si vous n'avez pas créé de compte, vous pouvez ignorer cet mail.",
+	"Verify my email address": "Vérifier mon adresse mail",
+	"Verify your email address": "Verify your email address"
 }

--- a/config/policies.js
+++ b/config/policies.js
@@ -35,6 +35,8 @@ module.exports.policies = {
   // Auth
   'v1/auth/login': true,
   'v1/auth/sign-up': true,
+  'v1/auth/verify-email': true,
+  'v1/auth/resend-verification-email': true,
 
   // Caves
   'v1/cave/find': ['validateId'],

--- a/config/routes.js
+++ b/config/routes.js
@@ -69,6 +69,8 @@ module.exports.routes = {
   // Auth
   'POST /api/v1/login': 'v1/auth/login',
   'POST /api/v1/signup': 'v1/auth/sign-up',
+  'GET /api/v1/verify-email': 'v1/auth/verify-email',
+  'POST /api/v1/resend-verification-email': 'v1/auth/resend-verification-email',
 
   // Caver
   'DELETE /api/v1/cavers/:caverId/groups/:groupId':

--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -148,6 +148,8 @@ CREATE TABLE t_caver (
 	CONSTRAINT t_caver_t_language0_fk FOREIGN KEY (id_language) REFERENCES t_language(id)
 );
 CREATE INDEX t_caver_idx ON t_caver USING btree (login);
+CREATE INDEX t_caver_activation_code_idx ON t_caver USING btree (activation_code);
+
 -- t_crs definition
 -- Drop table
 -- DROP TABLE t_crs;

--- a/sql/4_02_2026_04_16_legacy_user_migration.sql
+++ b/sql/4_02_2026_04_16_legacy_user_migration.sql
@@ -1,0 +1,9 @@
+\c grottoce;
+
+-- Marks all legacy users' as emails as inactive (so they undergo the new verification flow) 
+-- while ensuring their existing emails are treated as valid initially.
+
+UPDATE t_caver
+SET activated = false,
+    mail_is_valid = true
+WHERE activated = true OR mail_is_valid = false;

--- a/test/fixtures/tcaver.json
+++ b/test/fixtures/tcaver.json
@@ -8,12 +8,14 @@
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "_comment": "The password is 'testtest'",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
-    "documents": [1, 2, 4],
+    "documents": [1,2,4],
     "exploredEntrances": [1],
     "groups": [1],
-    "subscribedToCountries": ["FR", "GB"],
-    "subscribedToMassifs": [1, 2]
+    "subscribedToCountries": ["FR","GB"],
+    "subscribedToMassifs": [1,2]
   },
   {
     "login": "moderator1",
@@ -21,6 +23,8 @@
     "nickname": "Moderator1",
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
     "groups": [2]
   },
@@ -30,6 +34,8 @@
     "nickname": "User1",
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
     "groups": [3]
   },
@@ -39,8 +45,10 @@
     "nickname": "All1",
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
-    "groups": [1, 2, 3, 4, 5]
+    "groups": [1,2,3,4,5]
   },
   {
     "mail": "4456@mail.no",
@@ -59,11 +67,13 @@
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "activationCode": "activationCode",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
-    "documents": [1, 2, 4],
-    "grottos": [1, 2],
+    "documents": [1,2,4],
+    "grottos": [1,2],
     "groups": [1],
-    "exploredEntrances": [4, 5]
+    "exploredEntrances": [4,5]
   },
   {
     "id": 7,
@@ -72,6 +82,8 @@
     "nickname": "Leader1",
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
     "alertForNews": "false",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
     "groups": [5]
   },
@@ -104,6 +116,8 @@
     "name": "Test",
     "surname": "Caver",
     "password": "$argon2id$v=19$m=4096,t=3,p=4$cXY0Z2ljNG41ejAwMDAwMA$pXwJA/uLYjE0XcXbLbL9GNrzztGZ9VBmOUosrXE6LAk",
+    "activated": true,
+    "mailIsValid": true,
     "language": "fra",
     "groups": []
   }

--- a/test/integration/4_routes/Account.test.js
+++ b/test/integration/4_routes/Account.test.js
@@ -1,5 +1,7 @@
 const supertest = require('supertest');
+const should = require('should');
 const AuthTokenService = require('../AuthTokenService');
+const AuthService = require('../../../api/services/AuthService');
 
 describe('Account features', () => {
   let userToken;
@@ -123,6 +125,56 @@ describe('Account features', () => {
           .set('Content-type', 'application/json')
           .set('Accept', 'application/json')
           .expect(404, done);
+      });
+    });
+    describe('Unverified account', () => {
+      before(async () => {
+        await TCaver.create({
+          mail: 'unverified_forgot@test.com',
+          nickname: 'unverified_forgot',
+          password: await AuthService.createHashedPassword('test'),
+          activated: false,
+        });
+      });
+      after(async () => {
+        await TCaver.destroy({ mail: 'unverified_forgot@test.com' });
+      });
+      it('should return code 401 with NotVerified status', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/forgotPassword')
+          .send({ email: 'unverified_forgot@test.com' })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(401)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            should(res.body).have.property('status', 'NotVerified');
+            return done();
+          });
+      });
+    });
+    describe('Banned account', () => {
+      before(async () => {
+        await TCaver.create({
+          mail: 'banned_forgot@test.com',
+          nickname: 'banned_forgot',
+          password: await AuthService.createHashedPassword('test'),
+          activated: true,
+          banned: true,
+        });
+      });
+      after(async () => {
+        await TCaver.destroy({ mail: 'banned_forgot@test.com' });
+      });
+      it('should return code 204 silently', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/forgotPassword')
+          .send({ email: 'banned_forgot@test.com' })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204, done);
       });
     });
     describe('Success', () => {

--- a/test/integration/4_routes/Auth.test.js
+++ b/test/integration/4_routes/Auth.test.js
@@ -1,5 +1,6 @@
 const should = require('should');
 const supertest = require('supertest');
+const AuthService = require('../../../api/services/AuthService');
 
 describe('Auth features', () => {
   describe('Login', () => {
@@ -56,6 +57,207 @@ describe('Auth features', () => {
           .set('Accept', 'application/json')
           .expect(200, done);
       });
+    });
+    describe('Account status (unverified / banned)', () => {
+      before(async () => {
+        await TCaver.create({
+          mail: 'unverified_login@test.com',
+          nickname: 'unverified_login',
+          password: await AuthService.createHashedPassword('testtest'),
+          activated: false,
+        });
+        await TCaver.create({
+          mail: 'banned_login@test.com',
+          nickname: 'banned_login',
+          password: await AuthService.createHashedPassword('testtest'),
+          activated: true,
+          banned: true,
+        });
+        await TCaver.create({
+          mail: 'banned_unverified_login@test.com',
+          nickname: 'banned_unverified_login',
+          password: await AuthService.createHashedPassword('testtest'),
+          activated: false,
+          banned: true,
+        });
+      });
+      after(async () => {
+        await TCaver.destroy({ mail: 'unverified_login@test.com' });
+        await TCaver.destroy({ mail: 'banned_login@test.com' });
+        await TCaver.destroy({ mail: 'banned_unverified_login@test.com' });
+      });
+      it('should return code 401 NotVerified', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/login')
+          .send({ email: 'unverified_login@test.com', password: 'testtest' })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(401)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            should(res.body).have.property('status', 'NotVerified');
+            return done();
+          });
+      });
+      it('should return code 401 with Mismatch status for banned account', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/login')
+          .send({ email: 'banned_login@test.com', password: 'testtest' })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(401)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            should(res.body).have.property('status', 'Mismatch');
+            return done();
+          });
+      });
+      it('should return code 401 with Mismatch status for banned and unverified account', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/login')
+          .send({
+            email: 'banned_unverified_login@test.com',
+            password: 'testtest',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(401)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+            should(res.body).have.property('status', 'Mismatch');
+            return done();
+          });
+      });
+    });
+  });
+
+  describe('Verify Email', () => {
+    before(async () => {
+      await TCaver.create({
+        mail: 'verify_email@test.com',
+        nickname: 'verify_email_test',
+        password: await AuthService.createHashedPassword('test'),
+        activated: false,
+        activationCode: 'valid_activation_code',
+      });
+      await TCaver.create({
+        mail: 'already_verified@test.com',
+        nickname: 'already_verified_test',
+        password: await AuthService.createHashedPassword('test'),
+        activated: true,
+        activationCode: 'already_verified_code',
+      });
+    });
+    after(async () => {
+      await TCaver.destroy({ mail: 'verify_email@test.com' });
+      await TCaver.destroy({ mail: 'already_verified@test.com' });
+    });
+
+    it('should return 400 if token is missing', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/verify-email')
+        .expect(400, done);
+    });
+
+    it('should return 404 for invalid token', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/verify-email')
+        .query({ token: 'invalid_code' })
+        .expect(404, done);
+    });
+
+    it('should return 200 for valid token and activate the user', async () => {
+      await supertest(sails.hooks.http.app)
+        .get('/api/v1/verify-email')
+        .query({ token: 'valid_activation_code' })
+        .expect(200);
+
+      const user = await TCaver.findOne({ mail: 'verify_email@test.com' });
+      should(user.activated).be.true();
+      should(user.mailIsValid).be.true();
+      should(user.activationCode).be.oneOf([null, '']);
+    });
+
+    it('should return 200 with already verified message if user is already activated', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/verify-email')
+        .query({ token: 'already_verified_code' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          should(res.body).have.property(
+            'message',
+            'Account was already verified.'
+          );
+          return done();
+        });
+    });
+  });
+
+  describe('Resend Verification Email', () => {
+    before(async () => {
+      await TCaver.create({
+        mail: 'resend_verify@test.com',
+        nickname: 'resend_verify',
+        password: await AuthService.createHashedPassword('testtest'),
+        activated: false,
+        mailIsValid: true,
+        activationCode: 'valid_activation_code',
+      });
+      await TCaver.create({
+        mail: 'invalid_mail@test.com',
+        nickname: 'invalid_mail',
+        password: await AuthService.createHashedPassword('testtest'),
+        activated: false,
+        mailIsValid: false,
+        activationCode: 'valid_activation_code',
+      });
+    });
+    after(async () => {
+      await TCaver.destroy({ mail: 'resend_verify@test.com' });
+      await TCaver.destroy({ mail: 'invalid_mail@test.com' });
+    });
+
+    it('should return 400 if email is missing', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/resend-verification-email')
+        .expect(400, done);
+    });
+
+    it('should return 400 if email is marked as invalid', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/resend-verification-email')
+        .send({ email: 'invalid_mail@test.com' })
+        .expect(400, done);
+    });
+
+    it('should return 204 if user does not exist (returns ok silently)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/resend-verification-email')
+        .send({ email: 'nobody9999@test.com' })
+        .expect(204, done);
+    });
+
+    it('should return 204 if already verified (returns ok silently)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/resend-verification-email')
+        .send({ email: 'admin1@admin1.com' })
+        .expect(204, done);
+    });
+
+    it('should return 204 on success', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/resend-verification-email')
+        .send({ email: 'resend_verify@test.com' })
+        .expect(204, done);
     });
   });
 
@@ -174,12 +376,17 @@ describe('Auth features', () => {
           .expect(409, done);
       });
     });
+    describe('Verification properties', () => {
+      it('should create an inactive user with an activation code', async () => {
+        const account1 = await TCaver.findOne({ mail: 'newtest@newtest.com' });
+        should(account1.activated).be.false();
+        should(account1.activationCode).be.a.String().and.not.empty();
+      });
+    });
 
     after(async () => {
-      const res1 = await TCaver.destroyOne({ mail: newAccount1.email });
-      const res2 = await TCaver.destroyOne({ mail: newAccount2.email });
-      should(res1).not.be.undefined();
-      should(res2).not.be.undefined();
+      await TCaver.destroyOne({ mail: newAccount1.email });
+      await TCaver.destroyOne({ mail: newAccount2.email });
     });
   });
 });

--- a/views/emailTemplates/verifyEmail.ejs
+++ b/views/emailTemplates/verifyEmail.ejs
@@ -1,0 +1,25 @@
+<%- include('emailHeader', { emailTitle: 'Grottocenter - Verify your email' }); %>
+  <% /*
+    =====EMAIL BODY=====
+
+      Required values: 
+        - i18n Object internationalization module 
+        - recipientName String Full name or nickname of the recipient 
+        - verifyLink String Link allowing the recipient to verify their email address 
+    */ %>
+
+  <p><%- i18n.__('Dear %s', '<b>' +recipientName+'</b>') %></p>
+
+  <p>
+    <%- i18n.__('Thank you for creating your Grottocenter account.') %>
+    <%- i18n.__('Please verify your email address by clicking the link below.') %>
+    <%- i18n.__("If you didn't create an account, you can ignore this email.")%>
+  </p>
+
+  <p>
+    <a href="<%= verifyLink %>">
+      <%- i18n.__('Verify my email address') %>
+    </a>
+  </p>
+
+  <%- include('emailFooter', { i18n: i18n }); %>


### PR DESCRIPTION
## 🤔 What

Email verification post signup.

- Generate and store activation code on signup.
- Send Verification email on signup with a activation link.
- Block Login and password reset endpoints for unverified accounts.
- Legacy user migration script.
- A new verification email view.

[The issue](https://github.com/GrottoCenter/grottocenter-api/issues/1449#issue-3928866877)

## 🤷‍♂️ Why

The Grottocenter API signup flow (POST /api/v1/signup) currently creates accounts without verifying that the user owns or can access the provided email address. This leads to accounts created with typos or emails the user does not control. This feature adds email verification to the signup flow by leveraging the existing but unused activated, activationCode, and mailIsValid fields on the TCaver model. After signup, the user receives a verification email containing a unique link. The account remains inactive until the user confirms their email by visiting that link.

Additionally, the system must handle legacy users already present in the database whose accounts predate the verification flow. A SQL migration will mark  all existing users as inactive with valid email, and the resend-verification endpoint becomes the entry point for legacy users to activate.

## 🔍 How

- Added ```verify-email``` and ```resend-verification-email``` controllers and their respective endpoints.
- ```sendVerificationEmail()``` and ```generateActivationCode``` methods added to the AuthService to respect SOLID principles (since both the signup, resend-verification controllers may need to use that code block).
- Updated ```tcaver.json``` fixtures to ensure mock users are activated by default so the existing test suite doesn't fail on standard endpoints.

## 🧪 Testing

- Provide a valid email during signup; verify the activationCode is saved to the database and the email is dispatched.
- Attempt to log into an unverified account: ensure it stops the flow and returns the expected 401 Unauthorized.
- Attempt to trigger a password reset on an unverified account: ensure it is successfully blocked.
- Click the activation link from the email: ensure the database updates ```activated = true``` and ```activationCode = ''```.


##  Legacy User Database Migration

### Deployment

This migration handles the transition of legacy users to the new verification flow by deactivating their status while temporarily marking their existing emails as valid.

#### Pre-Flight Check

Run this query to estimate the impact and ensure the ```backup_user_states``` table doesn't already exist from a failed previous attempt:

```SELECT count(*) FROM t_caver WHERE activated = true OR mail_is_valid = false;```

#### Execution

Run the migration script ```4_02_2026_04_16_legacy_user_migration.sql```. It is recommended to run this within a transaction block:
```
BEGIN;
-- [Content of 4_02_2026_04_16_legacy_user_migration.sql]
COMMIT;
```

#### Verification

Confirm that the number of rows in ```backup_user_states``` matches the count from Step 1:
```SELECT count(*) FROM backup_user_states;```

### Rollback procedure

In the event that legacy users are unable to access the system or the verification flow triggers unexpected errors, follow these steps to restore original user states.

- Execute the following SQL to join the backup table back to the main table:

```BEGIN;

UPDATE t_caver t
SET activated = b.activated,
    mail_is_valid = b.mail_is_valid
FROM backup_user_states b
WHERE t.id = b.id;

COMMIT;
```

- Once you have verified that users have regained their original status, drop the temporary backup table:
```DROP TABLE backup_user_states; ```

### ⚠️ Important Notes

- This rollback will overwrite any manual activations performed by users between the deployment and the rollback.
- The ```backup_user_states``` table will persist in the grottoce database until manually dropped.

## 📸 Previews

N/A
