### PR TITLE
chore(deps): upgrade all dependencies and fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,33 +9,33 @@
       "version": "24.0.0",
       "license": "CC-BY-SA-3.0",
       "dependencies": {
-        "@aws-sdk/client-sesv2": "^3.1000.0",
+        "@aws-sdk/client-sesv2": "^3.1041.0",
         "@azure/storage-blob": "^12.31.0",
         "@natlibfi/marc-record": "^10.0.1",
-        "@natlibfi/marc-record-serializers": "^11.0.1",
+        "@natlibfi/marc-record-serializers": "^11.0.2",
         "archiver": "^7.0.1",
         "argon2": "^0.44.0",
-        "ejs": "^5.0.1",
-        "express-rate-limit": "^8.2.1",
+        "ejs": "^5.0.2",
+        "express-rate-limit": "^8.4.1",
         "jsonwebtoken": "^9.0.3",
         "mime-types": "^3.0.2",
         "moment": "^2.30.1",
         "moment-duration-format": "^2.3.2",
-        "multer": "^2.1.0",
+        "multer": "^2.1.1",
         "response-time": "^2.3.4",
         "rss-parser": "^3.13.0",
         "sails": "^1.5.17",
         "sails-hook-orm": "^4.0.3",
         "sails-postgresql": "^5.0.1",
-        "typesense": "^3.0.1",
+        "typesense": "^3.0.6",
         "underscore.date": "^0.6.1",
         "underscore.string": "^3.3.6",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "winston": "^3.19.0"
       },
       "devDependencies": {
-        "@commitlint/cli": "^20.4.2",
-        "@commitlint/config-conventional": "^20.4.1",
+        "@commitlint/cli": "^20.5.3",
+        "@commitlint/config-conventional": "^20.5.3",
         "cross-env": "^10.1.0",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -43,18 +43,18 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.5",
         "express": "^5.2.1",
-        "fast-check": "^4.5.3",
+        "fast-check": "^4.7.0",
         "fixted": "^4.2.7",
-        "glob": "^10.5.0",
+        "glob": "^13.0.6",
         "husky": "^9.1.7",
-        "lint-staged": "^16.3.1",
+        "lint-staged": "^16.4.0",
         "mocha": "^11.7.5",
         "nodemon": "^3.1.14",
         "nyc": "^18.0.0",
-        "pg": "^8.11.0",
-        "prettier": "^3.8.1",
+        "pg": "^8.20.0",
+        "prettier": "^3.8.3",
         "should": "^13.2.3",
-        "sinon": "^21.0.1",
+        "sinon": "^21.1.2",
         "supertest": "^7.2.2"
       },
       "engines": {
@@ -187,49 +187,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1033.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1033.0.tgz",
-      "integrity": "sha512-jjmEEKdkidAkacLvgAC6lIFT7J+HxnIzH06tL7P55PnFTc8yjX/2lco5HAe4gKVmfKRjT2Dl/aC4YkkYS09Tig==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1041.0.tgz",
+      "integrity": "sha512-CjcZxCkpJaj37Dv6Zgcl0z05uNK8KbfwNpUsHDdH351S/ecD9j2ZfUDbdSvm7onWE3SNpmHMRiJyjkefah0Vgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/credential-provider-node": "^3.972.33",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.18",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -238,22 +238,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.2.tgz",
-      "integrity": "sha512-oav5AOAz+1XkwUfp6SrEm42UPDpUP5D4jNYXkDwFR1VfWqYX62+jpytdfzURmJ9McSoJIQwi0OJlC4oCi6t0VQ==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.18",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -262,12 +263,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.28.tgz",
-      "integrity": "sha512-87GdRJ2OR0qR4VkMjXN/SZi66DZsunW2qQCbtw9rKw3Y7JurFi6tQWYKOSLY/gOADrU6OxGqFmdw3hKzZqDZOQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -278,20 +279,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.30.tgz",
-      "integrity": "sha512-6quozmW2PKwBJTUQLb+lk1q8w5Pm45qaqhx4Tld9EIqYYQOVGj+MT0a8NRVS7QgWJj7rzGlB7rQu3KYBFHemJw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -299,19 +300,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.32.tgz",
-      "integrity": "sha512-Nkr+UKtczZlocUjc6g96WzQadZSIZO/HVXPki4qbfaVOZYSbfLQKWKfADtJ0kGYsCvSYOZrO66tSc9dkboUt/w==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-login": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -324,13 +325,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.32.tgz",
-      "integrity": "sha512-UxgwT1HmZz1QPXuBy5ZUPJNFXOSlhwdQL61eGhWRthF0xRrT02BCOVJ1p5Ejg5AXfnESTWoKPJ7v/sCkNUtB9g==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -343,17 +344,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.33.tgz",
-      "integrity": "sha512-6pGQnEdSeRvBViTQh/FwaRKB38a3Th+W2mVxuvqAd2Z1Ayo3e6eJ5QqJoZwEMwR6xoxkl3wz3qAfiB1xRhMC+w==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-ini": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -366,12 +367,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.28.tgz",
-      "integrity": "sha512-CRAlD8u6oNBhjnX/3ekVGocarD+lFmEn/qeDzytgIdmwrmwMJGFPqS9lGwEfhOTihZKrQ0xSp3z6paX+iXJJhA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -383,14 +384,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.32.tgz",
-      "integrity": "sha512-whhmQghRYOt9mJxFyVMhX7eB8n0oA25OCvqoR7dzFAZjmioCkf7WVB22Bc6llM5cFpBXFX7s4Jv+xVq32VPGWg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
-        "@aws-sdk/token-providers": "3.1033.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -402,13 +403,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.32.tgz",
-      "integrity": "sha512-Z0Y0LDaqyQDznlmr9gv6n4+eWKKWNgmi9j5L6RENr6wyOCguhO8FRPmqDbVLSw0DPdMqICKnA3PurJiS8bD6Cw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -465,23 +466,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.31.tgz",
-      "integrity": "sha512-5hS08Fp0Rm+59uGCmkWhZmveXiA7OUV7Wa+IARejdzf9JTZ1qAVeIOE9JoBpsLPvUgEjmsGNHBuFbtGmYyqiqQ==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -490,18 +491,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.32.tgz",
-      "integrity": "sha512-HQ0x9DDKqLZOGhDiL2eicYXXkYT5dogE4mw0lAfHCpJ6t7MM0PNIsJl2TZzWKU9SpBzOMXHRa7K6ZLKUJu1y0w==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -509,48 +510,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.0.tgz",
-      "integrity": "sha512-4bI5GHjUiY5R8N6PtchpG6tW2Dl8I2IcZNg3JwqwxHRXjfvQlPoo4VMknG4qkd5W0t3Y20rQ6C7pSR561YG5JQ==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.18",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -559,13 +560,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
-      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -575,12 +576,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.19.tgz",
-      "integrity": "sha512-7Sy8+GhfwUi06NQNLplxuJuXMKJURDsNQfK8yTW6E9wN2J1B+8S5dWZG7vg3InvPPhaXqkcYTr8pzeE+dLjMbQ==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.31",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -592,13 +593,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1033.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1033.0.tgz",
-      "integrity": "sha512-/TsXhqjyRAFb0xVgmbFAha3cJfZdWjnyn6ohJ3AB4E3peLgxNcmKfYr45hruHymyJAydiHoXC3N1a8qgl41cog==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -635,15 +636,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
-      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,12 +676,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.18.tgz",
-      "integrity": "sha512-Nh4YvAL0Mzv5jBvzXLFL0tLf7WPrRMnYZQ5jlFuyS0xiVJQsObMUKAkbYjmt/e04wpQqUaa+Is7k+mBr89A9yA==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -700,37 +701,18 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -1221,15 +1203,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
-      "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
+      "integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^20.5.0",
-        "@commitlint/lint": "^20.5.0",
-        "@commitlint/load": "^20.5.0",
+        "@commitlint/lint": "^20.5.3",
+        "@commitlint/load": "^20.5.3",
         "@commitlint/read": "^20.5.0",
         "@commitlint/types": "^20.5.0",
         "tinyexec": "^1.0.0",
@@ -1243,9 +1225,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
-      "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
+      "integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1271,18 +1253,14 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
-      "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
+      "integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/types": "^20.5.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.snakecase": "^4.1.1",
-        "lodash.startcase": "^4.4.0",
-        "lodash.upperfirst": "^4.3.1"
+        "es-toolkit": "^1.46.0"
       },
       "engines": {
         "node": ">=v18"
@@ -1327,15 +1305,15 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
-      "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
+      "integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/is-ignored": "^20.5.0",
         "@commitlint/parse": "^20.5.0",
-        "@commitlint/rules": "^20.5.0",
+        "@commitlint/rules": "^20.5.3",
         "@commitlint/types": "^20.5.0"
       },
       "engines": {
@@ -1343,20 +1321,20 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
-      "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
+      "integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.0",
+        "@commitlint/resolve-extends": "^20.5.3",
         "@commitlint/types": "^20.5.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
         "is-plain-obj": "^4.1.0",
-        "lodash.mergewith": "^4.6.2",
         "picocolors": "^1.1.1"
       },
       "engines": {
@@ -1406,17 +1384,17 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
-      "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
+      "integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/types": "^20.5.0",
-        "global-directory": "^4.0.1",
+        "es-toolkit": "^1.46.0",
+        "global-directory": "^5.0.0",
         "import-meta-resolve": "^4.0.0",
-        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0"
       },
       "engines": {
@@ -1424,13 +1402,13 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
-      "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
+      "integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.5.0",
+        "@commitlint/ensure": "^20.5.3",
         "@commitlint/message": "^20.4.3",
         "@commitlint/to-lines": "^20.0.0",
         "@commitlint/types": "^20.5.0"
@@ -2017,6 +1995,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2201,16 +2191,16 @@
       "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
     },
     "node_modules/@sailshq/router": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@sailshq/router/-/router-1.3.10.tgz",
-      "integrity": "sha512-6h5IE0PrSEkF03Fze1lUwnDMnYMbBPkUgKaUG/mkthHpiO/VDzbD0QJXyD7xmhlD05dEzuZnGqrrUeY5oZIMAg==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@sailshq/router/-/router-1.3.11.tgz",
+      "integrity": "sha512-uQSnZnFm8RBO49gyCev27RgQRpBI3KY0qd6Bh4saHMDmRGCA8IdS/SiwnuuXCychjOhovDalT46GhBjHkPIiGA==",
       "license": "MIT",
       "dependencies": {
         "array-flatten": "3.0.0",
         "debug": "2.6.9",
         "methods": "~1.1.2",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "0.1.13",
         "setprototypeof": "1.2.0",
         "utils-merge": "1.0.1"
       },
@@ -2234,9 +2224,9 @@
       "license": "MIT"
     },
     "node_modules/@sailshq/router/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/@simple-libs/child-process-utils": {
@@ -2279,9 +2269,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.0.tgz",
-      "integrity": "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2289,9 +2279,9 @@
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.3.tgz",
-      "integrity": "sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2327,9 +2317,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2338,7 +2328,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -2434,13 +2424,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
@@ -2453,19 +2443,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -2474,12 +2464,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -2517,9 +2507,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2585,9 +2575,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1"
@@ -2629,17 +2619,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2736,13 +2726,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -2751,16 +2741,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.53",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -2808,12 +2798,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/service-error-classification": "^4.3.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -2822,13 +2812,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -2922,9 +2912,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -3003,9 +2993,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3027,6 +3017,15 @@
       "dependencies": {
         "@sailshq/lodash": "^3.10.2",
         "validator": "13.15.23"
+      }
+    },
+    "node_modules/anchor/node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ansi-escapes": {
@@ -3149,6 +3148,73 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/archy": {
@@ -3360,14 +3426,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -4597,13 +4663,13 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jiti": "^2.6.1"
+        "jiti": "2.6.1"
       },
       "engines": {
         "node": ">=v18"
@@ -4967,9 +5033,9 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
-      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
+      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
       "license": "Apache-2.0",
       "bin": {
         "ejs": "bin/cli.js"
@@ -5204,6 +5270,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -5720,9 +5797,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -5786,9 +5863,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
-      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
       "dev": true,
       "funding": [
         {
@@ -5867,9 +5944,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -5882,9 +5959,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -5893,9 +5970,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6062,13 +6140,6 @@
         "sails": "1.x"
       }
     },
-    "node_modules/fixted/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -6117,9 +6188,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6500,21 +6571,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6533,41 +6601,56 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ini": "4.1.1"
+        "ini": "6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7005,13 +7088,13 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/internal-slot": {
@@ -7651,90 +7734,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/lru-cache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
-      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
@@ -7753,16 +7752,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -8349,13 +8338,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -8405,13 +8387,6 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8419,38 +8394,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -8699,6 +8646,35 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/machinepack-postgresql/node_modules/pg": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.6.0",
+        "pg-pool": "^3.6.0",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/machinepack-process": {
       "version": "4.0.1",
@@ -8983,6 +8959,35 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8994,6 +8999,23 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9408,29 +9430,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/nyc/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/nyc/node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -9464,24 +9463,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nyc/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/nyc/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -9503,32 +9484,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/lru-cache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
-      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/nyc/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/p-limit": {
@@ -9558,23 +9513,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/rimraf": {
@@ -10045,9 +9983,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -10084,26 +10022,31 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -10123,24 +10066,23 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
-      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.6.0",
-        "pg-pool": "^3.6.0",
-        "pg-protocol": "^1.6.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.1.0"
+        "pg-cloudflare": "^1.3.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -10367,9 +10309,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10503,10 +10445,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -10546,6 +10491,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11905,6 +11851,21 @@
         "isarray": "0.0.1"
       }
     },
+    "node_modules/sails/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sails/node_modules/raw-body": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -12428,17 +12389,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.3.tgz",
-      "integrity": "sha512-0x8TQFr8EjADhSME01u1ZK31yv2+bd6Z5NrBCHVM+n4qL1wFqbxftmeyi3bwlr49FbbzRfrqSFOpyHCOh/YmYA==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
+      "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.1.1",
-        "@sinonjs/samsam": "^9.0.3",
-        "diff": "^8.0.3",
-        "supports-color": "^7.2.0"
+        "@sinonjs/fake-timers": "^15.3.2",
+        "@sinonjs/samsam": "^10.0.2",
+        "diff": "^8.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -12602,6 +12562,21 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/skipper/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/skipper/node_modules/raw-body": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -12649,15 +12624,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/skipper/node_modules/uuid": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.0.tgz",
-      "integrity": "sha512-LNUrNsXdI/fUsypJbWM8Jt4DgQdFAZh41p9C7WE9Cn+CULOEkoG2lgQyH68v3wnIy5K3fN4jdSt270K6IFA3MQ==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/skipper/node_modules/yallist": {
@@ -12734,29 +12700,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/spawn-wrap/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/spawn-wrap/node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -12769,67 +12712,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/lru-cache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
-      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/spawn-wrap/node_modules/rimraf": {
@@ -13150,9 +13032,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -13315,34 +13197,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.1.tgz",
-      "integrity": "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -13351,23 +13205,6 @@
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -13661,12 +13498,12 @@
       }
     },
     "node_modules/typesense": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/typesense/-/typesense-3.0.5.tgz",
-      "integrity": "sha512-Pw/yWosbqEOFMM/wQDsnS8FA6r3Qp5ilxuqZTMBoUc95SGCEBflMd39kvDEZZFoTORzNDxCLiiQ+LfYJTl1ulQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-3.0.6.tgz",
+      "integrity": "sha512-d3LL1qOLS8FCRxgAOqH+uDuK+VVA+/HYI1frU9fjYVwOg68mg/dX6XTtZ4yKKAkDCasB/se5uh/ZpMdOz/uJNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "1.13.5",
+        "axios": "^1.15.0",
         "loglevel": "^1.9.2",
         "tslib": "^2.8.1"
       },
@@ -13808,9 +13645,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -13818,15 +13655,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.15.35",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
-      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -13910,6 +13738,21 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/waterline-utils/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/waterline/node_modules/async": {

--- a/package.json
+++ b/package.json
@@ -7,28 +7,28 @@
   "license": "CC-BY-SA-3.0",
   "keywords": [],
   "dependencies": {
-    "@aws-sdk/client-sesv2": "^3.1000.0",
+    "@aws-sdk/client-sesv2": "^3.1041.0",
     "@azure/storage-blob": "^12.31.0",
     "@natlibfi/marc-record": "^10.0.1",
-    "@natlibfi/marc-record-serializers": "^11.0.1",
+    "@natlibfi/marc-record-serializers": "^11.0.2",
     "archiver": "^7.0.1",
     "argon2": "^0.44.0",
-    "ejs": "^5.0.1",
-    "express-rate-limit": "^8.2.1",
+    "ejs": "^5.0.2",
+    "express-rate-limit": "^8.4.1",
     "jsonwebtoken": "^9.0.3",
     "mime-types": "^3.0.2",
     "moment": "^2.30.1",
     "moment-duration-format": "^2.3.2",
-    "multer": "^2.1.0",
+    "multer": "^2.1.1",
     "response-time": "^2.3.4",
     "rss-parser": "^3.13.0",
     "sails": "^1.5.17",
     "sails-hook-orm": "^4.0.3",
     "sails-postgresql": "^5.0.1",
-    "typesense": "^3.0.1",
+    "typesense": "^3.0.6",
     "underscore.date": "^0.6.1",
     "underscore.string": "^3.3.6",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "winston": "^3.19.0"
   },
   "scripts": {
@@ -55,8 +55,8 @@
     "url": "git://github.com/GrottoCenter/grottocenter-api.git"
   },
   "devDependencies": {
-    "@commitlint/cli": "^20.4.2",
-    "@commitlint/config-conventional": "^20.4.1",
+    "@commitlint/cli": "^20.5.3",
+    "@commitlint/config-conventional": "^20.5.3",
     "cross-env": "^10.1.0",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -64,18 +64,18 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "express": "^5.2.1",
-    "fast-check": "^4.5.3",
+    "fast-check": "^4.7.0",
     "fixted": "^4.2.7",
-    "glob": "^10.5.0",
+    "glob": "^13.0.6",
     "husky": "^9.1.7",
-    "lint-staged": "^16.3.1",
+    "lint-staged": "^16.4.0",
     "mocha": "^11.7.5",
     "nodemon": "^3.1.14",
     "nyc": "^18.0.0",
-    "pg": "^8.11.0",
-    "prettier": "^3.8.1",
+    "pg": "^8.20.0",
+    "prettier": "^3.8.3",
     "should": "^13.2.3",
-    "sinon": "^21.0.1",
+    "sinon": "^21.1.2",
     "supertest": "^7.2.2"
   },
   "engines": {
@@ -85,9 +85,14 @@
     "*.js": "eslint --cache --fix"
   },
   "overrides": {
-    "validator": "^13.15.20",
-    "qs": "^6.14.1",
     "diff": "^8.0.3",
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0",
+    "skipper": {
+      "uuid": "^14.0.0"
+    },
+    "istanbul-lib-processinfo": {
+      "uuid": "^14.0.0"
+    }
   }
 }


### PR DESCRIPTION
## 🤔 What

Upgrade all dependencies to their latest compatible versions and resolve all npm audit vulnerabilities.

### Dependencies upgraded

| Package | From | To | Type |
|---|---|---|---|
| `@aws-sdk/client-sesv2` | 3.1000.0 | 3.1041.0 | minor |
| `@natlibfi/marc-record-serializers` | 11.0.1 | 11.0.2 | patch |
| `ejs` | 5.0.1 | 5.0.2 | patch |
| `express-rate-limit` | 8.2.1 | 8.4.1 | minor |
| `multer` | 2.1.0 | 2.1.1 | patch |
| `typesense` | 3.0.1 | 3.0.6 | patch |
| `uuid` | 13.0.0 | **14.0.0** | **major** |
| `@commitlint/cli` | 20.4.2 | 20.5.3 | minor |
| `@commitlint/config-conventional` | 20.4.1 | 20.5.3 | minor |
| `fast-check` | 4.5.3 | 4.7.0 | minor |
| `glob` | 10.5.0 | **13.0.6** | **major** |
| `lint-staged` | 16.3.1 | 16.4.0 | minor |
| `pg` | 8.11.0 | 8.20.0 | minor |
| `prettier` | 3.8.1 | 3.8.3 | patch |
| `sinon` | 21.0.1 | 21.1.2 | minor |

### Overrides updated

- **Removed** `validator` and `qs` overrides (no longer needed, parent packages resolve safe versions natively)
- **Bumped** `serialize-javascript` override from `^7.0.3` to `^7.0.5` (fixes RCE and DoS in `<=7.0.4`)
- **Added** `lodash: ^4.18.0` override (fixes code injection and prototype pollution in `<=4.17.23`, used by fixted)
- **Added** scoped `uuid: ^14.0.0` overrides for `skipper` and `istanbul-lib-processinfo` (fixes buffer bounds check in `<14.0.0`)

### Not upgraded

- **ESLint 8 → 10**: `eslint-config-airbnb-base` only supports ESLint 7/8. Upgrading requires migrating to flat config and finding compatible replacements — best done as a dedicated task.

## 🤷‍♂️ Why

- Keep dependencies up to date with security patches and bug fixes
- Resolve all 10 npm audit vulnerabilities (was 7 after initial upgrade, now **0**)

## 🔍 How

- Used `npm-check-updates` to identify available upgrades
- Upgraded all packages except ESLint (breaking config incompatibility)
- Ran `npm audit fix` for non-breaking transitive fixes
- Added targeted `overrides` for transitive dependencies that couldn't be fixed otherwise
- Verified that overridden packages only use stable APIs (e.g., skipper and istanbul-lib-processinfo only use `uuid.v4()`)
- Removed stale overrides (`validator`, `qs`) that are no longer needed

## 🧪 Testing

- `npm run lint` passes (0 errors)
- `npm audit` reports 0 vulnerabilities
- Run `npm test` to confirm full test suite passes

## 📸 Previews

N/A
