### PR TITLE
feat(qualitySort): add sort and order query params to with-quality endpoints

### DIFF
--- a/api/controllers/v1/country/get-entrances-data-quality.js
+++ b/api/controllers/v1/country/get-entrances-data-quality.js
@@ -4,6 +4,11 @@ const {
   toQualityDataEntrance,
 } = require('../../../services/mapping/converters');
 const { toListFromController } = require('../../../services/mapping/utils');
+const {
+  SORTABLE_COLUMNS_COUNTRY,
+  VALIDATION_ERROR,
+  validateSortParams,
+} = require('../../../utils/validateSortParams');
 
 module.exports = async (req, res) => {
   // Get entrances and the informations associated at each entrance
@@ -11,11 +16,18 @@ module.exports = async (req, res) => {
   const limit = Math.min(parseInt(req.param('limit', 50), 10), 1000);
   const offset = Math.max(parseInt(req.param('offset', 0), 10), 0);
 
+  const sortResult = validateSortParams(req, res, SORTABLE_COLUMNS_COUNTRY);
+  if (sortResult === VALIDATION_ERROR) return null;
+  const sort = sortResult ? sortResult.sort : null;
+  const order = sortResult ? sortResult.order : null;
+
   const [entrancesInformationToCompute, totalCount] = await Promise.all([
     DataQualityComputeService.getEntrancesWithQualityByCountry(
       countryId,
       limit,
-      offset
+      offset,
+      sort,
+      order
     ),
     DataQualityComputeService.getEntrancesWithQualityByCountryCount(countryId),
   ]);

--- a/api/controllers/v1/massif/get-entrances-data-quality.js
+++ b/api/controllers/v1/massif/get-entrances-data-quality.js
@@ -4,6 +4,11 @@ const {
   toQualityDataEntrance,
 } = require('../../../services/mapping/converters');
 const { toListFromController } = require('../../../services/mapping/utils');
+const {
+  SORTABLE_COLUMNS,
+  VALIDATION_ERROR,
+  validateSortParams,
+} = require('../../../utils/validateSortParams');
 
 module.exports = async (req, res) => {
   // Get entrances and the informations associated at each entrance
@@ -11,11 +16,18 @@ module.exports = async (req, res) => {
   const limit = Math.min(parseInt(req.param('limit', 50), 10), 1000);
   const offset = Math.max(parseInt(req.param('offset', 0), 10), 0);
 
+  const sortResult = validateSortParams(req, res, SORTABLE_COLUMNS);
+  if (sortResult === VALIDATION_ERROR) return null;
+  const sort = sortResult ? sortResult.sort : null;
+  const order = sortResult ? sortResult.order : null;
+
   const [entrancesInformationToCompute, totalCount] = await Promise.all([
     DataQualityComputeService.getEntrancesWithQualityByMassif(
       massifId,
       limit,
-      offset
+      offset,
+      sort,
+      order
     ),
     DataQualityComputeService.getEntrancesWithQualityByMassifCount(massifId),
   ]);

--- a/api/controllers/v1/region/get-entrances-data-quality.js
+++ b/api/controllers/v1/region/get-entrances-data-quality.js
@@ -4,6 +4,11 @@ const {
   toQualityDataEntrance,
 } = require('../../../services/mapping/converters');
 const { toListFromController } = require('../../../services/mapping/utils');
+const {
+  SORTABLE_COLUMNS_COUNTRY,
+  VALIDATION_ERROR,
+  validateSortParams,
+} = require('../../../utils/validateSortParams');
 
 module.exports = async (req, res) => {
   const { countryId } = req.params;
@@ -11,6 +16,11 @@ module.exports = async (req, res) => {
   const isoCode = `${countryId}-${regionId}`;
   const limit = Math.min(parseInt(req.param('limit', 50), 10), 1000);
   const offset = Math.max(parseInt(req.param('offset', 0), 10), 0);
+
+  const sortResult = validateSortParams(req, res, SORTABLE_COLUMNS_COUNTRY);
+  if (sortResult === VALIDATION_ERROR) return null;
+  const sort = sortResult ? sortResult.sort : null;
+  const order = sortResult ? sortResult.order : null;
 
   // Check if ISO 3166-2 region exists
   const region = await TISO31662.findOne({ id: isoCode });
@@ -25,7 +35,9 @@ module.exports = async (req, res) => {
     DataQualityComputeService.getEntrancesWithQualityByRegion(
       isoCode,
       limit,
-      offset
+      offset,
+      sort,
+      order
     ),
     DataQualityComputeService.getEntrancesWithQualityByRegionCount(isoCode),
   ]);

--- a/api/services/DataQualityComputeService.js
+++ b/api/services/DataQualityComputeService.js
@@ -4,18 +4,59 @@ const CommonService = require('./CommonService');
  * this service is used to retrieves the elements included
  * in the computation of the quality of the data of an entrance.
  */
+
+/**
+ * Placeholder token replaced by applySort with an ORDER BY clause (or
+ * removed when no sort is requested).  Using a named placeholder avoids
+ * the brittle `replace('LIMIT', ...)` pattern that would break if a
+ * subquery or CTE introduced its own LIMIT keyword.
+ */
+const ORDER_BY_PLACEHOLDER = '/*{{ORDER_BY}}*/';
+
+/**
+ * Replaces the ORDER_BY_PLACEHOLDER with an ORDER BY clause when sort is
+ * provided, or removes the placeholder when it is not.
+ *
+ * The sort column and order direction are interpolated directly into the SQL
+ * string — safe because allow-list validation has already occurred upstream.
+ *
+ * @param {string} sql - SQL query string containing ORDER_BY_PLACEHOLDER
+ * @param {string|null} sort - validated column name
+ * @param {string|null} order - 'asc' or 'desc'
+ * @returns {string} SQL with ORDER BY injected or placeholder removed
+ */
+const applySort = (sql, sort, order) => {
+  if (!sort) return sql.replace(ORDER_BY_PLACEHOLDER, '');
+  const orderBy = `ORDER BY ${sort} ${order.toUpperCase()} `;
+  return sql.replace(ORDER_BY_PLACEHOLDER, orderBy);
+};
+
 const GET_ENTRANCES_WITH_QUALITY_BY_MASSIF = `
   SELECT *
   FROM v_data_quality_compute_entrance
   WHERE id_massif = $1
-  LIMIT $2 OFFSET $3
+  ${ORDER_BY_PLACEHOLDER}LIMIT $2 OFFSET $3
+`;
+
+const GET_ENTRANCES_WITH_QUALITY_BY_MASSIF_NO_LIMIT = `
+  SELECT *
+  FROM v_data_quality_compute_entrance
+  WHERE id_massif = $1
+  ${ORDER_BY_PLACEHOLDER}
 `;
 
 const GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY = `
   SELECT DISTINCT id_entrance, general_latest_date_of_update, general_nb_contributions, location_latest_date_of_update, location_nb_contributions, description_latest_date_of_update, description_nb_contributions, document_latest_date_of_update, document_nb_contributions, rigging_latest_date_of_update, rigging_nb_contributions, history_latest_date_of_update, history_nb_contributions, comment_latest_date_of_update, comment_nb_contributions, entrance_name, id_country, country_name, date_of_update
   FROM v_data_quality_compute_entrance
   WHERE id_country = $1
-  LIMIT $2 OFFSET $3
+  ${ORDER_BY_PLACEHOLDER}LIMIT $2 OFFSET $3
+`;
+
+const GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY_NO_LIMIT = `
+  SELECT DISTINCT id_entrance, general_latest_date_of_update, general_nb_contributions, location_latest_date_of_update, location_nb_contributions, description_latest_date_of_update, description_nb_contributions, document_latest_date_of_update, document_nb_contributions, rigging_latest_date_of_update, rigging_nb_contributions, history_latest_date_of_update, history_nb_contributions, comment_latest_date_of_update, comment_nb_contributions, entrance_name, id_country, country_name, date_of_update
+  FROM v_data_quality_compute_entrance
+  WHERE id_country = $1
+  ${ORDER_BY_PLACEHOLDER}
 `;
 
 const GET_ENTRANCES_WITH_QUALITY_BY_REGION = `
@@ -23,7 +64,15 @@ const GET_ENTRANCES_WITH_QUALITY_BY_REGION = `
   FROM v_data_quality_compute_entrance v
   JOIN t_entrance e ON v.id_entrance = e.id
   WHERE e.iso_3166_2 = $1
-  LIMIT $2 OFFSET $3
+  ${ORDER_BY_PLACEHOLDER}LIMIT $2 OFFSET $3
+`;
+
+const GET_ENTRANCES_WITH_QUALITY_BY_REGION_NO_LIMIT = `
+  SELECT DISTINCT v.id_entrance, v.general_latest_date_of_update, v.general_nb_contributions, v.location_latest_date_of_update, v.location_nb_contributions, v.description_latest_date_of_update, v.description_nb_contributions, v.document_latest_date_of_update, v.document_nb_contributions, v.rigging_latest_date_of_update, v.rigging_nb_contributions, v.history_latest_date_of_update, v.history_nb_contributions, v.comment_latest_date_of_update, v.comment_nb_contributions, v.entrance_name, v.id_country, v.country_name, v.date_of_update
+  FROM v_data_quality_compute_entrance v
+  JOIN t_entrance e ON v.id_entrance = e.id
+  WHERE e.iso_3166_2 = $1
+  ${ORDER_BY_PLACEHOLDER}
 `;
 
 const COUNT_ENTRANCES_WITH_QUALITY_BY_MASSIF = `
@@ -51,26 +100,25 @@ module.exports = {
    * @param {int} massifId
    * @param {int} limit
    * @param {int} offset
+   * @param {string|null} sort - validated column name to sort by
+   * @param {string|null} order - 'asc' or 'desc'
    * @returns {Object} the date of the latest update and the number of contributions on all entrances in a massif
    *          or null if no result or something went wrong
    */
   getEntrancesWithQualityByMassif: async (
     massifId,
     limit = null,
-    offset = null
+    offset = null,
+    sort = null,
+    order = null
   ) => {
     try {
-      const params =
-        limit !== null && offset !== null
-          ? [massifId, limit, offset]
-          : [massifId];
-      const query =
-        limit !== null && offset !== null
-          ? GET_ENTRANCES_WITH_QUALITY_BY_MASSIF
-          : GET_ENTRANCES_WITH_QUALITY_BY_MASSIF.replace(
-              'LIMIT $2 OFFSET $3',
-              ''
-            );
+      const hasPagination = limit !== null && offset !== null;
+      const params = hasPagination ? [massifId, limit, offset] : [massifId];
+      const template = hasPagination
+        ? GET_ENTRANCES_WITH_QUALITY_BY_MASSIF
+        : GET_ENTRANCES_WITH_QUALITY_BY_MASSIF_NO_LIMIT;
+      const query = applySort(template, sort, order);
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {
@@ -102,26 +150,25 @@ module.exports = {
    * @param {string} countryId alpha-2 code
    * @param {int} limit
    * @param {int} offset
+   * @param {string|null} sort - validated column name to sort by
+   * @param {string|null} order - 'asc' or 'desc'
    * @returns {Object} the date of the latest update and the number of contributions on all entrances in a country
    *          or null if no result or something went wrong
    */
   getEntrancesWithQualityByCountry: async (
     countryId,
     limit = null,
-    offset = null
+    offset = null,
+    sort = null,
+    order = null
   ) => {
     try {
-      const params =
-        limit !== null && offset !== null
-          ? [countryId, limit, offset]
-          : [countryId];
-      const query =
-        limit !== null && offset !== null
-          ? GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY
-          : GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY.replace(
-              'LIMIT $2 OFFSET $3',
-              ''
-            );
+      const hasPagination = limit !== null && offset !== null;
+      const params = hasPagination ? [countryId, limit, offset] : [countryId];
+      const template = hasPagination
+        ? GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY
+        : GET_ENTRANCES_WITH_QUALITY_BY_COUNTRY_NO_LIMIT;
+      const query = applySort(template, sort, order);
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {
@@ -153,26 +200,25 @@ module.exports = {
    * @param {string} regionId ISO 3166-2 code (e.g., 'US-TN')
    * @param {int} limit
    * @param {int} offset
+   * @param {string|null} sort - validated column name to sort by
+   * @param {string|null} order - 'asc' or 'desc'
    * @returns {Object} the date of the latest update and the number of contributions on all entrances in a region
    *          or null if no result or something went wrong
    */
   getEntrancesWithQualityByRegion: async (
     regionId,
     limit = null,
-    offset = null
+    offset = null,
+    sort = null,
+    order = null
   ) => {
     try {
-      const params =
-        limit !== null && offset !== null
-          ? [regionId, limit, offset]
-          : [regionId];
-      const query =
-        limit !== null && offset !== null
-          ? GET_ENTRANCES_WITH_QUALITY_BY_REGION
-          : GET_ENTRANCES_WITH_QUALITY_BY_REGION.replace(
-              'LIMIT $2 OFFSET $3',
-              ''
-            );
+      const hasPagination = limit !== null && offset !== null;
+      const params = hasPagination ? [regionId, limit, offset] : [regionId];
+      const template = hasPagination
+        ? GET_ENTRANCES_WITH_QUALITY_BY_REGION
+        : GET_ENTRANCES_WITH_QUALITY_BY_REGION_NO_LIMIT;
+      const query = applySort(template, sort, order);
       const queryResult = await CommonService.query(query, params);
       return queryResult.rows;
     } catch (e) {

--- a/api/utils/validateSortParams.js
+++ b/api/utils/validateSortParams.js
@@ -1,0 +1,89 @@
+/**
+ * Sentinel value returned by validateSortParams when a 400 response has
+ * already been sent.  Using a named constant avoids fragile string
+ * comparisons in callers.
+ */
+const VALIDATION_ERROR = Symbol.for('validateSortParams.error');
+
+const SORTABLE_COLUMNS = [
+  'entrance_name',
+  'date_of_update',
+  'general_latest_date_of_update',
+  'general_nb_contributions',
+  'location_latest_date_of_update',
+  'location_nb_contributions',
+  'description_latest_date_of_update',
+  'description_nb_contributions',
+  'document_latest_date_of_update',
+  'document_nb_contributions',
+  'rigging_latest_date_of_update',
+  'rigging_nb_contributions',
+  'history_latest_date_of_update',
+  'history_nb_contributions',
+  'comment_latest_date_of_update',
+  'comment_nb_contributions',
+  'country_name',
+  'massif_name',
+];
+
+/**
+ * Columns available in the country and region queries.
+ * These queries use explicit SELECT lists that do NOT include massif_name.
+ */
+const SORTABLE_COLUMNS_COUNTRY = SORTABLE_COLUMNS.filter(
+  (c) => c !== 'massif_name'
+);
+
+const VALID_ORDERS = ['asc', 'desc'];
+
+/**
+ * Extracts and validates `sort` and `order` query parameters from the request.
+ *
+ * @param {Object} req - Sails request object
+ * @param {Object} res - Sails response object
+ * @param {string[]} [allowedColumns=SORTABLE_COLUMNS] - per-endpoint allow-list
+ * @returns {{ sort: string, order: string } | null | symbol}
+ *   - { sort, order } when a valid sort column is provided
+ *   - null when no sort is provided (order is ignored)
+ *   - VALIDATION_ERROR when a 400 response has already been sent
+ */
+const validateSortParams = (req, res, allowedColumns = SORTABLE_COLUMNS) => {
+  const sort = req.param('sort');
+  const order = req.param('order');
+
+  // No sort parameter — ignore order even if present
+  if (sort === undefined || sort === null) {
+    return null;
+  }
+
+  // Validate sort column against allow-list (case-insensitive)
+  const sortLower = sort.toString().toLowerCase();
+  if (!allowedColumns.includes(sortLower)) {
+    res.badRequest(
+      `Invalid sort column '${sort}'. Valid columns: ${allowedColumns.join(', ')}`
+    );
+    return VALIDATION_ERROR;
+  }
+
+  // Default order to 'asc' when absent
+  if (order === undefined || order === null) {
+    return { sort: sortLower, order: 'asc' };
+  }
+
+  // Validate order direction (case-insensitive)
+  const orderLower = order.toString().toLowerCase();
+  if (!VALID_ORDERS.includes(orderLower)) {
+    res.badRequest(`Invalid order value '${order}'. Must be 'asc' or 'desc'`);
+    return VALIDATION_ERROR;
+  }
+
+  return { sort: sortLower, order: orderLower };
+};
+
+module.exports = {
+  SORTABLE_COLUMNS,
+  SORTABLE_COLUMNS_COUNTRY,
+  VALID_ORDERS,
+  VALIDATION_ERROR,
+  validateSortParams,
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -2545,6 +2545,8 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - $ref: '#/components/parameters/qualitySortCountry'
+        - $ref: '#/components/parameters/qualityOrder'
       responses:
         '200':
           description: Successful operation
@@ -2563,6 +2565,8 @@ paths:
                   totalPages:
                     type: integer
                     description: Total number of pages based on limit
+        '400':
+          description: Invalid sort or order parameter value. The sort column must be one of the allowed column names and order must be asc or desc.
         '404':
           description: Region not found or has no entrances
 
@@ -3791,6 +3795,8 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - $ref: '#/components/parameters/qualitySortAll'
+        - $ref: '#/components/parameters/qualityOrder'
       responses:
         '200':
           description: Successful operation
@@ -3809,6 +3815,8 @@ paths:
                   totalPages:
                     type: integer
                     description: Total number of pages based on limit
+        '400':
+          description: Invalid sort or order parameter value. The sort column must be one of the allowed column names and order must be asc or desc.
         '404':
           description: Massif doesn't exist or hasn't entrances
 
@@ -3842,6 +3850,8 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - $ref: '#/components/parameters/qualitySortCountry'
+        - $ref: '#/components/parameters/qualityOrder'
       responses:
         '200':
           description: Successful operation
@@ -3860,6 +3870,8 @@ paths:
                   totalPages:
                     type: integer
                     description: Total number of pages based on limit
+        '400':
+          description: Invalid sort or order parameter value. The sort column must be one of the allowed column names and order must be asc or desc.
         '404':
           description: Country doesn't exist or hasn't entrances
 
@@ -5115,6 +5127,68 @@ components:
         type: integer
         minimum: 1
         maximum: 22
+    qualitySortAll:
+      name: sort
+      in: query
+      description: Column name to sort results by. When omitted, no specific order is applied.
+      required: false
+      schema:
+        type: string
+        enum:
+          - entrance_name
+          - date_of_update
+          - general_latest_date_of_update
+          - general_nb_contributions
+          - location_latest_date_of_update
+          - location_nb_contributions
+          - description_latest_date_of_update
+          - description_nb_contributions
+          - document_latest_date_of_update
+          - document_nb_contributions
+          - rigging_latest_date_of_update
+          - rigging_nb_contributions
+          - history_latest_date_of_update
+          - history_nb_contributions
+          - comment_latest_date_of_update
+          - comment_nb_contributions
+          - country_name
+          - massif_name
+    qualitySortCountry:
+      name: sort
+      in: query
+      description: Column name to sort results by. When omitted, no specific order is applied. Note that massif_name is not available on country and region endpoints.
+      required: false
+      schema:
+        type: string
+        enum:
+          - entrance_name
+          - date_of_update
+          - general_latest_date_of_update
+          - general_nb_contributions
+          - location_latest_date_of_update
+          - location_nb_contributions
+          - description_latest_date_of_update
+          - description_nb_contributions
+          - document_latest_date_of_update
+          - document_nb_contributions
+          - rigging_latest_date_of_update
+          - rigging_nb_contributions
+          - history_latest_date_of_update
+          - history_nb_contributions
+          - comment_latest_date_of_update
+          - comment_nb_contributions
+          - country_name
+    qualityOrder:
+      name: order
+      in: query
+      description: Sort direction. Only used when `sort` is provided. Defaults to `asc` when omitted.
+      required: false
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: asc
   securitySchemes:
     bearerAuth:
       type: http

--- a/test/integration/1_services/DataQualityComputeService.sort.test.js
+++ b/test/integration/1_services/DataQualityComputeService.sort.test.js
@@ -1,0 +1,216 @@
+const should = require('should');
+const sinon = require('sinon');
+const DataQualityComputeService = require('../../../api/services/DataQualityComputeService');
+const CommonService = require('../../../api/services/CommonService');
+
+describe('DataQualityComputeService - sort/order', () => {
+  let queryStub;
+  let capturedSql;
+
+  beforeEach(() => {
+    capturedSql = null;
+    queryStub = sinon.stub(CommonService, 'query').callsFake((sql) => {
+      capturedSql = sql;
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  afterEach(() => {
+    queryStub.restore();
+  });
+
+  // --- Data methods: sort + order provided ---
+
+  describe('getEntrancesWithQualityByMassif', () => {
+    it('should include ORDER BY before LIMIT when sort and order are provided', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByMassif(
+        1,
+        10,
+        0,
+        'entrance_name',
+        'desc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY entrance_name DESC/);
+      const orderIdx = capturedSql.indexOf('ORDER BY');
+      const limitIdx = capturedSql.indexOf('LIMIT');
+      orderIdx.should.be.lessThan(limitIdx);
+    });
+
+    it('should not include ORDER BY when sort is null', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByMassif(
+        1,
+        10,
+        0,
+        null,
+        null
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+
+    it('should include ORDER BY even without pagination (limit=null)', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByMassif(
+        1,
+        null,
+        null,
+        'entrance_name',
+        'asc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY entrance_name ASC/);
+      capturedSql.should.not.match(/LIMIT/);
+    });
+
+    it('should not contain placeholder token in final SQL', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByMassif(
+        1,
+        10,
+        0,
+        'entrance_name',
+        'desc'
+      );
+      capturedSql.should.not.containEql('{{ORDER_BY}}');
+    });
+
+    it('should not contain placeholder token when sort is null', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByMassif(
+        1,
+        10,
+        0,
+        null,
+        null
+      );
+      capturedSql.should.not.containEql('{{ORDER_BY}}');
+    });
+  });
+
+  describe('getEntrancesWithQualityByCountry', () => {
+    it('should include ORDER BY before LIMIT when sort and order are provided', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByCountry(
+        'FR',
+        10,
+        0,
+        'date_of_update',
+        'asc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY date_of_update ASC/);
+      const orderIdx = capturedSql.indexOf('ORDER BY');
+      const limitIdx = capturedSql.indexOf('LIMIT');
+      orderIdx.should.be.lessThan(limitIdx);
+    });
+
+    it('should not include ORDER BY when sort is null', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByCountry(
+        'FR',
+        10,
+        0,
+        null,
+        null
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+
+    it('should include ORDER BY even without pagination (limit=null)', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByCountry(
+        'FR',
+        null,
+        null,
+        'country_name',
+        'desc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY country_name DESC/);
+      capturedSql.should.not.match(/LIMIT/);
+    });
+  });
+
+  describe('getEntrancesWithQualityByRegion', () => {
+    it('should include ORDER BY before LIMIT when sort and order are provided', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByRegion(
+        'FR-01',
+        10,
+        0,
+        'general_nb_contributions',
+        'desc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY general_nb_contributions DESC/);
+      const orderIdx = capturedSql.indexOf('ORDER BY');
+      const limitIdx = capturedSql.indexOf('LIMIT');
+      orderIdx.should.be.lessThan(limitIdx);
+    });
+
+    it('should not include ORDER BY when sort is null', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByRegion(
+        'FR-01',
+        10,
+        0,
+        null,
+        null
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+
+    it('should include ORDER BY even without pagination (limit=null)', async () => {
+      await DataQualityComputeService.getEntrancesWithQualityByRegion(
+        'FR-01',
+        null,
+        null,
+        'entrance_name',
+        'asc'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.match(/ORDER BY entrance_name ASC/);
+      capturedSql.should.not.match(/LIMIT/);
+    });
+  });
+
+  // --- Count methods: never contain ORDER BY ---
+
+  describe('getEntrancesWithQualityByMassifCount', () => {
+    it('should never contain ORDER BY', async () => {
+      queryStub.restore();
+      queryStub = sinon.stub(CommonService, 'query').callsFake((sql) => {
+        capturedSql = sql;
+        return Promise.resolve({ rows: [{ count: '0' }] });
+      });
+      await DataQualityComputeService.getEntrancesWithQualityByMassifCount(1);
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+  });
+
+  describe('getEntrancesWithQualityByCountryCount', () => {
+    it('should never contain ORDER BY', async () => {
+      queryStub.restore();
+      queryStub = sinon.stub(CommonService, 'query').callsFake((sql) => {
+        capturedSql = sql;
+        return Promise.resolve({ rows: [{ count: '0' }] });
+      });
+      await DataQualityComputeService.getEntrancesWithQualityByCountryCount(
+        'FR'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+  });
+
+  describe('getEntrancesWithQualityByRegionCount', () => {
+    it('should never contain ORDER BY', async () => {
+      queryStub.restore();
+      queryStub = sinon.stub(CommonService, 'query').callsFake((sql) => {
+        capturedSql = sql;
+        return Promise.resolve({ rows: [{ count: '0' }] });
+      });
+      await DataQualityComputeService.getEntrancesWithQualityByRegionCount(
+        'FR-01'
+      );
+      should(capturedSql).not.be.null();
+      capturedSql.should.not.match(/ORDER BY/);
+    });
+  });
+});

--- a/test/integration/2_utils/validateSortParams.property.test.js
+++ b/test/integration/2_utils/validateSortParams.property.test.js
@@ -1,0 +1,202 @@
+const should = require('should');
+const sinon = require('sinon');
+const fc = require('fast-check');
+const {
+  SORTABLE_COLUMNS,
+  SORTABLE_COLUMNS_COUNTRY,
+  VALID_ORDERS,
+  VALIDATION_ERROR,
+  validateSortParams,
+} = require('../../../api/utils/validateSortParams');
+const CommonService = require('../../../api/services/CommonService');
+const DataQualityComputeService = require('../../../api/services/DataQualityComputeService');
+
+// --- Shared arbitraries ---
+
+// Any column from the allow-list
+const sortableColumnArb = fc.constantFrom(...SORTABLE_COLUMNS);
+
+// Any valid order direction
+const validOrderArb = fc.constantFrom('asc', 'desc');
+
+// Optional order: either a valid direction or undefined (to test default)
+const optionalOrderArb = fc.oneof(validOrderArb, fc.constant(undefined));
+
+// Arbitrary string that is NOT in the allow-list.
+// Filter out any accidental match against SORTABLE_COLUMNS (case-insensitive).
+const invalidColumnArb = fc
+  .string({ minLength: 1, maxLength: 60 })
+  .filter((s) => !SORTABLE_COLUMNS.includes(s.toLowerCase()));
+
+// Arbitrary string that is NOT 'asc' or 'desc' (case-insensitive).
+const invalidOrderArb = fc
+  .string({ minLength: 1, maxLength: 30 })
+  .filter((s) => !VALID_ORDERS.includes(s.toLowerCase()));
+
+// --- Helpers ---
+
+function mockReqRes(sortVal, orderVal) {
+  const req = {
+    param: sinon.stub(),
+  };
+  req.param.withArgs('sort').returns(sortVal);
+  req.param.withArgs('order').returns(orderVal);
+
+  const res = {
+    badRequest: sinon.spy(),
+  };
+  return { req, res };
+}
+
+/**
+ * Property 1: Valid sort parameters produce correct ORDER BY clause
+ *
+ * For any column from SORTABLE_COLUMNS and any valid order direction (asc,
+ * desc, or omitted — defaulting to asc), the SQL query string built by
+ * DataQualityComputeService.getEntrancesWithQualityByMassif contains an
+ * ORDER BY <column> <DIRECTION> clause positioned before the LIMIT clause.
+ *
+ * Validates: Requirements 1.1, 2.1, 2.2, 2.3
+ */
+describe('validateSortParams - Property 1: Valid sort parameters produce correct ORDER BY clause', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should produce ORDER BY <column> <direction> before LIMIT for any valid sort/order', function () {
+    this.timeout(30000);
+    return fc.assert(
+      fc.asyncProperty(
+        sortableColumnArb,
+        optionalOrderArb,
+        async (column, order) => {
+          const effectiveOrder = order || 'asc';
+
+          let capturedSql = null;
+          const stub = sinon.stub(CommonService, 'query').callsFake((sql) => {
+            capturedSql = sql;
+            return Promise.resolve({ rows: [] });
+          });
+
+          try {
+            await DataQualityComputeService.getEntrancesWithQualityByMassif(
+              1,
+              50,
+              0,
+              column,
+              effectiveOrder
+            );
+
+            should(capturedSql).be.a.String();
+
+            const expectedFragment = `ORDER BY ${column} ${effectiveOrder.toUpperCase()}`;
+            should(capturedSql).containEql(expectedFragment);
+
+            // ORDER BY must appear before LIMIT
+            const orderByIdx = capturedSql.indexOf('ORDER BY');
+            const limitIdx = capturedSql.indexOf('LIMIT');
+            should(orderByIdx).be.above(-1);
+            should(limitIdx).be.above(-1);
+            should(orderByIdx).be.below(limitIdx);
+          } finally {
+            stub.restore();
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 2: Invalid sort column rejection
+ *
+ * For any arbitrary string not in the allow-list, validateSortParams returns
+ * VALIDATION_ERROR and the string never appears in any SQL query.
+ *
+ * Validates: Requirements 3.1, 4.1
+ */
+describe('validateSortParams - Property 2: Invalid sort column rejection', () => {
+  it('should reject any sort column not in the allow-list', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(invalidColumnArb, (badColumn) => {
+        const { req, res } = mockReqRes(badColumn, undefined);
+
+        const result = validateSortParams(req, res);
+
+        should(result).equal(VALIDATION_ERROR);
+        should(res.badRequest.calledOnce).be.true();
+
+        // The invalid column must not appear in any SQL-like context.
+        // Verify the error message references the bad column but does not
+        // construct an ORDER BY with it.
+        const errorMsg = res.badRequest.firstCall.args[0];
+        should(errorMsg).not.containEql(`ORDER BY ${badColumn}`);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 3: Invalid order value rejection
+ *
+ * For any arbitrary string that is not 'asc' or 'desc' (case-insensitive),
+ * validateSortParams returns VALIDATION_ERROR and the string never appears
+ * in any SQL query.
+ *
+ * Validates: Requirements 3.2, 4.2
+ */
+describe('validateSortParams - Property 3: Invalid order value rejection', () => {
+  it('should reject any order value that is not asc or desc', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(sortableColumnArb, invalidOrderArb, (column, badOrder) => {
+        const { req, res } = mockReqRes(column, badOrder);
+
+        const result = validateSortParams(req, res);
+
+        should(result).equal(VALIDATION_ERROR);
+        should(res.badRequest.calledOnce).be.true();
+
+        // The invalid order must not appear in any SQL-like context.
+        const errorMsg = res.badRequest.firstCall.args[0];
+        should(errorMsg).not.containEql(`ORDER BY`);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 4: Per-endpoint allow-list enforcement
+ *
+ * massif_name is valid in the full allow-list but rejected by the country
+ * allow-list. This property verifies that the per-endpoint filtering works
+ * correctly for any column that exists in SORTABLE_COLUMNS but not in
+ * SORTABLE_COLUMNS_COUNTRY.
+ */
+describe('validateSortParams - Property 4: Per-endpoint allow-list enforcement', () => {
+  it('should reject columns excluded from the country allow-list', function () {
+    this.timeout(30000);
+    const excludedColumns = SORTABLE_COLUMNS.filter(
+      (c) => !SORTABLE_COLUMNS_COUNTRY.includes(c)
+    );
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...excludedColumns),
+        validOrderArb,
+        (column, order) => {
+          const { req, res } = mockReqRes(column, order);
+
+          const result = validateSortParams(req, res, SORTABLE_COLUMNS_COUNTRY);
+
+          should(result).equal(VALIDATION_ERROR);
+          should(res.badRequest.calledOnce).be.true();
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/test/integration/2_utils/validateSortParams.test.js
+++ b/test/integration/2_utils/validateSortParams.test.js
@@ -1,0 +1,266 @@
+const should = require('should');
+const sinon = require('sinon');
+const {
+  SORTABLE_COLUMNS,
+  SORTABLE_COLUMNS_COUNTRY,
+  VALIDATION_ERROR,
+  validateSortParams,
+} = require('../../../api/utils/validateSortParams');
+
+describe('validateSortParams - Unit Tests', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      param: sinon.stub(),
+    };
+    res = {
+      badRequest: sinon.spy(),
+    };
+  });
+
+  describe('SORTABLE_COLUMNS', () => {
+    it('should contain exactly 18 entries', () => {
+      should(SORTABLE_COLUMNS).have.length(18);
+    });
+
+    it('should include all expected column names', () => {
+      const expected = [
+        'entrance_name',
+        'date_of_update',
+        'general_latest_date_of_update',
+        'general_nb_contributions',
+        'location_latest_date_of_update',
+        'location_nb_contributions',
+        'description_latest_date_of_update',
+        'description_nb_contributions',
+        'document_latest_date_of_update',
+        'document_nb_contributions',
+        'rigging_latest_date_of_update',
+        'rigging_nb_contributions',
+        'history_latest_date_of_update',
+        'history_nb_contributions',
+        'comment_latest_date_of_update',
+        'comment_nb_contributions',
+        'country_name',
+        'massif_name',
+      ];
+      should(SORTABLE_COLUMNS).deepEqual(expected);
+    });
+  });
+
+  describe('SORTABLE_COLUMNS_COUNTRY', () => {
+    it('should contain exactly 17 entries (no massif_name)', () => {
+      should(SORTABLE_COLUMNS_COUNTRY).have.length(17);
+    });
+
+    it('should not include massif_name', () => {
+      should(SORTABLE_COLUMNS_COUNTRY).not.containEql('massif_name');
+    });
+
+    it('should be a strict subset of SORTABLE_COLUMNS', () => {
+      SORTABLE_COLUMNS_COUNTRY.forEach((col) => {
+        should(SORTABLE_COLUMNS).containEql(col);
+      });
+    });
+  });
+
+  describe('VALIDATION_ERROR', () => {
+    it('should be a Symbol', () => {
+      should(typeof VALIDATION_ERROR).equal('symbol');
+    });
+
+    it('should be retrievable via Symbol.for', () => {
+      should(VALIDATION_ERROR).equal(Symbol.for('validateSortParams.error'));
+    });
+  });
+
+  describe('valid sort column with default order', () => {
+    it('should return { sort, order } with default asc when order is absent', () => {
+      req.param.withArgs('sort').returns('entrance_name');
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'entrance_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+  });
+
+  describe('valid sort + valid order', () => {
+    it('should return correct values for sort=date_of_update order=desc', () => {
+      req.param.withArgs('sort').returns('date_of_update');
+      req.param.withArgs('order').returns('desc');
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'date_of_update', order: 'desc' });
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should return correct values for sort=country_name order=asc', () => {
+      req.param.withArgs('sort').returns('country_name');
+      req.param.withArgs('order').returns('asc');
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'country_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+  });
+
+  describe('case-insensitive matching', () => {
+    it('should accept uppercase sort column and normalise to lowercase', () => {
+      req.param.withArgs('sort').returns('ENTRANCE_NAME');
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'entrance_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should accept mixed-case sort column', () => {
+      req.param.withArgs('sort').returns('Country_Name');
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'country_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should accept uppercase order and normalise to lowercase', () => {
+      req.param.withArgs('sort').returns('entrance_name');
+      req.param.withArgs('order').returns('DESC');
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'entrance_name', order: 'desc' });
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should accept mixed-case order', () => {
+      req.param.withArgs('sort').returns('entrance_name');
+      req.param.withArgs('order').returns('Asc');
+
+      const result = validateSortParams(req, res);
+
+      should(result).deepEqual({ sort: 'entrance_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+  });
+
+  describe('invalid sort column', () => {
+    it('should call res.badRequest and return VALIDATION_ERROR for unknown column', () => {
+      req.param.withArgs('sort').returns('nonexistent_column');
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).equal(VALIDATION_ERROR);
+      should(res.badRequest.calledOnce).be.true();
+      should(res.badRequest.firstCall.args[0]).containEql(
+        'Invalid sort column'
+      );
+      should(res.badRequest.firstCall.args[0]).containEql('nonexistent_column');
+    });
+
+    it('should list valid columns in the error message', () => {
+      req.param.withArgs('sort').returns('bad_col');
+      req.param.withArgs('order').returns(undefined);
+
+      validateSortParams(req, res);
+
+      const msg = res.badRequest.firstCall.args[0];
+      should(msg).containEql('entrance_name');
+      should(msg).containEql('massif_name');
+    });
+  });
+
+  describe('invalid order value', () => {
+    it('should call res.badRequest and return VALIDATION_ERROR for invalid order', () => {
+      req.param.withArgs('sort').returns('entrance_name');
+      req.param.withArgs('order').returns('ascending');
+
+      const result = validateSortParams(req, res);
+
+      should(result).equal(VALIDATION_ERROR);
+      should(res.badRequest.calledOnce).be.true();
+      should(res.badRequest.firstCall.args[0]).containEql(
+        'Invalid order value'
+      );
+      should(res.badRequest.firstCall.args[0]).containEql('ascending');
+    });
+  });
+
+  describe('no sort param', () => {
+    it('should return null when sort is undefined', () => {
+      req.param.withArgs('sort').returns(undefined);
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).be.null();
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should return null when sort is null', () => {
+      req.param.withArgs('sort').returns(null);
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res);
+
+      should(result).be.null();
+      should(res.badRequest.called).be.false();
+    });
+  });
+
+  describe('order without sort', () => {
+    it('should return null and ignore order when sort is absent', () => {
+      req.param.withArgs('sort').returns(undefined);
+      req.param.withArgs('order').returns('desc');
+
+      const result = validateSortParams(req, res);
+
+      should(result).be.null();
+      should(res.badRequest.called).be.false();
+    });
+  });
+
+  describe('per-endpoint allow-list (SORTABLE_COLUMNS_COUNTRY)', () => {
+    it('should reject massif_name when using country allow-list', () => {
+      req.param.withArgs('sort').returns('massif_name');
+      req.param.withArgs('order').returns(undefined);
+
+      const result = validateSortParams(req, res, SORTABLE_COLUMNS_COUNTRY);
+
+      should(result).equal(VALIDATION_ERROR);
+      should(res.badRequest.calledOnce).be.true();
+      should(res.badRequest.firstCall.args[0]).containEql(
+        'Invalid sort column'
+      );
+    });
+
+    it('should accept entrance_name when using country allow-list', () => {
+      req.param.withArgs('sort').returns('entrance_name');
+      req.param.withArgs('order').returns('asc');
+
+      const result = validateSortParams(req, res, SORTABLE_COLUMNS_COUNTRY);
+
+      should(result).deepEqual({ sort: 'entrance_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+
+    it('should accept massif_name when using full allow-list', () => {
+      req.param.withArgs('sort').returns('massif_name');
+      req.param.withArgs('order').returns('asc');
+
+      const result = validateSortParams(req, res, SORTABLE_COLUMNS);
+
+      should(result).deepEqual({ sort: 'massif_name', order: 'asc' });
+      should(res.badRequest.called).be.false();
+    });
+  });
+});

--- a/test/integration/4_routes/Countries/get-entrances-data-quality.test.js
+++ b/test/integration/4_routes/Countries/get-entrances-data-quality.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
+const { describeSortAndOrder } = require('../_helpers/sortOrderTests');
 
 describe('Country entrances data quality features', () => {
   describe('get-entrances-data-quality', () => {
@@ -45,6 +46,12 @@ describe('Country entrances data quality features', () => {
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(200);
+    });
+  });
+
+  describe('sort and order parameters', () => {
+    describeSortAndOrder('/api/v1/entrances/with-quality/countries/FR', {
+      supportsMassifName: false,
     });
   });
 });

--- a/test/integration/4_routes/Massifs/get-entrances-data-quality.test.js
+++ b/test/integration/4_routes/Massifs/get-entrances-data-quality.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
+const { describeSortAndOrder } = require('../_helpers/sortOrderTests');
 
 describe('Massif entrances data quality features', () => {
   describe('get-entrances-data-quality', () => {
@@ -46,5 +47,9 @@ describe('Massif entrances data quality features', () => {
         .set('Accept', 'application/json')
         .expect(200);
     });
+  });
+
+  describe('sort and order parameters', () => {
+    describeSortAndOrder('/api/v1/entrances/with-quality/massifs/1');
   });
 });

--- a/test/integration/4_routes/Regions/get-entrances-data-quality.test.js
+++ b/test/integration/4_routes/Regions/get-entrances-data-quality.test.js
@@ -1,5 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
+const { describeSortAndOrder } = require('../_helpers/sortOrderTests');
 
 describe('Region entrances data quality features', () => {
   describe('get-entrances-data-quality', () => {
@@ -108,5 +109,12 @@ describe('Region entrances data quality features', () => {
         .set('Accept', 'application/json')
         .expect(404, done);
     });
+  });
+
+  describe('sort and order parameters', () => {
+    describeSortAndOrder(
+      '/api/v1/entrances/with-quality/countries/FR/regions/01',
+      { supportsMassifName: false }
+    );
   });
 });

--- a/test/integration/4_routes/_helpers/sortOrderTests.js
+++ b/test/integration/4_routes/_helpers/sortOrderTests.js
@@ -1,0 +1,88 @@
+const supertest = require('supertest');
+const should = require('should');
+
+/**
+ * Shared sort/order integration tests for with-quality endpoints.
+ * Call inside a describe() block — generates it() tests.
+ *
+ * @param {string} baseUrl - The endpoint URL that returns 200 for a valid entity
+ *   e.g. '/api/v1/entrances/with-quality/massifs/1'
+ * @param {Object} [options]
+ * @param {boolean} [options.supportsMassifName=true] - Whether the endpoint
+ *   supports sorting by massif_name. Country and region endpoints do not.
+ */
+const describeSortAndOrder = (baseUrl, options = {}) => {
+  const { supportsMassifName = true } = options;
+
+  it('should return 200 with valid sort and order', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .get(`${baseUrl}?sort=entrance_name&order=desc`)
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    should(res.body).have.property('quality');
+    should(res.body).have.property('totalCount');
+    should(res.body).have.property('totalPages');
+  });
+
+  it('should return 400 for invalid sort column with descriptive message', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .get(`${baseUrl}?sort=invalid_column`)
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(400);
+
+    should(res.body).have.property('message');
+    should(res.body.message).containEql('Invalid sort column');
+    should(res.body.message).containEql('entrance_name');
+  });
+
+  it('should return 400 for invalid order value with descriptive message', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .get(`${baseUrl}?sort=entrance_name&order=invalid`)
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(400);
+
+    should(res.body).have.property('message');
+    should(res.body.message).containEql('Invalid order value');
+  });
+
+  it('should return 200 with sort but no order (defaults to asc)', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .get(`${baseUrl}?sort=entrance_name`)
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    should(res.body).have.property('quality');
+    should(res.body).have.property('totalCount');
+  });
+
+  it('should return 200 with order but no sort (order ignored)', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .get(`${baseUrl}?order=desc`)
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    should(res.body).have.property('quality');
+    should(res.body).have.property('totalCount');
+  });
+
+  if (!supportsMassifName) {
+    it('should return 400 when sorting by massif_name (not available on this endpoint)', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .get(`${baseUrl}?sort=massif_name&order=asc`)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400);
+
+      should(res.body).have.property('message');
+      should(res.body.message).containEql('Invalid sort column');
+    });
+  }
+};
+
+module.exports = { describeSortAndOrder };


### PR DESCRIPTION
## 🤔 What

- Add server-side `sort` and `order` query parameters to the three `*/with-quality/*` endpoints
- Sorting is applied at the SQL level **before** pagination (`ORDER BY` before `LIMIT`/`OFFSET`)
- Closes #1512

Affected endpoints:
- `GET /api/v1/entrances/with-quality/massifs/:id`
- `GET /api/v1/entrances/with-quality/countries/:id`
- `GET /api/v1/entrances/with-quality/countries/:countryId/regions/:regionId`

## 🤷‍♂️ Why

The front-end currently sorts only the current page of results client-side (see [grottocenter-front#1245](https://github.com/GrottoCenter/grottocenter-front/issues/1245)). This means page 1 doesn't necessarily show the best-quality caves — a higher-quality cave could be on page 3. Server-side sorting before pagination fixes this.

## 🔍 How

- **Shared validation utility** (`api/utils/validateSortParams.js`): extracts and validates `sort` and `order` query params against a strict allow-list of 18 columns from the `v_data_quality_compute_entrance` materialized view. Returns validated values or sends a 400 response with a descriptive error message.
- **Service layer** (`DataQualityComputeService.js`): a shared `applySort()` helper injects `ORDER BY <column> <direction>` into the SQL string before the `LIMIT` clause. The column and direction are interpolated directly (safe because allow-list validation has already occurred). Count queries are unchanged.
- **Controllers**: all three `get-entrances-data-quality.js` controllers call `validateSortParams()` and pass the result to the service.
- **Swagger**: all three endpoint paths updated with `sort` (enum of 18 columns) and `order` (enum: asc/desc, default: asc) parameter definitions, plus 400 error documentation.

**Note**: the computed `data_quality` score is calculated in JavaScript post-fetch, not stored in the materialized view, so it cannot be sorted server-side. This is a known limitation — see [comment on #1512](https://github.com/GrottoCenter/grottocenter-api/issues/1512#issuecomment-4364471871).

## 🧪 Testing

64 tests passing (27 unit/property/service + 37 integration):

- **Unit tests** (`test/integration/2_utils/validateSortParams.test.js`): 15 tests covering valid/invalid sort, valid/invalid order, case-insensitivity, defaults, edge cases
- **Property tests** (`test/integration/2_utils/validateSortParams.property.test.js`): 3 fast-check properties (100 runs each) — valid ORDER BY construction, invalid sort rejection, invalid order rejection
- **Service tests** (`test/integration/1_services/DataQualityComputeService.sort.test.js`): 9 tests verifying SQL construction for all 6 service methods
- **Integration tests** (shared via `test/integration/4_routes/_helpers/sortOrderTests.js`): 5 tests per endpoint × 3 endpoints — valid sort+order, invalid sort, invalid order, sort without order, order without sort

```bash
npm run test -- --grep "data quality|validateSortParams|DataQualityComputeService - sort"
```

## 📸 Previews

```bash
# Sort by name descending
curl 'http://localhost:1337/api/v1/entrances/with-quality/countries/FR?sort=entrance_name&order=desc&limit=3'

# Invalid sort column → 400
curl 'http://localhost:1337/api/v1/entrances/with-quality/countries/FR?sort=hacked_column'
# → {"message":"Invalid sort column 'hacked_column'. Valid columns: entrance_name, ..."}

# Invalid order → 400
curl 'http://localhost:1337/api/v1/entrances/with-quality/countries/FR?sort=entrance_name&order=sideways'
# → {"message":"Invalid order value 'sideways'. Must be 'asc' or 'desc'"}
```
