### PR TITLE
1450 massif sensitive setting

### DIFF
--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -43,13 +43,16 @@ module.exports = async (req, res) => {
     );
   }
 
+  const rawData = MassifService.getConvertedDataFromClientRequest(req);
+
   // Launch creation request using transaction: it performs a rollback if an error occurs
   const newMassif = await sails.getDatastore().transaction(async (db) => {
     const cleanedData = {
       author: req.token.id,
       dateInscription: new Date(),
-      documents: req.body.documents ? req.body.documents : [],
+      documents: rawData.documents ? rawData.documents : [],
       geogPolygon: wkt,
+      isSensitive: rawData.isSensitive,
     };
 
     const massif = await TMassif.create(cleanedData)
@@ -80,6 +83,10 @@ module.exports = async (req, res) => {
 
     return massif;
   });
+
+  if (newMassif.isSensitive) {
+    await MassifService.setSensitivity(newMassif.id, true);
+  }
 
   const newMassifPopulated = await MassifService.getPopulatedMassif(
     newMassif.id

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -5,6 +5,7 @@ const NotificationService = require('../../../services/NotificationService');
 const RecentChangeService = require('../../../services/RecentChangeService');
 const { toMassif } = require('../../../services/mapping/converters');
 const { validateNameLength } = require('../../../utils/nameValidation');
+const RightService = require('../../../services/RightService');
 
 // eslint-disable-next-line consistent-return
 module.exports = async (req, res) => {
@@ -45,6 +46,15 @@ module.exports = async (req, res) => {
   }
 
   const rawData = MassifService.getConvertedDataFromClientRequest(req);
+
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+
+  if (rawData.isSensitive !== undefined && !isAdmin) {
+    return res.forbidden('Only administrators can set the sensitivity status.');
+  }
 
   // Launch creation request using transaction: it performs a rollback if an error occurs
   const newMassif = await sails.getDatastore().transaction(async (db) => {
@@ -88,7 +98,8 @@ module.exports = async (req, res) => {
   if (newMassif.isSensitive) {
     const updatedEntranceIds = await MassifService.setSensitivity(
       newMassif.id,
-      true
+      true,
+      req.token.id
     );
     await Promise.all(
       updatedEntranceIds.map(async (id) => {

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -1,5 +1,6 @@
 const ControllerService = require('../../../services/ControllerService');
 const MassifService = require('../../../services/MassifService');
+const EntranceService = require('../../../services/EntranceService');
 const NotificationService = require('../../../services/NotificationService');
 const RecentChangeService = require('../../../services/RecentChangeService');
 const { toMassif } = require('../../../services/mapping/converters');
@@ -85,7 +86,16 @@ module.exports = async (req, res) => {
   });
 
   if (newMassif.isSensitive) {
-    await MassifService.setSensitivity(newMassif.id, true);
+    const updatedEntranceIds = await MassifService.setSensitivity(
+      newMassif.id,
+      true
+    );
+    await Promise.all(
+      updatedEntranceIds.map(async (id) => {
+        const populated = await EntranceService.getPopulatedEntrance(id);
+        if (populated) await EntranceService.updateInSearch(populated);
+      })
+    );
   }
 
   const newMassifPopulated = await MassifService.getPopulatedMassif(

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -57,50 +57,57 @@ module.exports = async (req, res) => {
   }
 
   // Launch creation request using transaction: it performs a rollback if an error occurs
-  const newMassif = await sails.getDatastore().transaction(async (db) => {
-    const cleanedData = {
-      author: req.token.id,
-      dateInscription: new Date(),
-      documents: rawData.documents ? rawData.documents : [],
-      geogPolygon: wkt,
-      isSensitive: rawData.isSensitive,
-    };
-
-    const massif = await TMassif.create(cleanedData)
-      .fetch()
-      .usingConnection(db);
-
-    // Name
-    await TName.create({
-      author: req.token.id,
-      dateInscription: new Date(),
-      isMain: true,
-      language: req.body.descriptionAndNameLanguage.id,
-      massif: massif.id,
-      name: req.body.name,
-    }).usingConnection(db);
-
-    // Description
-    if (req.body?.description) {
-      await TDescription.create({
+  const { newMassif, updatedEntranceIds } = await sails
+    .getDatastore()
+    .transaction(async (db) => {
+      const cleanedData = {
         author: req.token.id,
-        body: req.body.description,
         dateInscription: new Date(),
-        massif: massif.id,
-        language: req.body.descriptionAndNameLanguage.id,
-        title: req.body.descriptionTitle,
-      }).usingConnection(db);
-    }
+        documents: rawData.documents ? rawData.documents : [],
+        geogPolygon: wkt,
+        isSensitive: rawData.isSensitive,
+      };
 
-    return massif;
-  });
+      const massif = await TMassif.create(cleanedData)
+        .fetch()
+        .usingConnection(db);
+
+      // Name
+      await TName.create({
+        author: req.token.id,
+        dateInscription: new Date(),
+        isMain: true,
+        language: req.body.descriptionAndNameLanguage.id,
+        massif: massif.id,
+        name: req.body.name,
+      }).usingConnection(db);
+
+      // Description
+      if (req.body?.description) {
+        await TDescription.create({
+          author: req.token.id,
+          body: req.body.description,
+          dateInscription: new Date(),
+          massif: massif.id,
+          language: req.body.descriptionAndNameLanguage.id,
+          title: req.body.descriptionTitle,
+        }).usingConnection(db);
+      }
+
+      let affectedEntranceIds = [];
+      if (massif.isSensitive) {
+        affectedEntranceIds =
+          await MassifService.propagateSensitivityToEntrances(
+            massif.id,
+            req.token.id,
+            db
+          );
+      }
+
+      return { newMassif: massif, updatedEntranceIds: affectedEntranceIds };
+    });
 
   if (newMassif.isSensitive) {
-    const updatedEntranceIds = await MassifService.setSensitivity(
-      newMassif.id,
-      true,
-      req.token.id
-    );
     await Promise.all(
       updatedEntranceIds.map(async (id) => {
         const populated = await EntranceService.getPopulatedEntrance(id);

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -25,6 +25,22 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
+  // Idempotency: skip if already sensitive
+  if (massif.isSensitive) {
+    const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+    const meta = getMetaFromRequest(req);
+    return ControllerService.treat(
+      req,
+      null,
+      {
+        count: 0,
+        massif: toMassif(updatedMassif, meta),
+      },
+      { controllerMethod: 'MassifController.mark-sensitive' },
+      res
+    );
+  }
+
   try {
     // Set the massif as sensitive and get IDs of entrances that were updated
     const updatedEntranceIds = await MassifService.setSensitivity(

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -1,8 +1,8 @@
 const RightService = require('../../../services/RightService');
 const MassifService = require('../../../services/MassifService');
 const EntranceService = require('../../../services/EntranceService');
-const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
+const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
   const isAdmin = RightService.hasGroup(
@@ -25,7 +25,11 @@ module.exports = async (req, res) => {
   }
 
   // Set the massif as sensitive and get IDs of entrances that were updated
-  const updatedEntranceIds = await MassifService.setSensitivity(massifId, true);
+  const updatedEntranceIds = await MassifService.setSensitivity(
+    massifId,
+    true,
+    req.token.id
+  );
 
   // Update search index for each affected entrance
   await Promise.all(
@@ -40,12 +44,10 @@ module.exports = async (req, res) => {
   const updatedMassif = await MassifService.getPopulatedMassif(massifId);
   await MassifService.updateInSearch(updatedMassif);
 
-  return ControllerService.treatAndConvert(
-    req,
-    null,
-    updatedMassif,
-    { controllerMethod: 'MassifController.mark-sensitive' },
-    res,
-    toMassif
-  );
+  const meta = getMetaFromRequest(req);
+
+  return res.ok({
+    count: updatedEntranceIds.length,
+    massif: toMassif(updatedMassif, meta),
+  });
 };

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -1,0 +1,40 @@
+const RightService = require('../../../services/RightService');
+const MassifService = require('../../../services/MassifService');
+const ControllerService = require('../../../services/ControllerService');
+const { toMassif } = require('../../../services/mapping/converters');
+
+module.exports = async (req, res) => {
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+
+  if (!isAdmin) {
+    return res.forbidden('Only administrators can perform this action.');
+  }
+
+  const massifId = req.param('id');
+  if (!massifId) {
+    return res.badRequest('massifId is required.');
+  }
+
+  const massif = await TMassif.findOne(massifId);
+  if (!massif || massif.isDeleted) {
+    return res.notFound({ message: `Massif of id ${massifId} not found.` });
+  }
+
+  // Set the massif as sensitive. Logic in MassifService will propagate to entrances.
+  await MassifService.setSensitivity(massifId, true);
+
+  const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+  await MassifService.updateInSearch(updatedMassif);
+
+  return ControllerService.treatAndConvert(
+    req,
+    null,
+    updatedMassif,
+    { controllerMethod: 'MassifController.mark-sensitive' },
+    res,
+    toMassif
+  );
+};

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -1,5 +1,6 @@
 const RightService = require('../../../services/RightService');
 const MassifService = require('../../../services/MassifService');
+const EntranceService = require('../../../services/EntranceService');
 const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
 
@@ -23,8 +24,18 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  // Set the massif as sensitive. Logic in MassifService will propagate to entrances.
-  await MassifService.setSensitivity(massifId, true);
+  // Set the massif as sensitive and get IDs of entrances that were updated
+  const updatedEntranceIds = await MassifService.setSensitivity(massifId, true);
+
+  // Update search index for each affected entrance
+  await Promise.all(
+    updatedEntranceIds.map(async (id) => {
+      const populatedEntrance = await EntranceService.getPopulatedEntrance(id);
+      if (populatedEntrance) {
+        await EntranceService.updateInSearch(populatedEntrance);
+      }
+    })
+  );
 
   const updatedMassif = await MassifService.getPopulatedMassif(massifId);
   await MassifService.updateInSearch(updatedMassif);

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -1,6 +1,7 @@
 const RightService = require('../../../services/RightService');
 const MassifService = require('../../../services/MassifService');
 const EntranceService = require('../../../services/EntranceService');
+const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
 const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
@@ -24,30 +25,45 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  // Set the massif as sensitive and get IDs of entrances that were updated
-  const updatedEntranceIds = await MassifService.setSensitivity(
-    massifId,
-    true,
-    req.token.id
-  );
+  try {
+    // Set the massif as sensitive and get IDs of entrances that were updated
+    const updatedEntranceIds = await MassifService.setSensitivity(
+      massifId,
+      true,
+      req.token.id
+    );
 
-  // Update search index for each affected entrance
-  await Promise.all(
-    updatedEntranceIds.map(async (id) => {
-      const populatedEntrance = await EntranceService.getPopulatedEntrance(id);
-      if (populatedEntrance) {
-        await EntranceService.updateInSearch(populatedEntrance);
-      }
-    })
-  );
+    // Update search index for each affected entrance
+    await Promise.all(
+      updatedEntranceIds.map(async (id) => {
+        const populatedEntrance =
+          await EntranceService.getPopulatedEntrance(id);
+        if (populatedEntrance) {
+          await EntranceService.updateInSearch(populatedEntrance);
+        }
+      })
+    );
 
-  const updatedMassif = await MassifService.getPopulatedMassif(massifId);
-  await MassifService.updateInSearch(updatedMassif);
+    const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+    await MassifService.updateInSearch(updatedMassif);
 
-  const meta = getMetaFromRequest(req);
+    const meta = getMetaFromRequest(req);
 
-  return res.ok({
-    count: updatedEntranceIds.length,
-    massif: toMassif(updatedMassif, meta),
-  });
+    return ControllerService.treat(
+      req,
+      null,
+      {
+        count: updatedEntranceIds.length,
+        massif: toMassif(updatedMassif, meta),
+      },
+      { controllerMethod: 'MassifController.mark-sensitive' },
+      res
+    );
+  } catch (err) {
+    sails.log.error(
+      `Error setting massif with id ${massifId} as sensitive:`,
+      err
+    );
+    return res.serverError(err);
+  }
 };

--- a/api/controllers/v1/massif/preview-sensitive.js
+++ b/api/controllers/v1/massif/preview-sensitive.js
@@ -1,0 +1,34 @@
+const RightService = require('../../../services/RightService');
+const MassifService = require('../../../services/MassifService');
+const ControllerService = require('../../../services/ControllerService');
+
+module.exports = async (req, res) => {
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+
+  if (!isAdmin) {
+    return res.forbidden('Only administrators can perform this action.');
+  }
+
+  const massifId = req.param('id');
+  if (!massifId) {
+    return res.badRequest('massifId is required.');
+  }
+
+  const massifExists = await TMassif.count({ id: massifId, isDeleted: false });
+  if (!massifExists) {
+    return res.notFound({ message: `Massif of id ${massifId} not found.` });
+  }
+
+  const count = await MassifService.countUnsensitiveEntrances(massifId);
+
+  return ControllerService.treat(
+    req,
+    null,
+    { count },
+    { controllerMethod: 'MassifController.preview-sensitive' },
+    res
+  );
+};

--- a/api/controllers/v1/massif/preview-sensitive.js
+++ b/api/controllers/v1/massif/preview-sensitive.js
@@ -22,13 +22,21 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  const count = await MassifService.countUnsensitiveEntrances(massifId);
+  try {
+    const count = await MassifService.countUnsensitiveEntrances(massifId);
 
-  return ControllerService.treat(
-    req,
-    null,
-    { count },
-    { controllerMethod: 'MassifController.preview-sensitive' },
-    res
-  );
+    return ControllerService.treat(
+      req,
+      null,
+      { count },
+      { controllerMethod: 'MassifController.preview-sensitive' },
+      res
+    );
+  } catch (err) {
+    sails.log.error(
+      `Error fetching preview for massif with id ${massifId}:`,
+      err
+    );
+    return res.serverError(err);
+  }
 };

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -2,6 +2,7 @@ const RightService = require('../../../services/RightService');
 const MassifService = require('../../../services/MassifService');
 const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
+const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
   const isAdmin = RightService.hasGroup(
@@ -23,6 +24,22 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
+  // Idempotency: skip if already non-sensitive
+  if (!massif.isSensitive) {
+    const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+    const meta = getMetaFromRequest(req);
+    return ControllerService.treat(
+      req,
+      null,
+      {
+        count: 0,
+        massif: toMassif(updatedMassif, meta),
+      },
+      { controllerMethod: 'MassifController.unmark-sensitive' },
+      res
+    );
+  }
+
   try {
     // Unmark the massif as sensitive. Logic won't cascade the removal to entrances.
     await MassifService.setSensitivity(massifId, false, req.token.id);
@@ -30,13 +47,17 @@ module.exports = async (req, res) => {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
     await MassifService.updateInSearch(updatedMassif);
 
-    return ControllerService.treatAndConvert(
+    const meta = getMetaFromRequest(req);
+
+    return ControllerService.treat(
       req,
       null,
-      updatedMassif,
+      {
+        count: 0,
+        massif: toMassif(updatedMassif, meta),
+      },
       { controllerMethod: 'MassifController.unmark-sensitive' },
-      res,
-      toMassif
+      res
     );
   } catch (err) {
     sails.log.error(

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -24,7 +24,7 @@ module.exports = async (req, res) => {
   }
 
   // Unmark the massif as sensitive. Logic won't cascade the removal to entrances.
-  await MassifService.setSensitivity(massifId, false);
+  await MassifService.setSensitivity(massifId, false, req.token.id);
 
   const updatedMassif = await MassifService.getPopulatedMassif(massifId);
   await MassifService.updateInSearch(updatedMassif);

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -1,0 +1,40 @@
+const RightService = require('../../../services/RightService');
+const MassifService = require('../../../services/MassifService');
+const ControllerService = require('../../../services/ControllerService');
+const { toMassif } = require('../../../services/mapping/converters');
+
+module.exports = async (req, res) => {
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+
+  if (!isAdmin) {
+    return res.forbidden('Only administrators can perform this action.');
+  }
+
+  const massifId = req.param('id');
+  if (!massifId) {
+    return res.badRequest('massifId is required.');
+  }
+
+  const massif = await TMassif.findOne(massifId);
+  if (!massif || massif.isDeleted) {
+    return res.notFound({ message: `Massif of id ${massifId} not found.` });
+  }
+
+  // Unmark the massif as sensitive. Logic won't cascade the removal to entrances.
+  await MassifService.setSensitivity(massifId, false);
+
+  const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+  await MassifService.updateInSearch(updatedMassif);
+
+  return ControllerService.treatAndConvert(
+    req,
+    null,
+    updatedMassif,
+    { controllerMethod: 'MassifController.unmark-sensitive' },
+    res,
+    toMassif
+  );
+};

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -23,18 +23,26 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  // Unmark the massif as sensitive. Logic won't cascade the removal to entrances.
-  await MassifService.setSensitivity(massifId, false, req.token.id);
+  try {
+    // Unmark the massif as sensitive. Logic won't cascade the removal to entrances.
+    await MassifService.setSensitivity(massifId, false, req.token.id);
 
-  const updatedMassif = await MassifService.getPopulatedMassif(massifId);
-  await MassifService.updateInSearch(updatedMassif);
+    const updatedMassif = await MassifService.getPopulatedMassif(massifId);
+    await MassifService.updateInSearch(updatedMassif);
 
-  return ControllerService.treatAndConvert(
-    req,
-    null,
-    updatedMassif,
-    { controllerMethod: 'MassifController.unmark-sensitive' },
-    res,
-    toMassif
-  );
+    return ControllerService.treatAndConvert(
+      req,
+      null,
+      updatedMassif,
+      { controllerMethod: 'MassifController.unmark-sensitive' },
+      res,
+      toMassif
+    );
+  } catch (err) {
+    sails.log.error(
+      `Error clearing sensitive status from massif with id ${massifId}:`,
+      err
+    );
+    return res.serverError(err);
+  }
 };

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -26,6 +26,16 @@ module.exports = async (req, res) => {
       );
     }
   }
+  // Handle sensitivity change separately as it propagates to entrances
+  if (
+    cleanedData.isSensitive !== undefined &&
+    cleanedData.isSensitive !== rawMassif.isSensitive
+  ) {
+    await MassifService.setSensitivity(massifId, cleanedData.isSensitive);
+    // Remove from cleanedData to avoid redundant update below
+    delete cleanedData.isSensitive;
+  }
+
   // The name is updated via the /api/v1/names route by the front
   await TMassif.updateOne(massifId).set(cleanedData);
 

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -1,5 +1,6 @@
 const ControllerService = require('../../../services/ControllerService');
 const MassifService = require('../../../services/MassifService');
+const EntranceService = require('../../../services/EntranceService');
 const NotificationService = require('../../../services/NotificationService');
 const { toMassif } = require('../../../services/mapping/converters');
 
@@ -31,7 +32,16 @@ module.exports = async (req, res) => {
     cleanedData.isSensitive !== undefined &&
     cleanedData.isSensitive !== rawMassif.isSensitive
   ) {
-    await MassifService.setSensitivity(massifId, cleanedData.isSensitive);
+    const updatedEntranceIds = await MassifService.setSensitivity(
+      massifId,
+      cleanedData.isSensitive
+    );
+    await Promise.all(
+      updatedEntranceIds.map(async (id) => {
+        const populated = await EntranceService.getPopulatedEntrance(id);
+        if (populated) await EntranceService.updateInSearch(populated);
+      })
+    );
     // Remove from cleanedData to avoid redundant update below
     delete cleanedData.isSensitive;
   }

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -1,6 +1,5 @@
 const ControllerService = require('../../../services/ControllerService');
 const MassifService = require('../../../services/MassifService');
-const EntranceService = require('../../../services/EntranceService');
 const NotificationService = require('../../../services/NotificationService');
 const { toMassif } = require('../../../services/mapping/converters');
 
@@ -27,24 +26,8 @@ module.exports = async (req, res) => {
       );
     }
   }
-  // Handle sensitivity change separately as it propagates to entrances
-  if (
-    cleanedData.isSensitive !== undefined &&
-    cleanedData.isSensitive !== rawMassif.isSensitive
-  ) {
-    const updatedEntranceIds = await MassifService.setSensitivity(
-      massifId,
-      cleanedData.isSensitive
-    );
-    await Promise.all(
-      updatedEntranceIds.map(async (id) => {
-        const populated = await EntranceService.getPopulatedEntrance(id);
-        if (populated) await EntranceService.updateInSearch(populated);
-      })
-    );
-    // Remove from cleanedData to avoid redundant update below
-    delete cleanedData.isSensitive;
-  }
+  // Sensitivity is managed exclusively via mark-sensitive / unmark-sensitive
+  delete cleanedData.isSensitive;
 
   // The name is updated via the /api/v1/names route by the front
   await TMassif.updateOne(massifId).set(cleanedData);

--- a/api/models/HMassif.js
+++ b/api/models/HMassif.js
@@ -47,5 +47,11 @@ module.exports = {
       allowNull: true,
       columnName: 'geog_polygon',
     },
+    isSensitive: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive',
+      defaultsTo: false,
+    },
   },
 };

--- a/api/models/TMassif.js
+++ b/api/models/TMassif.js
@@ -49,6 +49,13 @@ module.exports = {
       defaultsTo: false,
     },
 
+    isSensitive: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive',
+      defaultsTo: false,
+    },
+
     redirectTo: {
       type: 'number',
       allowNull: true,

--- a/api/services/CommonService.js
+++ b/api/services/CommonService.js
@@ -10,7 +10,13 @@ module.exports = {
    *
    * @returns {Promise} which resolves to the succesfully queried strings
    */
-  query: async (sql, values) => sails.sendNativeQuery(sql, values || []),
+  query: async (sql, values, connection) => {
+    let query = sails.sendNativeQuery(sql, values || []);
+    if (connection) {
+      query = query.usingConnection(connection);
+    }
+    return query;
+  },
 
   /**
    * @param {string} html - the html string to convert to text

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -176,6 +176,7 @@ module.exports = {
     entranceData.dateInscription = entranceData.dateInscription ?? new Date();
     /* eslint-enable no-param-reassign */
 
+    let autoMarkedSensitive = false;
     // Automatically inherit sensitivity from the massif
     if (entranceData.latitude !== null && entranceData.longitude !== null) {
       /* eslint-disable no-param-reassign */
@@ -185,9 +186,7 @@ module.exports = {
           entranceData.longitude
         );
       if (!entranceData.isSensitive && isPointInSensitiveMassif) {
-        sails.log.info(
-          'Entrance auto-marked sensitive at creation because its coordinates lie within a sensitive massif.'
-        );
+        autoMarkedSensitive = true;
       }
       entranceData.isSensitive =
         entranceData.isSensitive || isPointInSensitiveMassif;
@@ -242,6 +241,12 @@ module.exports = {
 
       return newEntrance.id;
     });
+
+    if (autoMarkedSensitive) {
+      sails.log.info(
+        `Entrance with ID ${newEntranceId} auto-marked sensitive at creation because its coordinates lie within a sensitive massif.`
+      );
+    }
 
     await RecentChangeService.setNameCreate(
       'entrance',

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -177,6 +177,12 @@ module.exports = {
       /* eslint-enable no-param-reassign */
     }
 
+    /* eslint-disable no-param-reassign */
+    entranceData.geology = entranceData.geology ?? 'Q35758';
+    entranceData.isSensitive = entranceData.isSensitive ?? false;
+    entranceData.dateInscription = entranceData.dateInscription ?? new Date();
+    /* eslint-enable no-param-reassign */
+
     // Automatically inherit sensitivity from the massif
     if (entranceData.latitude !== null && entranceData.longitude !== null) {
       /* eslint-disable no-param-reassign */
@@ -270,6 +276,9 @@ module.exports = {
     // For example, the complete caver object for the 'author' and 'reviewer' fields.
     // Although we could leave them intact, since search results also pass through the converter,
     // We prefer to clean them to ensure only clean data remains in the search database.
+    const rawEntrance = populatedEntrance.toJSON
+      ? populatedEntrance.toJSON()
+      : populatedEntrance;
     const {
       names,
       country,
@@ -281,7 +290,7 @@ module.exports = {
       documents,
       comments,
       ...e
-    } = populatedEntrance;
+    } = rawEntrance;
     // Strip non-indexed boolean characteristics from search document
     NON_INDEXED_BOOLEAN_FIELDS.forEach((f) => delete e[f]);
     const entrance = {
@@ -293,12 +302,12 @@ module.exports = {
         new Date(e.dateInscription).getTime(),
         e.dateReviewed ? new Date(e.dateReviewed).getTime() : null
       ),
-      authorId: e.author.id,
-      author: e.author.nickname,
+      authorId: e.author?.id,
+      author: e.author?.nickname,
       reviewerId: e.reviewer?.id,
       reviewer: e.reviewer?.nickname,
-      name: names[0].name,
-      language: names[0].language,
+      name: names?.[0]?.name,
+      language: names?.[0]?.language,
       iso3166: e.iso_3166_2,
       country: [country?.id, country?.nativeName].filter((c) => c).join(' - '),
       geology: e.geology?.trim(),

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -25,16 +25,9 @@ const HistoryService = require('./HistoryService');
 const LocationService = require('./LocationService');
 const RightService = require('./RightService');
 const coerceToInt = require('../utils/coerceToInt');
-
-function coerceBool(req, field) {
-  const value = req.param(field);
-  if (value === undefined || value === null) return value;
-  return typeof value === 'string' ? value === 'true' : Boolean(value);
-}
+const coerceBool = require('../utils/coerceBool');
 
 module.exports = {
-  coerceBool,
-
   getConvertedNameFromClientRequest: (req) => {
     const result = {
       name: {

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -179,12 +179,18 @@ module.exports = {
     // Automatically inherit sensitivity from the massif
     if (entranceData.latitude !== null && entranceData.longitude !== null) {
       /* eslint-disable no-param-reassign */
-      entranceData.isSensitive =
-        entranceData.isSensitive ||
-        (await MassifService.isPointInSensitiveMassif(
+      const isPointInSensitiveMassif =
+        await MassifService.isPointInSensitiveMassif(
           entranceData.latitude,
           entranceData.longitude
-        ));
+        );
+      if (!entranceData.isSensitive && isPointInSensitiveMassif) {
+        sails.log.info(
+          'Entrance auto-marked sensitive at creation because its coordinates lie within a sensitive massif.'
+        );
+      }
+      entranceData.isSensitive =
+        entranceData.isSensitive || isPointInSensitiveMassif;
       /* eslint-enable no-param-reassign */
     }
 

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -13,6 +13,7 @@ const RecentChangeService = require('./RecentChangeService');
 const CaveService = require('./CaveService');
 const CommentService = require('./CommentService');
 const DocumentService = require('./DocumentService');
+const MassifService = require('./MassifService');
 const {
   NON_INDEXED_BOOLEAN_FIELDS,
   computeDateLastModif,
@@ -173,6 +174,18 @@ module.exports = {
       entranceData.city = address.city;
       entranceData.country = address.id_country;
       entranceData.iso_3166_2 = address.iso_3166_2;
+      /* eslint-enable no-param-reassign */
+    }
+
+    // Automatically inherit sensitivity from the massif
+    if (entranceData.latitude !== null && entranceData.longitude !== null) {
+      /* eslint-disable no-param-reassign */
+      entranceData.isSensitive =
+        entranceData.isSensitive ||
+        (await MassifService.isPointInSensitiveMassif(
+          entranceData.latitude,
+          entranceData.longitude
+        ));
       /* eslint-enable no-param-reassign */
     }
 

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -3,7 +3,6 @@ const NameService = require('./NameService');
 const SearchService = require('./SearchService');
 const DescriptionService = require('./DescriptionService');
 const CommonService = require('./CommonService');
-const EntranceService = require('./EntranceService');
 
 const MAX_AREA_KM2 = 35000;
 
@@ -161,25 +160,32 @@ module.exports = {
    * @returns {Promise<boolean>}
    */
   async isPointInSensitiveMassif(latitude, longitude) {
-    if (latitude === null || longitude === null) return false;
-    const query = `
-      SELECT EXISTS (
-        SELECT 1
-        FROM t_massif 
-        WHERE is_sensitive = true 
-        AND is_deleted = false
-        AND geog_polygon && ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography
-        AND ST_Contains(geog_polygon::geometry, ST_SetSRID(ST_MakePoint($1, $2), 4326))
-      ) as is_sensitive;
-    `;
-    const result = await CommonService.query(query, [longitude, latitude]);
-    return result.rows[0].is_sensitive;
+    if (latitude == null || longitude == null) return false;
+    try {
+      const query = `
+        SELECT EXISTS (
+          SELECT 1
+          FROM t_massif 
+          WHERE is_sensitive = true 
+          AND is_deleted = false
+          AND geog_polygon && ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography
+          AND ST_Contains(geog_polygon::geometry, ST_SetSRID(ST_MakePoint($1, $2), 4326))
+        ) as is_sensitive;
+      `;
+      const result = await CommonService.query(query, [longitude, latitude]);
+      return result.rows[0].is_sensitive;
+    } catch (e) {
+      return false;
+    }
   },
 
   /**
    * Set the sensitivity status of a massif and propagate it to all entrances within it.
+   * Returns the IDs of entrances that were updated, so the caller can refresh
+   * the search index without introducing a circular dependency.
    * @param {number} massifId
    * @param {boolean} isSensitive
+   * @returns {Promise<number[]>} IDs of entrances whose sensitivity was changed
    */
   async setSensitivity(massifId, isSensitive) {
     // 1. Update the massif itself
@@ -201,20 +207,12 @@ module.exports = {
       const entranceIds = result.rows.map((r) => r.id);
 
       if (entranceIds.length > 0) {
-        // Update DB
         await TEntrance.update({ id: entranceIds }).set({ isSensitive: true });
-
-        // Update Search Index for each entrance
-        await Promise.all(
-          entranceIds.map(async (id) => {
-            const populatedEntrance =
-              await EntranceService.getPopulatedEntrance(id);
-            if (populatedEntrance) {
-              await EntranceService.updateInSearch(populatedEntrance);
-            }
-          })
-        );
       }
+
+      return entranceIds;
     }
+
+    return [];
   },
 };

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -39,6 +39,16 @@ const COUNT_ENTRANCES_IN_MASSIF = `
   AND e.is_deleted = false
 `;
 
+const COUNT_UNSENSITIVE_ENTRANCES_IN_MASSIF = `
+  SELECT COUNT(e.id)::integer AS count
+  FROM t_entrance AS e
+  JOIN t_massif AS m
+  ON e.point_geom && m.geog_polygon AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+  WHERE m.id = $1
+  AND e.is_deleted = false
+  AND e.is_sensitive = false
+`;
+
 async function safeDBQuery(sql, param) {
   try {
     const queryResult = await CommonService.query(sql, [param]);
@@ -131,6 +141,17 @@ module.exports = {
       const result = await CommonService.query(COUNT_ENTRANCES_IN_MASSIF, [
         massifId,
       ]);
+      return result.rows[0]?.count ?? 0;
+    } catch (e) {
+      return 0;
+    }
+  },
+  countUnsensitiveEntrances: async (massifId) => {
+    try {
+      const result = await CommonService.query(
+        COUNT_UNSENSITIVE_ENTRANCES_IN_MASSIF,
+        [massifId]
+      );
       return result.rows[0]?.count ?? 0;
     } catch (e) {
       return 0;

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -85,7 +85,7 @@ module.exports = {
     documents: req.param('documents'),
     geogPolygon: req.param('geogPolygon'),
     names: req.param('names'),
-    isSensitive: coerceBool(req, 'isSensitive') ?? false,
+    isSensitive: coerceBool(req, 'isSensitive'),
   }),
 
   async getPopulatedMassif(massifId) {
@@ -204,13 +204,16 @@ module.exports = {
    * Set the sensitivity status of a massif and propagate it to all entrances within it.
    * Returns the IDs of entrances that were updated, so the caller can refresh
    * the search index without introducing a circular dependency.
-   * @param {number} massifId
-   * @param {boolean} isSensitive
+   * @param {number} reviewerId
    * @returns {Promise<number[]>} IDs of entrances whose sensitivity was changed
    */
-  async setSensitivity(massifId, isSensitive) {
+  async setSensitivity(massifId, isSensitive, reviewerId) {
     // 1. Update the massif itself
-    await TMassif.updateOne({ id: massifId }).set({ isSensitive });
+    await TMassif.updateOne({ id: massifId }).set({
+      isSensitive,
+      reviewer: reviewerId,
+      dateReviewed: new Date(),
+    });
 
     // 2. If setting to sensitive, propagate to all entrances geographically within it
     if (isSensitive) {

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -205,42 +205,93 @@ module.exports = {
   },
 
   /**
+   * Propagates sensitivity to all non-sensitive entrances geographically within the massif.
+   *
+   * Decoupled from `setSensitivity` so new massifs can update child entrances without
+   * triggering a redundant TMassif update that creates spurious history logs.
+   *
+   * @param {number} massifId
+   * @param {number} reviewerId
+   * @param {object} [db] - optional database connection for transactions
+   * @returns {Promise<number[]>} IDs of entrances whose sensitivity was changed
+   */
+  async propagateSensitivityToEntrances(massifId, reviewerId, db) {
+    // Find IDs of non-sensitive entrances within the massif
+    const findEntrancesQuery = `
+      SELECT e.id
+      FROM t_entrance AS e
+      JOIN t_massif AS m ON m.id = $1
+      WHERE e.is_deleted = false
+      AND e.point_geom && m.geog_polygon
+      AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+      AND e.is_sensitive = false
+    `;
+    const result = await CommonService.query(
+      findEntrancesQuery,
+      [massifId],
+      db
+    );
+    const entranceIds = result.rows.map((r) => r.id);
+
+    if (entranceIds.length > 0) {
+      let updateQuery = TEntrance.update({ id: entranceIds }).set({
+        isSensitive: true,
+        reviewer: reviewerId,
+        dateReviewed: new Date(),
+      });
+      if (db) {
+        updateQuery = updateQuery.usingConnection(db);
+      }
+      await updateQuery;
+      sails.log.info(
+        `Massif ${massifId} marked sensitive: converted non-sensitive entrances [${entranceIds.join(
+          ', '
+        )}] to sensitive.`
+      );
+    }
+
+    return entranceIds;
+  },
+
+  /**
    * Set the sensitivity status of a massif and propagate it to all entrances within it.
    * Returns the IDs of entrances that were updated, so the caller can refresh
    * the search index without introducing a circular dependency.
-   * @param {number} reviewerId
+   *
+   * @param {number} massifId - ID of the massif to update
+   * @param {boolean} isSensitive - The new sensitivity status
+   * @param {number} reviewerId - ID of the admin performing this action
+   * @param {object} [db] - optional database connection for transactions
    * @returns {Promise<number[]>} IDs of entrances whose sensitivity was changed
    */
-  async setSensitivity(massifId, isSensitive, reviewerId) {
-    // 1. Update the massif itself
-    await TMassif.updateOne({ id: massifId }).set({
-      isSensitive,
-      reviewer: reviewerId,
-      dateReviewed: new Date(),
-    });
+  async setSensitivity(massifId, isSensitive, reviewerId, db) {
+    const work = async (connection) => {
+      // 1. Update the massif itself
+      let updateMassif = TMassif.updateOne({ id: massifId }).set({
+        isSensitive,
+        reviewer: reviewerId,
+        dateReviewed: new Date(),
+      });
+      if (connection) {
+        updateMassif = updateMassif.usingConnection(connection);
+      }
+      await updateMassif;
 
-    // 2. If setting to sensitive, propagate to all entrances geographically within it
-    if (isSensitive) {
-      // Find IDs of non-sensitive entrances within the massif
-      const findEntrancesQuery = `
-        SELECT e.id
-        FROM t_entrance AS e
-        JOIN t_massif AS m ON m.id = $1
-        WHERE e.is_deleted = false
-        AND e.point_geom && m.geog_polygon
-        AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
-        AND e.is_sensitive = false
-      `;
-      const result = await CommonService.query(findEntrancesQuery, [massifId]);
-      const entranceIds = result.rows.map((r) => r.id);
-
-      if (entranceIds.length > 0) {
-        await TEntrance.update({ id: entranceIds }).set({ isSensitive: true });
+      // 2. If setting to sensitive, propagate to all entrances geographically within it
+      if (isSensitive) {
+        return module.exports.propagateSensitivityToEntrances(
+          massifId,
+          reviewerId,
+          connection
+        );
       }
 
-      return entranceIds;
-    }
+      return [];
+    };
 
-    return [];
+    if (db) {
+      return work(db);
+    }
+    return sails.getDatastore().transaction(work);
   },
 };

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -3,6 +3,7 @@ const NameService = require('./NameService');
 const SearchService = require('./SearchService');
 const DescriptionService = require('./DescriptionService');
 const CommonService = require('./CommonService');
+const coerceBool = require('../utils/coerceBool');
 
 const MAX_AREA_KM2 = 35000;
 
@@ -56,12 +57,6 @@ async function safeDBQuery(sql, param) {
   } catch (e) {
     return []; // Fail silently (happens when the longitude and latitude are null for example)
   }
-}
-
-function coerceBool(req, field) {
-  const value = req.param(field);
-  if (value === undefined || value === null) return value;
-  return value === 'true' || value === true;
 }
 
 module.exports = {
@@ -143,7 +138,8 @@ module.exports = {
       ]);
       return result.rows[0]?.count ?? 0;
     } catch (e) {
-      return 0;
+      sails.log.error(`Error counting entrances for massif ${massifId}:`, e);
+      throw e;
     }
   },
   countUnsensitiveEntrances: async (massifId) => {
@@ -154,7 +150,11 @@ module.exports = {
       );
       return result.rows[0]?.count ?? 0;
     } catch (e) {
-      return 0;
+      sails.log.error(
+        `Error counting unsensitive entrances for massif ${massifId}:`,
+        e
+      );
+      throw e;
     }
   },
   getNetworks: async (massifId) =>
@@ -196,7 +196,11 @@ module.exports = {
       const result = await CommonService.query(query, [longitude, latitude]);
       return result.rows[0].is_sensitive;
     } catch (e) {
-      return false;
+      sails.log.error(
+        `Error checking point sensitivity for lat=${latitude}, long=${longitude}:`,
+        e
+      );
+      throw e;
     }
   },
 

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -3,6 +3,7 @@ const NameService = require('./NameService');
 const SearchService = require('./SearchService');
 const DescriptionService = require('./DescriptionService');
 const CommonService = require('./CommonService');
+const EntranceService = require('./EntranceService');
 
 const MAX_AREA_KM2 = 35000;
 
@@ -48,6 +49,12 @@ async function safeDBQuery(sql, param) {
   }
 }
 
+function coerceBool(req, field) {
+  const value = req.param(field);
+  if (value === undefined || value === null) return value;
+  return value === 'true' || value === true;
+}
+
 module.exports = {
   MAX_AREA_KM2,
 
@@ -69,6 +76,7 @@ module.exports = {
     documents: req.param('documents'),
     geogPolygon: req.param('geogPolygon'),
     names: req.param('names'),
+    isSensitive: coerceBool(req, 'isSensitive') ?? false,
   }),
 
   async getPopulatedMassif(massifId) {
@@ -144,5 +152,69 @@ module.exports = {
     const query = `SELECT ST_AsGeoJSON($1)`;
     const queryResult = await CommonService.query(query, [geometry]);
     return queryResult.rows[0].st_asgeojson;
+  },
+
+  /**
+   * Check if a point (lat, long) is within a massif marked as sensitive.
+   * @param {number} latitude
+   * @param {number} longitude
+   * @returns {Promise<boolean>}
+   */
+  async isPointInSensitiveMassif(latitude, longitude) {
+    if (latitude === null || longitude === null) return false;
+    const query = `
+      SELECT EXISTS (
+        SELECT 1
+        FROM t_massif 
+        WHERE is_sensitive = true 
+        AND is_deleted = false
+        AND geog_polygon && ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography
+        AND ST_Contains(geog_polygon::geometry, ST_SetSRID(ST_MakePoint($1, $2), 4326))
+      ) as is_sensitive;
+    `;
+    const result = await CommonService.query(query, [longitude, latitude]);
+    return result.rows[0].is_sensitive;
+  },
+
+  /**
+   * Set the sensitivity status of a massif and propagate it to all entrances within it.
+   * @param {number} massifId
+   * @param {boolean} isSensitive
+   */
+  async setSensitivity(massifId, isSensitive) {
+    // 1. Update the massif itself
+    await TMassif.updateOne({ id: massifId }).set({ isSensitive });
+
+    // 2. If setting to sensitive, propagate to all entrances geographically within it
+    if (isSensitive) {
+      // Find IDs of non-sensitive entrances within the massif
+      const findEntrancesQuery = `
+        SELECT e.id
+        FROM t_entrance AS e
+        JOIN t_massif AS m ON m.id = $1
+        WHERE e.is_deleted = false
+        AND e.point_geom && m.geog_polygon
+        AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+        AND e.is_sensitive = false
+      `;
+      const result = await CommonService.query(findEntrancesQuery, [massifId]);
+      const entranceIds = result.rows.map((r) => r.id);
+
+      if (entranceIds.length > 0) {
+        // Update DB
+        await TEntrance.update({ id: entranceIds }).set({ isSensitive: true });
+
+        // Update Search Index for each entrance
+        await Promise.all(
+          entranceIds.map(async (id) => {
+            const populatedEntrance =
+              await EntranceService.getPopulatedEntrance(id);
+            if (populatedEntrance) {
+              await EntranceService.updateInSearch(populatedEntrance);
+            }
+          })
+        );
+      }
+    }
   },
 };

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -527,12 +527,13 @@ const c = {
     cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
-  toMassif: (source) => ({
+  toMassif: (source, meta) => ({
     ...MassifModel,
     id: source.id,
     '@id': String(source.id),
     isDeleted: source.isDeleted,
-    isSensitive: source.isSensitive,
+    isSensitive:
+      meta?.hasCompleteViewRight === true ? source.isSensitive : undefined,
     redirectTo: source.redirectTo,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -532,8 +532,9 @@ const c = {
     id: source.id,
     '@id': String(source.id),
     isDeleted: source.isDeleted,
-    isSensitive:
-      meta?.hasCompleteViewRight === true ? source.isSensitive : undefined,
+    ...(meta?.hasCompleteViewRight === true && {
+      isSensitive: source.isSensitive,
+    }),
     redirectTo: source.redirectTo,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -709,7 +709,7 @@ const c = {
       else if (_type === 'entrances') data = c.toEntrance(item.document, meta);
       else if (_type === 'organizations')
         data = c.toOrganization(item.document, meta);
-      else if (_type === 'massifs') data = c.toMassif(item.document);
+      else if (_type === 'massifs') data = c.toMassif(item.document, meta);
 
       return {
         ...data,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -532,6 +532,7 @@ const c = {
     id: source.id,
     '@id': String(source.id),
     isDeleted: source.isDeleted,
+    isSensitive: source.isSensitive,
     redirectTo: source.redirectTo,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),

--- a/api/utils/coerceBool.js
+++ b/api/utils/coerceBool.js
@@ -1,0 +1,5 @@
+module.exports = function coerceBool(req, field) {
+  const value = req.param(field);
+  if (value === undefined || value === null) return value;
+  return typeof value === 'string' ? value === 'true' : Boolean(value);
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4486,6 +4486,82 @@ paths:
         '404':
           description: Resource not found
 
+  '/massifs/{id}/mark-sensitive':
+    post:
+      tags:
+        - massifs
+      description: Mark a massif as sensitive and propagate this status to all entrances inside it. Requires ADMINISTRATOR group permissions.
+      parameters:
+        - name: id
+          in: path
+          description: Massif ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Massif'
+        '403':
+          description: Only administrators can perform this action.
+        '404':
+          description: Massif not found
+
+  '/massifs/{id}/unmark-sensitive':
+    post:
+      tags:
+        - massifs
+      description: Unmark a massif as sensitive. This action does not propagate to entrances. Requires ADMINISTRATOR group permissions.
+      parameters:
+        - name: id
+          in: path
+          description: Massif ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Massif'
+        '403':
+          description: Only administrators can perform this action.
+        '404':
+          description: Massif not found
+
+  '/massifs/{id}/preview-sensitive':
+    get:
+      tags:
+        - massifs
+      description: Compute the number of currently unsensitive entrances that would be affected by marking this massif as sensitive. Requires ADMINISTRATOR group permissions.
+      parameters:
+        - name: id
+          in: path
+          description: Massif ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of affected entrances
+        '403':
+          description: Only administrators can perform this action.
+        '404':
+          description: Massif not found
+
   '/organizations':
     post:
       tags:

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4504,7 +4504,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Massif'
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of entrances marked as sensitive
+                  massif:
+                    $ref: '#/components/schemas/Massif'
         '403':
           description: Only administrators can perform this action.
         '404':

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4511,6 +4511,8 @@ paths:
                     description: Number of entrances marked as sensitive
                   massif:
                     $ref: '#/components/schemas/Massif'
+        '401':
+          description: Authentication required.
         '403':
           description: Only administrators can perform this action.
         '404':
@@ -4535,6 +4537,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Massif'
+        '401':
+          description: Authentication required.
         '403':
           description: Only administrators can perform this action.
         '404':
@@ -4563,6 +4567,8 @@ paths:
                   count:
                     type: integer
                     description: Number of affected entrances
+        '401':
+          description: Authentication required.
         '403':
           description: Only administrators can perform this action.
         '404':
@@ -5991,6 +5997,9 @@ components:
           type: string
         dateReviewed:
           type: string
+        isSensitive:
+          type: boolean
+          description: Whether the massif is marked as sensitive
         name:
           type: string
         names:

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4536,7 +4536,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Massif'
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of entrances affected (always 0 as this action does not propagate to entrances)
+                  massif:
+                    $ref: '#/components/schemas/Massif'
         '401':
           description: Authentication required.
         '403':

--- a/config/policies.js
+++ b/config/policies.js
@@ -218,6 +218,7 @@ module.exports.policies = {
   'v1/massif/restore': 'tokenAuth',
   'v1/massif/mark-sensitive': 'tokenAuth',
   'v1/massif/unmark-sensitive': 'tokenAuth',
+  'v1/massif/preview-sensitive': 'tokenAuth',
   'v1/massif/add-document': 'tokenAuth',
   'v1/massif/unlink-document': 'tokenAuth',
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -216,6 +216,8 @@ module.exports.policies = {
   'v1/massif/unsubscribe': 'tokenAuth',
   'v1/massif/delete': 'tokenAuth',
   'v1/massif/restore': 'tokenAuth',
+  'v1/massif/mark-sensitive': 'tokenAuth',
+  'v1/massif/unmark-sensitive': 'tokenAuth',
   'v1/massif/add-document': 'tokenAuth',
   'v1/massif/unlink-document': 'tokenAuth',
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -232,6 +232,7 @@ module.exports.routes = {
     'v1/massif/add-document',
   'DELETE /api/v1/massifs/:massifId/documents/:documentId':
     'v1/massif/unlink-document',
+  'GET /api/v1/massifs/:id/preview-sensitive': 'v1/massif/preview-sensitive',
 
   // Document
   'GET /api/v1/documents': 'v1/document/find-all',

--- a/config/routes.js
+++ b/config/routes.js
@@ -226,6 +226,8 @@ module.exports.routes = {
   'GET /api/v1/massifs/:id/statistics': 'v1/massif/get-statistics',
   'DELETE /api/v1/massifs/:id': 'v1/massif/delete',
   'POST /api/v1/massifs/:id/restore': 'v1/massif/restore',
+  'POST /api/v1/massifs/:id/mark-sensitive': 'v1/massif/mark-sensitive',
+  'POST /api/v1/massifs/:id/unmark-sensitive': 'v1/massif/unmark-sensitive',
   'PUT /api/v1/massifs/:massifId/documents/:documentId':
     'v1/massif/add-document',
   'DELETE /api/v1/massifs/:massifId/documents/:documentId':

--- a/sql/9_02_2026_04_23_massif_is_sensitive.sql
+++ b/sql/9_02_2026_04_23_massif_is_sensitive.sql
@@ -1,0 +1,64 @@
+\c grottoce;
+
+BEGIN;
+
+-- Add is_sensitive column to t_massif
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 't_massif' AND column_name = 'is_sensitive'
+    ) THEN
+        ALTER TABLE t_massif ADD COLUMN is_sensitive bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Add is_sensitive column to h_massif
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'h_massif' AND column_name = 'is_sensitive'
+    ) THEN
+        ALTER TABLE h_massif ADD COLUMN is_sensitive bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Update the history trigger to include is_sensitive
+CREATE OR REPLACE FUNCTION histo_update_massif() RETURNS trigger AS $$
+DECLARE date_r timestamp;
+BEGIN 
+    -- Determine the reference date
+    if new.date_reviewed is null then date_r := NEW.date_inscription;
+    else date_r := NEW.date_reviewed;
+    end if;
+
+    -- Only archive if it's not a soft delete or restore (is_deleted hasn't changed)
+    if NEW.is_deleted = OLD.is_deleted then 
+        INSERT INTO h_massif (
+            id,
+            id_author,
+            id_reviewer,
+            date_inscription,
+            date_reviewed,
+            geog_polygon,
+            is_sensitive
+        )
+        VALUES (
+            OLD.id,
+            OLD.id_author,
+            OLD.id_reviewer,
+            OLD.date_inscription,
+            date_r,
+            OLD.geog_polygon,
+            OLD.is_sensitive
+        );
+    end if;
+
+    -- Update modification date in the main table
+    NEW.date_reviewed := now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/test/fixtures/tmassif.json
+++ b/test/fixtures/tmassif.json
@@ -14,5 +14,17 @@
     "author": 3,
     "names": [10],
     "reviewer": 1
+  },
+  {
+    "id": 100,
+    "author": 2,
+    "isSensitive": true,
+    "geogPolygon": "POLYGON((0.9 0.9, 0.9 1.1, 1.1 1.1, 1.1 0.9, 0.9 0.9))"
+  },
+  {
+    "id": 101,
+    "author": 2,
+    "isSensitive": false,
+    "geogPolygon": "POLYGON((1.9 1.9, 1.9 2.1, 2.1 2.1, 2.1 1.9, 1.9 1.9))"
   }
 ]

--- a/test/fixtures/tmassif.json
+++ b/test/fixtures/tmassif.json
@@ -19,12 +19,14 @@
     "id": 100,
     "author": 2,
     "isSensitive": true,
-    "geogPolygon": "POLYGON((0.9 0.9, 0.9 1.1, 1.1 1.1, 1.1 0.9, 0.9 0.9))"
+    "geogPolygon": "POLYGON((0.9 0.9, 0.9 1.1, 1.1 1.1, 1.1 0.9, 0.9 0.9))",
+    "names": [100]
   },
   {
     "id": 101,
     "author": 2,
     "isSensitive": false,
-    "geogPolygon": "POLYGON((1.9 1.9, 1.9 2.1, 2.1 2.1, 2.1 1.9, 1.9 1.9))"
+    "geogPolygon": "POLYGON((1.9 1.9, 1.9 2.1, 2.1 2.1, 2.1 1.9, 1.9 1.9))",
+    "names": [101]
   }
 ]

--- a/test/fixtures/tname.json
+++ b/test/fixtures/tname.json
@@ -110,5 +110,25 @@
     "name": "L'entrée avec le nom 13",
     "isMain": false,
     "language": "fr"
+  },
+  {
+    "id": 100,
+    "author": 1,
+    "reviewer": 2,
+    "dateInscription": "2024-01-01 00:00:00",
+    "dateReviewed": "2024-01-02 00:00:00",
+    "name": "Sensitive Massif 100",
+    "isMain": true,
+    "language": "eng"
+  },
+  {
+    "id": 101,
+    "author": 1,
+    "reviewer": 2,
+    "dateInscription": "2024-01-01 00:00:00",
+    "dateReviewed": "2024-01-02 00:00:00",
+    "name": "Unsensitive Massif 101",
+    "isMain": true,
+    "language": "eng"
   }
 ]

--- a/test/integration/1_services/EntranceService.test.js
+++ b/test/integration/1_services/EntranceService.test.js
@@ -612,5 +612,90 @@ describe('EntranceService', () => {
       should(result.locations.length).be.greaterThan(0);
       await TLocation.destroy({ entrance: createdEntranceId });
     });
+
+    it('should automatically set isSensitive to true when created within a sensitive massif', async () => {
+      sinon.stub(GeocodingService, 'reverse').resolves(null);
+
+      const entranceData = {
+        author: 1,
+        latitude: 1.0, // Inside sensitive massif ID 100
+        longitude: 1.0,
+        cave: 1,
+      };
+
+      const nameDescLocData = {
+        name: {
+          author: 1,
+          text: 'Sensitive Massif Test',
+          language: 'eng',
+        },
+      };
+
+      const result = await EntranceService.createEntrance(
+        userReq,
+        entranceData,
+        nameDescLocData
+      );
+
+      createdEntranceId = result.id;
+      should(result.isSensitive).be.true();
+    });
+
+    it('should set isSensitive to false when created within a non-sensitive massif', async () => {
+      sinon.stub(GeocodingService, 'reverse').resolves(null);
+
+      const entranceData = {
+        author: 1,
+        latitude: 2.0, // Inside non-sensitive massif ID 101
+        longitude: 2.0,
+        cave: 1,
+      };
+
+      const nameDescLocData = {
+        name: {
+          author: 1,
+          text: 'Non-Sensitive Massif Test',
+          language: 'eng',
+        },
+      };
+
+      const result = await EntranceService.createEntrance(
+        userReq,
+        entranceData,
+        nameDescLocData
+      );
+
+      createdEntranceId = result.id;
+      should(result.isSensitive).be.false();
+    });
+
+    it('should keep isSensitive as true if manually provided even if not in a sensitive massif', async () => {
+      sinon.stub(GeocodingService, 'reverse').resolves(null);
+
+      const entranceData = {
+        author: 1,
+        latitude: 0,
+        longitude: 0,
+        cave: 1,
+        isSensitive: true,
+      };
+
+      const nameDescLocData = {
+        name: {
+          author: 1,
+          text: 'Manual Sensitive Test',
+          language: 'eng',
+        },
+      };
+
+      const result = await EntranceService.createEntrance(
+        userReq,
+        entranceData,
+        nameDescLocData
+      );
+
+      createdEntranceId = result.id;
+      should(result.isSensitive).be.true();
+    });
   });
 });

--- a/test/integration/1_services/MassifSensitivityPropagation.test.js
+++ b/test/integration/1_services/MassifSensitivityPropagation.test.js
@@ -20,9 +20,6 @@ describe('Massif Sensitivity Propagation', () => {
     let massifId;
     let caveId;
     let entranceId;
-    const searchUpdateStub = sinon
-      .stub(EntranceService, 'updateInSearch')
-      .resolves();
 
     try {
       // Step 1: Create a massif
@@ -83,8 +80,9 @@ describe('Massif Sensitivity Propagation', () => {
       }
 
       // Step 3: Trigger Service propagation logic
+      let updatedEntranceIds;
       try {
-        await MassifService.setSensitivity(massifId, true);
+        updatedEntranceIds = await MassifService.setSensitivity(massifId, true);
       } catch (err) {
         throw new Error(
           `MassifService.setSensitivity threw an error: ${err.stack}`
@@ -93,6 +91,8 @@ describe('Massif Sensitivity Propagation', () => {
 
       // Step 4: Verify Propagation
       try {
+        updatedEntranceIds.should.containEql(entranceId);
+
         const updatedEntrance = await TEntrance.findOne(entranceId);
         updatedEntrance.isSensitive.should.be.true(
           'Entrance did not inherit sensitivity from Massif'
@@ -101,10 +101,6 @@ describe('Massif Sensitivity Propagation', () => {
         const updatedMassif = await TMassif.findOne(massifId);
         updatedMassif.isSensitive.should.be.true(
           'Massif sensitivity was not updated in database'
-        );
-
-        searchUpdateStub.calledOnce.should.be.true(
-          'EntranceService.updateInSearch was not called for propagation'
         );
       } catch (err) {
         throw new Error(`Verification step failed: ${err.message}`);

--- a/test/integration/1_services/MassifSensitivityPropagation.test.js
+++ b/test/integration/1_services/MassifSensitivityPropagation.test.js
@@ -1,0 +1,211 @@
+const should = require('should');
+const sinon = require('sinon');
+const MassifService = require('../../../api/services/MassifService');
+const EntranceService = require('../../../api/services/EntranceService');
+const AuthTokenService = require('../AuthTokenService');
+const CommonService = require('../../../api/services/CommonService');
+
+describe('Massif Sensitivity Propagation', () => {
+  const userReq = {};
+
+  before(async () => {
+    userReq.token = await AuthTokenService.getUserToken();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should propagate sensitivity to entrances when a massif is marked as sensitive', async () => {
+    let massifId;
+    let caveId;
+    let entranceId;
+    const searchUpdateStub = sinon
+      .stub(EntranceService, 'updateInSearch')
+      .resolves();
+
+    try {
+      // Step 1: Create a massif
+      try {
+        const massif = await TMassif.create({
+          author: 1,
+          dateInscription: new Date(),
+          isSensitive: false,
+          geogPolygon: 'SRID=4326;POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))',
+        }).fetch();
+        massifId = massif.id;
+      } catch (err) {
+        throw new Error(`Failed to create massif: ${err.message}`);
+      }
+
+      // Step 2: Create a cave and entrance
+      try {
+        const cave = await TCave.create({
+          author: 1,
+          dateInscription: new Date(),
+        }).fetch();
+        caveId = cave.id;
+
+        const createdEntranceData = await EntranceService.createEntrance(
+          userReq,
+          {
+            author: 1,
+            latitude: 0.5,
+            longitude: 0.5,
+            cave: caveId,
+            isSensitive: false,
+          },
+          {
+            name: {
+              author: 1,
+              text: 'Propagation Test Entrance',
+              language: 'eng', // Use valid string code for Language
+            },
+          }
+        );
+        entranceId = createdEntranceData.id;
+
+        // Verify the entrance actually has a name created
+        const names = await TName.find({ entrance: entranceId });
+        should.exist(names, 'TName array should exist');
+        names.length.should.be.greaterThan(
+          0,
+          'Entrance should have at least one name created'
+        );
+
+        // Manually set point_geom
+        await CommonService.query(
+          'UPDATE t_entrance SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) WHERE id = $1',
+          [entranceId]
+        );
+      } catch (err) {
+        throw new Error(`Failed to create cave/entrance setup: ${err.message}`);
+      }
+
+      // Step 3: Trigger Service propagation logic
+      try {
+        await MassifService.setSensitivity(massifId, true);
+      } catch (err) {
+        throw new Error(
+          `MassifService.setSensitivity threw an error: ${err.stack}`
+        );
+      }
+
+      // Step 4: Verify Propagation
+      try {
+        const updatedEntrance = await TEntrance.findOne(entranceId);
+        updatedEntrance.isSensitive.should.be.true(
+          'Entrance did not inherit sensitivity from Massif'
+        );
+
+        const updatedMassif = await TMassif.findOne(massifId);
+        updatedMassif.isSensitive.should.be.true(
+          'Massif sensitivity was not updated in database'
+        );
+
+        searchUpdateStub.calledOnce.should.be.true(
+          'EntranceService.updateInSearch was not called for propagation'
+        );
+      } catch (err) {
+        throw new Error(`Verification step failed: ${err.message}`);
+      }
+    } finally {
+      // Cleanup
+      if (entranceId) {
+        await TName.destroy({ entrance: entranceId }).catch(() => {});
+        await TEntrance.destroyOne(entranceId).catch(() => {});
+      }
+      if (caveId) await TCave.destroyOne(caveId).catch(() => {});
+      if (massifId) await TMassif.destroyOne(massifId).catch(() => {});
+    }
+  });
+
+  it('should not propagate sensitivity reversal (keep manually set sensitivity)', async () => {
+    let massifId;
+    let caveId;
+    let entranceId;
+
+    try {
+      // Step 1: Create a sensitive massif
+      try {
+        const massif = await TMassif.create({
+          author: 1,
+          dateInscription: new Date(),
+          isSensitive: true,
+          geogPolygon: 'SRID=4326;POLYGON((10 10, 11 10, 11 11, 10 11, 10 10))',
+        }).fetch();
+        massifId = massif.id;
+      } catch (err) {
+        throw new Error(`Failed to create massif: ${err.message}`);
+      }
+
+      // Step 2: Create a sensitive entrance
+      try {
+        const cave = await TCave.create({
+          author: 1,
+          dateInscription: new Date(),
+        }).fetch();
+        caveId = cave.id;
+
+        const createdEntranceData = await EntranceService.createEntrance(
+          userReq,
+          {
+            author: 1,
+            latitude: 10.5,
+            longitude: 10.5,
+            cave: caveId,
+            isSensitive: true,
+          },
+          {
+            name: {
+              author: 1,
+              text: 'Sensitive Propagation Reversal Test Entrance',
+              language: 'eng', // Use valid string code
+            },
+          }
+        );
+        entranceId = createdEntranceData.id;
+
+        // Manually set point_geom
+        await CommonService.query(
+          'UPDATE t_entrance SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) WHERE id = $1',
+          [entranceId]
+        );
+      } catch (err) {
+        throw new Error(`Failed to create cave/entrance setup: ${err.message}`);
+      }
+
+      // Step 3: Trigger Reversal logic
+      try {
+        await MassifService.setSensitivity(massifId, false);
+      } catch (err) {
+        throw new Error(
+          `MassifService.setSensitivity threw an error: ${err.stack}`
+        );
+      }
+
+      // Step 4: Verify Entrance stays sensitive
+      try {
+        const updatedEntrance = await TEntrance.findOne(entranceId);
+        updatedEntrance.isSensitive.should.be.true(
+          'Entrance lost its sensitive status inappropriately'
+        );
+
+        const updatedMassif = await TMassif.findOne(massifId);
+        updatedMassif.isSensitive.should.be.false(
+          'Massif failed to lose its sensitive status'
+        );
+      } catch (err) {
+        throw new Error(`Verification step failed: ${err.message}`);
+      }
+    } finally {
+      // Cleanup
+      if (entranceId) {
+        await TName.destroy({ entrance: entranceId }).catch(() => {});
+        await TEntrance.destroyOne(entranceId).catch(() => {});
+      }
+      if (caveId) await TCave.destroyOne(caveId).catch(() => {});
+      if (massifId) await TMassif.destroyOne(massifId).catch(() => {});
+    }
+  });
+});

--- a/test/integration/1_services/MassifSensitivityPropagation.test.js
+++ b/test/integration/1_services/MassifSensitivityPropagation.test.js
@@ -82,7 +82,11 @@ describe('Massif Sensitivity Propagation', () => {
       // Step 3: Trigger Service propagation logic
       let updatedEntranceIds;
       try {
-        updatedEntranceIds = await MassifService.setSensitivity(massifId, true);
+        updatedEntranceIds = await MassifService.setSensitivity(
+          massifId,
+          true,
+          userReq.token.id
+        );
       } catch (err) {
         throw new Error(
           `MassifService.setSensitivity threw an error: ${err.stack}`
@@ -101,6 +105,10 @@ describe('Massif Sensitivity Propagation', () => {
         const updatedMassif = await TMassif.findOne(massifId);
         updatedMassif.isSensitive.should.be.true(
           'Massif sensitivity was not updated in database'
+        );
+        updatedMassif.reviewer.should.equal(
+          userReq.token.id,
+          'Massif reviewer was not correctly set'
         );
       } catch (err) {
         throw new Error(`Verification step failed: ${err.message}`);
@@ -173,7 +181,7 @@ describe('Massif Sensitivity Propagation', () => {
 
       // Step 3: Trigger Reversal logic
       try {
-        await MassifService.setSensitivity(massifId, false);
+        await MassifService.setSensitivity(massifId, false, userReq.token.id);
       } catch (err) {
         throw new Error(
           `MassifService.setSensitivity threw an error: ${err.stack}`
@@ -190,6 +198,10 @@ describe('Massif Sensitivity Propagation', () => {
         const updatedMassif = await TMassif.findOne(massifId);
         updatedMassif.isSensitive.should.be.false(
           'Massif failed to lose its sensitive status'
+        );
+        updatedMassif.reviewer.should.equal(
+          userReq.token.id,
+          'Massif reviewer was not correctly set during reversal'
         );
       } catch (err) {
         throw new Error(`Verification step failed: ${err.message}`);

--- a/test/integration/1_services/MassifService.test.js
+++ b/test/integration/1_services/MassifService.test.js
@@ -85,10 +85,29 @@ describe('MassifService', () => {
   });
 
   describe('countEntrances', () => {
-    it('should return 0 on database error', async () => {
+    it('should throw on database error', async () => {
       sinon.stub(CommonService, 'query').rejects(new Error('DB Error'));
-      const count = await MassifService.countEntrances(999);
-      should(count).eql(0);
+      await MassifService.countEntrances(999).should.be.rejectedWith(
+        'DB Error'
+      );
+    });
+  });
+
+  describe('countUnsensitiveEntrances', () => {
+    it('should throw on database error', async () => {
+      sinon.stub(CommonService, 'query').rejects(new Error('DB Error'));
+      await MassifService.countUnsensitiveEntrances(999).should.be.rejectedWith(
+        'DB Error'
+      );
+    });
+  });
+
+  describe('isPointInSensitiveMassif', () => {
+    it('should throw on database error', async () => {
+      sinon.stub(CommonService, 'query').rejects(new Error('DB Error'));
+      await MassifService.isPointInSensitiveMassif(0, 0).should.be.rejectedWith(
+        'DB Error'
+      );
     });
   });
 

--- a/test/integration/4_routes/Massifs/create.test.js
+++ b/test/integration/4_routes/Massifs/create.test.js
@@ -87,6 +87,7 @@ describe('Massif features', () => {
             descriptionAndNameLanguage: { id: 'fra' },
             documents: [testDoc1Id, testDoc2Id],
             geogPolygon: massifPolygon.geoJsonSmall,
+            isSensitive: true,
           })
           .set('Authorization', adminToken)
           .set('Content-type', 'application/json')
@@ -95,6 +96,7 @@ describe('Massif features', () => {
           .end((err, res) => {
             if (err) return done(err);
             const { body: massif } = res;
+            should(massif.isSensitive).be.true();
             should(massif.name).equal('Massif 1');
             should(massif.descriptions.length).equal(1);
             should(massif.descriptions).containDeep([

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -2,7 +2,9 @@ const supertest = require('supertest');
 const should = require('should');
 const fc = require('fast-check');
 const massifPolygon = require('./FAKE_DATA');
+const AuthTokenService = require('../../AuthTokenService');
 
+// Fields visible to any user (no auth required)
 const MASSIF_PROPERTIES = [
   '@context',
   '@id',
@@ -14,12 +16,17 @@ const MASSIF_PROPERTIES = [
   'documents',
   'geogPolygon',
   'name',
-  'isSensitive',
   'author',
   'reviewer',
 ];
 
 describe('Massif features', () => {
+  let adminToken;
+
+  before(async () => {
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+  });
+
   describe('find', () => {
     it('should return code 404 for non-existent massif', (done) => {
       supertest(sails.hooks.http.app)
@@ -52,8 +59,22 @@ describe('Massif features', () => {
           if (err) return done(err);
           const { body: massif } = res;
           should(massif).have.properties(MASSIF_PROPERTIES);
+          should(massif).not.have.property('isSensitive');
           should(massif.geogPolygon).equal(massifPolygon.geoJson1ToString);
           should(massif.name).not.be.empty();
+          return done();
+        });
+    });
+    it('should return isSensitive for admin', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/1')
+        .set('Authorization', adminToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body).have.property('isSensitive');
           return done();
         });
     });
@@ -72,7 +93,6 @@ describe('Massif features', () => {
       'documents',
       'networks',
       'geogPolygon',
-      'isSensitive',
       'author',
       'reviewer',
     ];
@@ -96,6 +116,8 @@ describe('Massif features', () => {
             should(massif).have.property(field);
           });
 
+          // isSensitive is only returned for admins
+          should(massif).not.have.property('isSensitive');
           should(massif).not.have.property('entrances');
         }),
         { numRuns: 100 }

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -14,6 +14,7 @@ const MASSIF_PROPERTIES = [
   'documents',
   'geogPolygon',
   'name',
+  'isSensitive',
   'author',
   'reviewer',
 ];
@@ -71,6 +72,7 @@ describe('Massif features', () => {
       'documents',
       'networks',
       'geogPolygon',
+      'isSensitive',
       'author',
       'reviewer',
     ];

--- a/test/integration/4_routes/Massifs/mark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/mark-sensitive.test.js
@@ -65,6 +65,33 @@ describe('Massif mark-sensitive route features', () => {
       const modified = await TMassif.findOne(massif.id);
       modified.isSensitive.should.be.true();
 
+      await TName.destroy({ massif: massif.id });
+      await TMassif.destroyOne(massif.id);
+    });
+
+    it('should be idempotent: return 200 and count: 0 when marking an already sensitive massif', async () => {
+      sinon.stub(MassifService, 'updateInSearch').resolves();
+
+      const massif = await TMassif.create({
+        isSensitive: true,
+        author: 1,
+      }).fetch();
+      await TName.create({
+        massif: massif.id,
+        name: 'Already Sensitive Massif',
+        language: 'eng',
+        isMain: true,
+        author: 1,
+      });
+
+      const response = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/mark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      response.body.count.should.equal(0);
+      response.body.massif.isSensitive.should.be.true();
+
       // Cleanup
       await TName.destroy({ massif: massif.id });
       await TMassif.destroyOne(massif.id);

--- a/test/integration/4_routes/Massifs/mark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/mark-sensitive.test.js
@@ -1,0 +1,73 @@
+const supertest = require('supertest');
+const sinon = require('sinon');
+const AuthTokenService = require('../../AuthTokenService');
+const EntranceService = require('../../../../api/services/EntranceService');
+const MassifService = require('../../../../api/services/MassifService');
+
+describe('Massif mark-sensitive route features', () => {
+  let adminToken;
+  let userToken;
+  let moderatorToken;
+
+  before(async () => {
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
+    moderatorToken = await AuthTokenService.getRawBearerModeratorToken();
+  });
+
+  describe('POST /api/v1/massifs/:id/mark-sensitive', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return 403 for user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/1/mark-sensitive')
+        .set('Authorization', userToken)
+        .expect(403, done);
+    });
+
+    it('should return 403 for moderator (non-admin)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/1/mark-sensitive')
+        .set('Authorization', moderatorToken)
+        .expect(403, done);
+    });
+
+    it('should return 404 on non-existing massif', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/987654321/mark-sensitive')
+        .set('Authorization', adminToken)
+        .expect(404, done);
+    });
+
+    it('should return 200 and mark massif as sensitive for admin', async () => {
+      sinon.stub(EntranceService, 'updateInSearch').resolves();
+      sinon.stub(MassifService, 'updateInSearch').resolves();
+
+      const massif = await TMassif.create({
+        isSensitive: false,
+        author: 1,
+      }).fetch();
+      await TName.create({
+        massif: massif.id,
+        name: 'Test Sensitive Massif Mark',
+        language: 'eng',
+        isMain: true,
+        author: 1,
+      });
+
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/mark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      const modified = await TMassif.findOne(massif.id);
+      modified.isSensitive.should.be.true();
+
+      // Cleanup
+      await TName.destroy({ massif: massif.id });
+      await TMassif.destroyOne(massif.id);
+    });
+  });
+});

--- a/test/integration/4_routes/Massifs/preview-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/preview-sensitive.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const sinon = require('sinon');
+const should = require('should');
 const AuthTokenService = require('../../AuthTokenService');
 
 describe('Massif preview-sensitive route features', () => {
@@ -28,6 +29,17 @@ describe('Massif preview-sensitive route features', () => {
         .get('/api/v1/massifs/987654321/preview-sensitive')
         .set('Authorization', adminToken)
         .expect(404, done);
+    });
+
+    it('should return 200 and a count for admin', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/100/preview-sensitive')
+        .set('Authorization', adminToken)
+        .expect(200)
+        .expect((res) => {
+          should(res.body).have.property('count', 0);
+        })
+        .end(done);
     });
   });
 });

--- a/test/integration/4_routes/Massifs/preview-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/preview-sensitive.test.js
@@ -1,0 +1,33 @@
+const supertest = require('supertest');
+const sinon = require('sinon');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Massif preview-sensitive route features', () => {
+  let adminToken;
+  let userToken;
+
+  before(async () => {
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
+  });
+
+  describe('GET /api/v1/massifs/:id/preview-sensitive', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return 403 for user', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/1/preview-sensitive')
+        .set('Authorization', userToken)
+        .expect(403, done);
+    });
+
+    it('should return 404 on non-existing massif', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/987654321/preview-sensitive')
+        .set('Authorization', adminToken)
+        .expect(404, done);
+    });
+  });
+});

--- a/test/integration/4_routes/Massifs/unmark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/unmark-sensitive.test.js
@@ -65,6 +65,33 @@ describe('Massif unmark-sensitive route features', () => {
       const modified = await TMassif.findOne(massif.id);
       modified.isSensitive.should.be.false();
 
+      await TName.destroy({ massif: massif.id });
+      await TMassif.destroyOne(massif.id);
+    });
+
+    it('should be idempotent: return 200 and count: 0 when unmarking an already non-sensitive massif', async () => {
+      sinon.stub(MassifService, 'updateInSearch').resolves();
+
+      const massif = await TMassif.create({
+        isSensitive: false,
+        author: 1,
+      }).fetch();
+      await TName.create({
+        massif: massif.id,
+        name: 'Already Non-Sensitive Massif',
+        language: 'eng',
+        isMain: true,
+        author: 1,
+      });
+
+      const response = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/unmark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      response.body.count.should.equal(0);
+      response.body.massif.isSensitive.should.be.false();
+
       // Cleanup
       await TName.destroy({ massif: massif.id });
       await TMassif.destroyOne(massif.id);

--- a/test/integration/4_routes/Massifs/unmark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/unmark-sensitive.test.js
@@ -1,0 +1,73 @@
+const supertest = require('supertest');
+const sinon = require('sinon');
+const AuthTokenService = require('../../AuthTokenService');
+const EntranceService = require('../../../../api/services/EntranceService');
+const MassifService = require('../../../../api/services/MassifService');
+
+describe('Massif unmark-sensitive route features', () => {
+  let adminToken;
+  let userToken;
+  let moderatorToken;
+
+  before(async () => {
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
+    moderatorToken = await AuthTokenService.getRawBearerModeratorToken();
+  });
+
+  describe('POST /api/v1/massifs/:id/unmark-sensitive', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return 403 for user', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/1/unmark-sensitive')
+        .set('Authorization', userToken)
+        .expect(403, done);
+    });
+
+    it('should return 403 for moderator (non-admin)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/1/unmark-sensitive')
+        .set('Authorization', moderatorToken)
+        .expect(403, done);
+    });
+
+    it('should return 404 on non-existing massif', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/massifs/987654321/unmark-sensitive')
+        .set('Authorization', adminToken)
+        .expect(404, done);
+    });
+
+    it('should return 200 and unmark massif as sensitive for admin', async () => {
+      sinon.stub(EntranceService, 'updateInSearch').resolves();
+      sinon.stub(MassifService, 'updateInSearch').resolves();
+
+      const massif = await TMassif.create({
+        isSensitive: true,
+        author: 1,
+      }).fetch();
+      await TName.create({
+        massif: massif.id,
+        name: 'Test Sensitive Massif Unmark',
+        language: 'eng',
+        isMain: true,
+        author: 1,
+      });
+
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/unmark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      const modified = await TMassif.findOne(massif.id);
+      modified.isSensitive.should.be.false();
+
+      // Cleanup
+      await TName.destroy({ massif: massif.id });
+      await TMassif.destroyOne(massif.id);
+    });
+  });
+});

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -94,7 +94,7 @@ describe('Massif features', () => {
             .populate('documents');
           massifUpdated.caves = await MassifService.getCaves(testMassifId);
 
-          should(massifUpdated.isSensitive).be.true();
+          should(massifUpdated.isSensitive).be.false();
 
           should(massifUpdated.descriptions).containDeep([{ id: testDescId }]);
           should(massifUpdated.documents).containDeep([

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -94,7 +94,7 @@ describe('Massif features', () => {
             .populate('documents');
           massifUpdated.caves = await MassifService.getCaves(testMassifId);
 
-          should(massifUpdated.isSensitive).be.false();
+          should(massifUpdated.isSensitive).be.false(); // Sensitivity must only be changed via dedicated /mark-sensitive and /unmark-sensitive endpoints
 
           should(massifUpdated.descriptions).containDeep([{ id: testDescId }]);
           should(massifUpdated.documents).containDeep([

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -14,10 +14,6 @@ describe('Massif features', () => {
   let testDescId;
   let testNameId;
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
   before(async () => {
     userToken = await AuthTokenService.getRawBearerUserToken();
     const massif = await TMassif.create({ author: 1, reviewer: 2 }).fetch();
@@ -46,6 +42,10 @@ describe('Massif features', () => {
       massif: massif.id,
     }).fetch();
     testNameId = name.id;
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   after(async () => {

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -1,8 +1,10 @@
 const supertest = require('supertest');
 const should = require('should');
+const sinon = require('sinon');
 const AuthTokenService = require('../../AuthTokenService');
 const massifPolygon = require('./FAKE_DATA');
 const MassifService = require('../../../../api/services/MassifService');
+const EntranceService = require('../../../../api/services/EntranceService');
 
 describe('Massif features', () => {
   let userToken;
@@ -11,6 +13,10 @@ describe('Massif features', () => {
   let testDoc2Id;
   let testDescId;
   let testNameId;
+
+  afterEach(() => {
+    sinon.restore();
+  });
 
   before(async () => {
     userToken = await AuthTokenService.getRawBearerUserToken();
@@ -68,7 +74,10 @@ describe('Massif features', () => {
         documents: [testDoc1Id, testDoc2Id],
         geogPolygon: massifPolygon.geoJsonSmall,
         names: [testNameId],
+        isSensitive: true,
       };
+      sinon.stub(EntranceService, 'updateInSearch').resolves();
+
       supertest(sails.hooks.http.app)
         .put(`/api/v1/massifs/${testMassifId}`)
         .send(updateData)
@@ -84,6 +93,8 @@ describe('Massif features', () => {
             .populate('descriptions')
             .populate('documents');
           massifUpdated.caves = await MassifService.getCaves(testMassifId);
+
+          should(massifUpdated.isSensitive).be.true();
 
           should(massifUpdated.descriptions).containDeep([{ id: testDescId }]);
           should(massifUpdated.documents).containDeep([

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -94,7 +94,9 @@ describe('Massif features', () => {
             .populate('documents');
           massifUpdated.caves = await MassifService.getCaves(testMassifId);
 
-          should(massifUpdated.isSensitive).be.false(); // Sensitivity must only be changed via dedicated /mark-sensitive and /unmark-sensitive endpoints
+          // We check that the update controller doesnt change sensitivity status
+          // Sensitivity must only be changed via dedicated /mark-sensitive and /unmark-sensitive endpoints
+          should(massifUpdated.isSensitive).be.false();
 
           should(massifUpdated.descriptions).containDeep([{ id: testDescId }]);
           should(massifUpdated.documents).containDeep([


### PR DESCRIPTION
## 🤔 What

This PR implements a sensitivity management system for massifs, allowing administrators to protect location data for all entrances within a massif area.

- **Model Updates**: Added `isSensitive` boolean flag to `TMassif` and `HMassif` models (defaults to `false`).
- **New API Endpoints**:
    - `POST /api/v1/massifs/:id/mark-sensitive`: Marks a massif as sensitive and propagates the status to all geographically contained entrances. Returns a summary count of affected entrances.
    - `POST /api/v1/massifs/:id/unmark-sensitive`: Removes the sensitive status from a massif record.
    - `GET /api/v1/massifs/:id/preview-sensitive`: Previews the number of entrances that would be affected by marking the massif as sensitive.
- **Auto-Inheritance**: Enforced automatic sensitive marking for any new entrance created within the polygon of a sensitive massif (supporting both standard creation and CSV imports).
- **Security & Privacy**: 
    - Restricted all sensitivity-modifying actions to users within the administrator group.
    - Implemented a privacy gate in the `toMassif` converter to hide the `isSensitive` field from non-admin users.
    - Decoupled sensitivity toggling from the general `PUT /massifs/:id` update route to prevent accidental changes.
- **Auditing**: Sensitivity updates are now captured in the `HMassif` history table, including the `reviewer` ID and timestamp.
- **Documentation**: Updated Swagger documentation to reflect the new routes and response shapes.

[Link to issue: #1450](https://github.com/GrottoCenter/grottocenter-api/issues/1450#issue-3928987374)

## 🤷‍♂️ Why

To protect the location data of caves and entrances within sensitive geographic areas. This feature provides Administrators with the tools to manage data protection at scale (per-massif) rather than forcing manual updates for every individual entrance, while maintaining an audit trail for these changes.

## 🔍 How

- **Spatial Logic**: Used PostGIS `ST_Contains` for geographic containment checks to link entrances to their respective massifs based on coordinates.
- **Service Layer**: Centralized propagation and validation logic in `MassifService.js` and `EntranceService.js`.
- **Mapping Layer**: Utilized the `meta.hasCompleteViewRight` flag in the converter layer to handle conditional field visibility (Privacy Gate).
- **Controller Refactoring**: Moved sensitivity logic out of the general `update.js` controller and into specific, authorized actions to ensure strict access control.

## 🧪 Testing

- **Automated Tests**:
    - Added `mark-sensitive.test.js` and `preview-sensitive.test.js`.
    - Updated `find.test.js` to assert that `isSensitive` is omitted for non-admins.
    - Updated `update.test.js` to ensure the general update route no longer handles the sensitive flag.
- **Verification**: Verified that history records are correctly created in the `h_massif` table upon status changes.