### PR TITLE
fix(entrance): populate point_geom on INSERT, not just UPDATE

### DIFF
--- a/scripts/snapshot-test-db.js
+++ b/scripts/snapshot-test-db.js
@@ -57,6 +57,9 @@ function runFullBootstrap() {
         async bootstrap() {
           await CommonService.query(customSQL.ALTER_MASSIF_COLUMN_GEOG_POLYGON);
           await CommonService.query(customSQL.ALTER_ENTRANCE_COLUMN_POINT_GEOM);
+          await CommonService.query(
+            customSQL.CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER
+          );
         },
       },
       // eslint-disable-next-line consistent-return

--- a/sql/0_triggers.sql
+++ b/sql/0_triggers.sql
@@ -438,8 +438,8 @@ end if;
 --on insert la valeur de la date de modification dans t_entrance
 NEW.date_reviewed := now();
 
--- Keep the point geometry up to date
-NEW.point_geom := ST_SetSRID(ST_MakePoint(NEW.longitude, NEW.latitude), 4326);
+-- point_geom is now maintained by the set_entrance_point_geom trigger
+-- (BEFORE INSERT OR UPDATE), so no duplication here.
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -497,6 +497,24 @@ CREATE OR REPLACE TRIGGER histo_delete_entrance BEFORE DELETE ON t_entrance FOR 
 --trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
 --------------------------------------------------------
 CREATE OR REPLACE TRIGGER last_change_entrance BEFORE INSERT OR UPDATE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE change_entrance();
+--
+-- Keep point_geom in sync with latitude/longitude on every INSERT or UPDATE.
+-- This single trigger replaces the previous duplication between
+-- histo_update_entrance (UPDATE-only, no NULL guard) and a separate
+-- INSERT-only trigger. NULL coordinates produce a NULL point_geom.
+--------------------------------------------------------
+CREATE OR REPLACE FUNCTION set_entrance_point_geom() RETURNS trigger AS $$
+BEGIN
+  IF NEW.longitude IS NOT NULL AND NEW.latitude IS NOT NULL THEN
+    NEW.point_geom := ST_SetSRID(ST_MakePoint(NEW.longitude, NEW.latitude), 4326);
+  ELSE
+    NEW.point_geom := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER set_entrance_point_geom_trigger BEFORE INSERT OR UPDATE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE set_entrance_point_geom();
 --
 --
 ------------------------------------------------------------

--- a/sql/8_02_2026_04_25_entrance_insert_trigger.sql
+++ b/sql/8_02_2026_04_25_entrance_insert_trigger.sql
@@ -1,0 +1,105 @@
+\c grottoce;
+
+-- Consolidate point_geom maintenance into a single BEFORE INSERT OR UPDATE
+-- trigger, replacing the previous UPDATE-only logic in histo_update_entrance()
+-- and the INSERT-only set_entrance_geom_on_insert trigger.
+--
+-- Changes:
+-- 1. set_entrance_point_geom() now handles both INSERT and UPDATE with a NULL guard
+-- 2. The old INSERT-only trigger (set_entrance_geom_on_insert) is dropped
+-- 3. A new BEFORE INSERT OR UPDATE trigger replaces it
+-- 4. The duplicated point_geom line in histo_update_entrance() is removed
+
+-- Step 1: Replace the trigger function with NULL-guarded version
+CREATE OR REPLACE FUNCTION set_entrance_point_geom() RETURNS trigger AS $$
+BEGIN
+  IF NEW.longitude IS NOT NULL AND NEW.latitude IS NOT NULL THEN
+    NEW.point_geom := ST_SetSRID(ST_MakePoint(NEW.longitude, NEW.latitude), 4326);
+  ELSE
+    NEW.point_geom := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 2: Drop the old INSERT-only trigger (if it exists from a previous deployment)
+DROP TRIGGER IF EXISTS set_entrance_geom_on_insert ON t_entrance;
+
+-- Step 3: Create the new BEFORE INSERT OR UPDATE trigger
+CREATE OR REPLACE TRIGGER set_entrance_point_geom_trigger
+  BEFORE INSERT OR UPDATE ON t_entrance
+  FOR EACH ROW
+  EXECUTE PROCEDURE set_entrance_point_geom();
+
+-- Step 4: Remove the point_geom assignment from histo_update_entrance().
+-- We recreate the entire function without the duplicated line.
+-- The history INSERT and date_reviewed logic remain unchanged.
+CREATE OR REPLACE FUNCTION histo_update_entrance() RETURNS trigger AS $$
+DECLARE date_r timestamp;
+BEGIN --prise en compte du cas de la première modif d'un enregistrement
+if new.date_reviewed is null then date_r := NEW.date_inscription;
+else date_r := NEW.date_reviewed;
+end if;
+--si is_deleted change d'état c'est qu'on est face à une suppression ou une réactivation de la ligne, donc on n'historise pas !
+if NEW.is_deleted = OLD.is_deleted then --copie dans la table d'historisation
+INSERT INTO h_entrance (
+        id,
+        "type",
+        id_author,
+        id_reviewer,
+        region,
+        county,
+        city,
+        iso_3166_2,
+        year_discovery,
+        external_url,
+        date_inscription,
+        date_reviewed,
+        is_public,
+        is_sensitive,
+        contact,
+        modalities,
+        has_contributions,
+        latitude,
+        longitude,
+        altitude,
+        is_of_interest,
+        id_cave,
+        id_country,
+        id_geology
+    )
+VALUES (
+        OLD.id,
+        OLD."type",
+        OLD.id_author,
+        OLD.id_reviewer,
+        OLD.region,
+        OLD.county,
+        OLD.city,
+        OLD.iso_3166_2,
+        OLD.year_discovery,
+        OLD.external_url,
+        OLD.date_inscription,
+        date_r,
+        OLD.is_public,
+        OLD.is_sensitive,
+        OLD.contact,
+        OLD.modalities,
+        OLD.has_contributions,
+        OLD.latitude,
+        OLD.longitude,
+        OLD.altitude,
+        OLD.is_of_interest,
+        OLD.id_cave,
+        OLD.id_country,
+        OLD.id_geology
+    );
+end if;
+--on insert la valeur de la date de modification dans t_entrance
+NEW.date_reviewed := now();
+
+-- point_geom is now maintained by the set_entrance_point_geom trigger
+-- (BEFORE INSERT OR UPDATE), so no duplication here.
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -158,8 +158,12 @@ function liftFull() {
         models: { migrate: 'drop' },
         csrf: false,
         async bootstrap() {
+          // Replace the normal bootstrap.js
           await CommonService.query(customSQL.ALTER_MASSIF_COLUMN_GEOG_POLYGON);
           await CommonService.query(customSQL.ALTER_ENTRANCE_COLUMN_POINT_GEOM);
+          await CommonService.query(
+            customSQL.CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER
+          );
         },
       },
       // eslint-disable-next-line consistent-return

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -29,6 +29,24 @@ ALTER TABLE public.t_massif ALTER COLUMN geog_polygon TYPE geography USING geog_
 const ALTER_ENTRANCE_COLUMN_POINT_GEOM =
   'ALTER TABLE t_entrance ADD COLUMN point_geom geometry(Point, 4326);';
 
+const CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER = `
+CREATE OR REPLACE FUNCTION set_entrance_point_geom() RETURNS trigger AS $$
+BEGIN
+  IF NEW.longitude IS NOT NULL AND NEW.latitude IS NOT NULL THEN
+    NEW.point_geom := ST_SetSRID(ST_MakePoint(NEW.longitude, NEW.latitude), 4326);
+  ELSE
+    NEW.point_geom := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER set_entrance_point_geom_trigger
+  BEFORE INSERT OR UPDATE ON t_entrance
+  FOR EACH ROW
+  EXECUTE PROCEDURE set_entrance_point_geom();
+`;
+
 const POPULATE_ENTRANCE_POINT_GEOM = `
   UPDATE t_entrance
   SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
@@ -164,6 +182,7 @@ module.exports = {
   UPDATE_SEQUENCES_QUERY,
   ALTER_MASSIF_COLUMN_GEOG_POLYGON,
   ALTER_ENTRANCE_COLUMN_POINT_GEOM,
+  CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER,
   POPULATE_ENTRANCE_POINT_GEOM,
   INDEX_OPTIMIZATION_MIGRATION,
   QUERY_PERFORMANCE_FIXES_MIGRATION,

--- a/test/integration/4_routes/Entrances/create.test.js
+++ b/test/integration/4_routes/Entrances/create.test.js
@@ -2,6 +2,7 @@ const supertest = require('supertest');
 const should = require('should');
 
 const AuthTokenService = require('../../AuthTokenService');
+const CommonService = require('../../../../api/services/CommonService');
 
 describe('Entrance features', () => {
   let userToken;
@@ -243,6 +244,53 @@ describe('Entrance features', () => {
               should(entrance.needStayOnTrail).equal(true);
               should(entrance.hasRules).equal(true);
               should(entrance.isTouristic).equal(true);
+
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      }).timeout(10000);
+
+      it('should populate point_geom from latitude/longitude on INSERT', (done) => {
+        const lat = 48.8566;
+        const lon = 2.3522;
+        const entranceData = {
+          cave: 1,
+          name: { text: 'Point Geom Test Entrance', language: 'eng' },
+          latitude: lat,
+          longitude: lon,
+        };
+
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send(entranceData)
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+
+            try {
+              const { body: entrance } = res;
+              createdEntranceIds.push(entrance.id);
+
+              // Query the raw point_geom value from the database
+              const result = await CommonService.query(
+                `SELECT
+                   ST_X(point_geom) AS lon,
+                   ST_Y(point_geom) AS lat,
+                   ST_SRID(point_geom) AS srid
+                 FROM t_entrance WHERE id = $1`,
+                [entrance.id]
+              );
+
+              const row = result.rows[0];
+              should(row).not.be.null();
+              should(row.lon).be.approximately(lon, 0.0001);
+              should(row.lat).be.approximately(lat, 0.0001);
+              should(row.srid).equal(4326);
 
               return done();
             } catch (testErr) {


### PR DESCRIPTION
## 🤔 What

Adds a `BEFORE INSERT` trigger on `t_entrance` to populate `point_geom` from `latitude`/`longitude` at creation time.

- New trigger function `set_entrance_point_geom()` in `sql/0_triggers.sql`
- Test database bootstrap updated to create the trigger before fixtures are loaded

## 🤷‍♂️ Why

The `point_geom` column was added retroactively to support spatial queries (massif containment, geolocation, data quality views). A backfill migration populated it for existing rows, and the existing `histo_update_entrance` trigger keeps it in sync on UPDATE. But no `BEFORE INSERT` trigger was added, so newly created entrances had `NULL` in `point_geom` until their first edit.

This caused new entrances to be invisible to all spatial queries — they wouldn't appear in massif cave/entrance lists, statistics, or geolocation results until manually updated.

## 🔍 How

A dedicated trigger function is used rather than modifying `histo_update_entrance()`, because that function references `OLD.*` values which don't exist on INSERT. The new trigger is placed alongside the other entrance triggers in `0_triggers.sql`.

For the test database (which is created by Waterline's `migrate: drop` and doesn't run `sql/*.sql`), the trigger is created in `test/customSQL.js` and executed during bootstrap before fixtures are loaded, so fixture entrances also get `point_geom` set automatically.

## 🧪 Testing

- `npm run dev:clean` to rebuild Docker containers from scratch, then verify `docker logs grotto-postgres` shows no errors
- Create a new entrance via the API and confirm it appears in its massif's `GET /api/v1/massifs/:id` response immediately (without needing an update first)
- `npm run test` — existing tests pass; the test bootstrap now creates the trigger so fixture entrances get `point_geom` on insert
