### PR TITLE
fix(organization): coerce empty-string coordinates to null

### DIFF
--- a/api/controllers/v1/cave/update.js
+++ b/api/controllers/v1/cave/update.js
@@ -1,5 +1,6 @@
 const ControllerService = require('../../../services/ControllerService');
 const coerceToInt = require('../../../utils/coerceToInt');
+const coerceToNumeric = require('../../../utils/coerceToNumeric');
 const CaveService = require('../../../services/CaveService');
 const NotificationService = require('../../../services/NotificationService');
 const { toCave } = require('../../../services/mapping/converters');
@@ -26,8 +27,10 @@ module.exports = async (req, res) => {
     // dateReviewed will be updated automaticly by the SQL historisation trigger
   };
 
-  if (newLatitude != null) updatedFields.latitude = newLatitude;
-  if (newLongitude != null) updatedFields.longitude = newLongitude;
+  if (newLatitude != null)
+    updatedFields.latitude = coerceToNumeric(newLatitude);
+  if (newLongitude != null)
+    updatedFields.longitude = coerceToNumeric(newLongitude);
   if (newDepth != null) updatedFields.depth = coerceToInt(newDepth);
   if (newLength != null) updatedFields.caveLength = coerceToInt(newLength);
   if (newTemperature != null) updatedFields.temperature = newTemperature;

--- a/api/services/CaveService.js
+++ b/api/services/CaveService.js
@@ -1,5 +1,6 @@
 const CommonService = require('./CommonService');
 const coerceToInt = require('../utils/coerceToInt');
+const coerceToNumeric = require('../utils/coerceToNumeric');
 const DocumentService = require('./DocumentService');
 const DescriptionService = require('./DescriptionService');
 const NameService = require('./NameService');
@@ -99,8 +100,8 @@ module.exports = {
     depth: coerceToInt(req.param('depth')),
     documents: req.param('documents'),
     isDiving: req.param('isDiving'),
-    latitude: req.param('latitude'),
-    longitude: req.param('longitude'),
+    latitude: coerceToNumeric(req.param('latitude')),
+    longitude: coerceToNumeric(req.param('longitude')),
     caveLength: coerceToInt(req.param('length')),
     massif: req.param('massif'),
     temperature: req.param('temperature'),

--- a/api/services/GrottoService.js
+++ b/api/services/GrottoService.js
@@ -5,6 +5,7 @@ const NameService = require('./NameService');
 const NotificationService = require('./NotificationService');
 const GeocodingService = require('./GeocodingService');
 const RecentChangeService = require('./RecentChangeService');
+const coerceToNumeric = require('../utils/coerceToNumeric');
 
 module.exports = {
   // Extract everything from a request body except id
@@ -14,8 +15,8 @@ module.exports = {
     country: req.body?.country?.id ?? null,
     county: req.param('county'),
     customMessage: req.param('customMessage'),
-    latitude: req.param('latitude'),
-    longitude: req.param('longitude'),
+    latitude: coerceToNumeric(req.param('latitude')),
+    longitude: coerceToNumeric(req.param('longitude')),
     mail: req.param('mail'),
     postalCode: req.param('postalCode'),
     region: req.param('region'),
@@ -107,6 +108,14 @@ module.exports = {
    * @returns
    */
   createGrotto: async (req, cleanedData, nameData) => {
+    // Defensive re-coercion: createGrotto can be called directly with raw
+    // data that hasn't gone through getConvertedDataFromClientRequest, so we
+    // ensure coordinates are coerced here as a safety net.
+    // eslint-disable-next-line no-param-reassign
+    cleanedData.latitude = coerceToNumeric(cleanedData.latitude);
+    // eslint-disable-next-line no-param-reassign
+    cleanedData.longitude = coerceToNumeric(cleanedData.longitude);
+
     if (cleanedData.latitude && cleanedData.longitude) {
       const address = await GeocodingService.reverse(
         cleanedData.latitude,
@@ -115,11 +124,6 @@ module.exports = {
       // eslint-disable-next-line no-param-reassign
       if (address) cleanedData.iso_3166_2 = address.iso_3166_2;
     }
-
-    // eslint-disable-next-line no-param-reassign
-    if (cleanedData.latitude === '') delete cleanedData.latitude;
-    // eslint-disable-next-line no-param-reassign
-    if (cleanedData.longitude === '') delete cleanedData.longitude;
 
     const newOrganizationId = await sails
       .getDatastore()

--- a/api/utils/coerceToNumeric.js
+++ b/api/utils/coerceToNumeric.js
@@ -1,0 +1,16 @@
+/**
+ * Coerce a value for a numeric (decimal) database column.
+ * Converts empty strings to null so PostgreSQL doesn't choke on ''.
+ * Passes through null, undefined, and any other value unchanged
+ * (letting Waterline / the DB adapter handle further validation).
+ *
+ * @param {*} value
+ * @returns {*} null for empty strings, original value otherwise
+ */
+const coerceToNumeric = (value) => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string' && value.trim() === '') return null;
+  return value;
+};
+
+module.exports = coerceToNumeric;

--- a/test/integration/2_utils/coerceToNumeric.test.js
+++ b/test/integration/2_utils/coerceToNumeric.test.js
@@ -1,0 +1,104 @@
+const should = require('should');
+const coerceToNumeric = require('../../../api/utils/coerceToNumeric');
+const GrottoService = require('../../../api/services/GrottoService');
+const CaveService = require('../../../api/services/CaveService');
+
+describe('coerceToNumeric - Unit Tests', () => {
+  describe('coerceToNumeric()', () => {
+    it('should convert empty string to null', () => {
+      should(coerceToNumeric('')).equal(null);
+    });
+
+    it('should convert whitespace-only string to null', () => {
+      should(coerceToNumeric(' ')).equal(null);
+      should(coerceToNumeric('  ')).equal(null);
+      should(coerceToNumeric('\t')).equal(null);
+    });
+
+    it('should pass through null unchanged', () => {
+      should(coerceToNumeric(null)).equal(null);
+    });
+
+    it('should pass through undefined unchanged', () => {
+      should(coerceToNumeric(undefined)).equal(undefined);
+    });
+
+    it('should pass through numeric strings unchanged', () => {
+      should(coerceToNumeric('43.62505')).equal('43.62505');
+      should(coerceToNumeric('-3.862038')).equal('-3.862038');
+      should(coerceToNumeric('0')).equal('0');
+      should(coerceToNumeric('100')).equal('100');
+    });
+
+    it('should pass through numbers unchanged', () => {
+      should(coerceToNumeric(43.62505)).equal(43.62505);
+      should(coerceToNumeric(0)).equal(0);
+      should(coerceToNumeric(-100)).equal(-100);
+    });
+
+    // Design boundary: coerceToNumeric intentionally does NOT validate that
+    // the value is a well-formed number. Its only job is to convert blank
+    // strings to null so PostgreSQL doesn't choke on ''. Actual numeric
+    // validation is delegated to Waterline / the DB adapter, which will
+    // reject malformed values like 'abc' with a proper validation error.
+    it('should pass through non-numeric strings unchanged', () => {
+      should(coerceToNumeric('abc')).equal('abc');
+      should(coerceToNumeric('12.3.4')).equal('12.3.4');
+    });
+  });
+
+  describe('GrottoService.getConvertedDataFromClientRequest()', () => {
+    const makeReq = (body) => ({
+      body,
+      param: (key) => body[key],
+    });
+
+    it('should coerce empty latitude and longitude to null', () => {
+      const req = makeReq({ latitude: '', longitude: '' });
+      const result = GrottoService.getConvertedDataFromClientRequest(req);
+      should(result.latitude).equal(null);
+      should(result.longitude).equal(null);
+    });
+
+    it('should preserve valid numeric latitude and longitude', () => {
+      const req = makeReq({
+        latitude: '43.62505',
+        longitude: '3.862038',
+      });
+      const result = GrottoService.getConvertedDataFromClientRequest(req);
+      should(result.latitude).equal('43.62505');
+      should(result.longitude).equal('3.862038');
+    });
+
+    it('should pass through null latitude and longitude', () => {
+      const req = makeReq({ latitude: null, longitude: null });
+      const result = GrottoService.getConvertedDataFromClientRequest(req);
+      should(result.latitude).equal(null);
+      should(result.longitude).equal(null);
+    });
+  });
+
+  describe('CaveService.getConvertedDataFromClient()', () => {
+    const makeReq = (body) => ({
+      body,
+      param: (key) => body[key],
+    });
+
+    it('should coerce empty latitude and longitude to null', () => {
+      const req = makeReq({ latitude: '', longitude: '' });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.latitude).equal(null);
+      should(result.longitude).equal(null);
+    });
+
+    it('should preserve valid numeric latitude and longitude', () => {
+      const req = makeReq({
+        latitude: '43.62505',
+        longitude: '3.862038',
+      });
+      const result = CaveService.getConvertedDataFromClient(req);
+      should(result.latitude).equal('43.62505');
+      should(result.longitude).equal('3.862038');
+    });
+  });
+});

--- a/test/integration/4_routes/Caves/update.test.js
+++ b/test/integration/4_routes/Caves/update.test.js
@@ -109,6 +109,28 @@ describe('Cave features', () => {
           });
       });
 
+      it('should return 200 when latitude and longitude are empty strings', (done) => {
+        supertest(sails.hooks.http.app)
+          .put(`/api/v1/caves/${caveId}`)
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({
+            latitude: '',
+            longitude: '',
+          })
+          .expect(200)
+          .end(async (err) => {
+            if (err) return done(err);
+            // latitude/longitude are deprecated on TCave and not exposed
+            // by the toCave converter, so verify at the DB level.
+            const cave = await TCave.findOne(caveId);
+            should(cave.latitude).equal(null);
+            should(cave.longitude).equal(null);
+            return done();
+          });
+      });
+
       it('should return code 200 on name update', (done) => {
         supertest(sails.hooks.http.app)
           .put(`/api/v1/caves/${caveId}`)

--- a/test/integration/4_routes/Organization/update.test.js
+++ b/test/integration/4_routes/Organization/update.test.js
@@ -42,6 +42,27 @@ describe('Organization features', () => {
             return done();
           });
       });
+
+      it('should return 200 when latitude and longitude are empty strings', (done) => {
+        supertest(sails.hooks.http.app)
+          .put(`/api/v1/organizations/1`)
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({
+            latitude: '',
+            longitude: '',
+            url: 'https://example.com',
+          })
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            const { body: organization } = res;
+            should(organization.latitude).equal(null);
+            should(organization.longitude).equal(null);
+            return done();
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix 500 error on `PUT /api/v1/organizations/:id` when `latitude` or `longitude` are sent as empty strings
- Add `coerceToNumeric` utility to convert empty/whitespace strings to `null` for numeric DB columns
- Apply the same fix to `CaveService` and the cave update controller (same latent bug)

## 🤷‍♂️ Why

The frontend sends `latitude: ""` and `longitude: ""` when a user clears the coordinate fields. The `TGrotto` model declares these as `type: 'string'` but the underlying PostgreSQL column is `numeric(24,20)`. Waterline passes the empty string straight to the DB adapter, which triggers a `22P02: invalid input syntax for type numeric: ""` error and returns a 500 to the user.

The `createGrotto` path had an ad-hoc `delete` workaround for this, but the update path did not. The cave endpoints had the same latent issue.

## 🔍 How

- New `api/utils/coerceToNumeric.js` — mirrors the existing `coerceToInt` pattern. Converts empty and whitespace-only strings to `null`, passes everything else through unchanged.
- `GrottoService.getConvertedDataFromClientRequest` — wraps `latitude`/`longitude` with `coerceToNumeric` so both create and update paths are covered at the extraction layer.
- `GrottoService.createGrotto` — replaces the inline `delete` hack with `coerceToNumeric` as a safety net for direct callers.
- `CaveService.getConvertedDataFromClient` — same treatment for cave latitude/longitude.
- `api/controllers/v1/cave/update.js` — applies `coerceToNumeric` when assigning coordinates to `updatedFields`.

## 🧪 Testing

- Added `test/integration/2_utils/coerceToNumeric.test.js` — unit tests for the utility plus integration tests verifying `GrottoService` and `CaveService` coerce correctly.
- Added integration test in `test/integration/4_routes/Organization/update.test.js` that reproduces the exact production scenario: sending empty-string coordinates and asserting a 200 with `null` values instead of a 500.
- All 1700 existing tests pass.
