### PR TITLE
feat(notification): notify document author on validation and rejection

### DIFF
--- a/api/controllers/v1/document/multiple-validate.js
+++ b/api/controllers/v1/document/multiple-validate.js
@@ -85,6 +85,8 @@ async function updateSearchAndNotify(req, documentId, userId) {
     NotificationService.NOTIFICATION_TYPES.VALIDATE,
     NotificationService.NOTIFICATION_ENTITIES.DOCUMENT
   );
+
+  return document;
 }
 
 module.exports = async (req, res) => {
@@ -121,6 +123,7 @@ module.exports = async (req, res) => {
   const documentIds = documentChanges.map((e) => e.id);
   const foundDocuments = await TDocument.find({ id: documentIds });
 
+  // Sequential to preserve partial-success semantics per document
   for (const document of foundDocuments) {
     const change = documentChanges.find((d) => d.id === document.id);
     const isAModifiedDoc = !!document.modifiedDocJson;
@@ -131,6 +134,24 @@ module.exports = async (req, res) => {
         document.id,
         change.validationComment,
         req.token.id
+      );
+      // eslint-disable-next-line no-await-in-loop
+      const rejectedDoc = await DocumentService.getPopulatedDocument(
+        document.id
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await NotificationService.notifyAuthor(
+        req,
+        rejectedDoc,
+        req.token.id,
+        NotificationService.NOTIFICATION_TYPES.REJECT,
+        change.validationComment
+      ).catch((err) =>
+        sails.log.error(
+          'Document multiple-validate notifyAuthor error',
+          document,
+          err
+        )
       );
       continue; // eslint-disable-line no-continue
     }
@@ -153,13 +174,35 @@ module.exports = async (req, res) => {
     }
 
     // eslint-disable-next-line no-await-in-loop
-    await updateSearchAndNotify(res, document.id, req.token.id).catch((err) =>
+    const populatedDoc = await updateSearchAndNotify(
+      req,
+      document.id,
+      req.token.id
+    ).catch((err) => {
       sails.log.error(
         'Document multiple validate updateSearchAndNotify error',
         document,
         err
-      )
-    );
+      );
+      return null;
+    });
+
+    if (populatedDoc) {
+      // eslint-disable-next-line no-await-in-loop
+      await NotificationService.notifyAuthor(
+        req,
+        populatedDoc,
+        req.token.id,
+        NotificationService.NOTIFICATION_TYPES.VALIDATE,
+        change.validationComment
+      ).catch((err) =>
+        sails.log.error(
+          'Document multiple-validate notifyAuthor error',
+          document,
+          err
+        )
+      );
+    }
   }
 
   return res.ok();

--- a/api/controllers/v1/document/validate.js
+++ b/api/controllers/v1/document/validate.js
@@ -35,9 +35,9 @@ module.exports = async (req, res) => {
     validator: req.token.id,
   });
 
-  let populatedDoc;
+  const populatedDoc = await DocumentService.getPopulatedDocument(id);
+
   if (isValidated) {
-    populatedDoc = await DocumentService.getPopulatedDocument(id);
     await DocumentService.updateInSearch(populatedDoc);
 
     await NotificationService.notifySubscribers(
@@ -48,6 +48,19 @@ module.exports = async (req, res) => {
       NotificationService.NOTIFICATION_ENTITIES.DOCUMENT
     );
   }
+
+  // Notify author for both acceptance and rejection
+  await NotificationService.notifyAuthor(
+    req,
+    populatedDoc,
+    req.token.id,
+    isValidated
+      ? NotificationService.NOTIFICATION_TYPES.VALIDATE
+      : NotificationService.NOTIFICATION_TYPES.REJECT,
+    validationComment
+  ).catch((err) =>
+    sails.log.error('Document validate notifyAuthor error', err)
+  );
 
   const params = {
     controllerMethod: 'DocumentController.validate',

--- a/api/services/NotificationService.js
+++ b/api/services/NotificationService.js
@@ -21,6 +21,7 @@ const NOTIFICATION_TYPES = {
   UPDATE: 'UPDATE',
   VALIDATE: 'VALIDATE',
   RESTORE: 'RESTORE',
+  REJECT: 'REJECT',
 };
 
 async function removeOlderNotifications() {
@@ -68,6 +69,7 @@ const sendNotificationEmail = async (
     [NOTIFICATION_TYPES.UPDATE]: 'updated',
     [NOTIFICATION_TYPES.VALIDATE]: 'validated',
     [NOTIFICATION_TYPES.RESTORE]: 'restored',
+    [NOTIFICATION_TYPES.REJECT]: 'rejected',
   };
 
   const actionVerb = actionVerbMap[notificationType];
@@ -133,6 +135,8 @@ const sendNotificationEmail = async (
         recipientName: user.nickname,
         subscriptionName: user.subscriptionName,
         subscriptionType: user.subscriptionType,
+        isAuthorNotification: user.isAuthorNotification || false,
+        validationComment: user.validationComment || null,
       },
     })
     .intercept('sendSESEmailError', () => {
@@ -477,6 +481,82 @@ module.exports = {
       // Fail silently to avoid sending an error to the user
       sails.log.error(
         `An error occurred when trying to notify subscribers: ${error.message} ${error.stack}`
+      );
+      return false;
+    }
+  },
+
+  /**
+   * Create an in-app notification for the document author and optionally send an email.
+   *
+   * @param {Object}  req              - Express request (carries i18n)
+   * @param {Object}  document         - Populated TDocument (must have .author)
+   * @param {Number}  moderatorId      - ID of the moderator who made the decision
+   * @param {String}  notificationType - NOTIFICATION_TYPES.VALIDATE or NOTIFICATION_TYPES.REJECT
+   * @param {String|null} validationComment - Moderator's comment (required for REJECT)
+   * @returns {Boolean} true on success, false on silent failure
+   */
+  notifyAuthor: async (
+    req,
+    document,
+    moderatorId,
+    notificationType,
+    validationComment
+  ) => {
+    const authorId = safeGetPropId('author', document);
+    if (!authorId) {
+      sails.log.debug(
+        `notifyAuthor: document ${document.id} has no author, skipping notification`
+      );
+      return true;
+    }
+    if (authorId === moderatorId) {
+      return true;
+    }
+
+    if (!Object.values(NOTIFICATION_TYPES).includes(notificationType)) {
+      throw new Error(`Invalid notification type: ${notificationType}`);
+    }
+
+    try {
+      const notificationTypeRecord = await TNotificationType.findOne({
+        name: notificationType,
+      });
+
+      if (!notificationTypeRecord) {
+        throw new Error(
+          `Notification type '${notificationType}' not found in DB — migration may not have run`
+        );
+      }
+
+      await TNotification.create({
+        dateInscription: new Date(),
+        notificationType: notificationTypeRecord.id,
+        notifier: moderatorId,
+        notified: authorId,
+        document: document.id,
+      });
+
+      const author = await TCaver.findOne(authorId);
+
+      if (author && author.sendNotificationByEmail) {
+        await sendNotificationEmail(
+          document,
+          notificationType,
+          NOTIFICATION_ENTITIES.DOCUMENT,
+          req,
+          {
+            ...author,
+            isAuthorNotification: true,
+            validationComment,
+          }
+        );
+      }
+
+      return true;
+    } catch (error) {
+      sails.log.error(
+        `An error occurred when trying to notify the document author: ${error.message} ${error.stack}`
       );
       return false;
     }

--- a/sql/10_01_add_reject_notification_type.sql
+++ b/sql/10_01_add_reject_notification_type.sql
@@ -1,0 +1,3 @@
+\c grottoce;
+
+INSERT INTO public.t_notification_type (id, "name") VALUES (7, 'REJECT') ON CONFLICT (id) DO NOTHING;

--- a/test/fixtures/tnotificationtype.json
+++ b/test/fixtures/tnotificationtype.json
@@ -14,5 +14,17 @@
   {
     "id": 4,
     "name": "VALIDATE"
+  },
+  {
+    "id": 5,
+    "name": "PERMANENT_DELETE"
+  },
+  {
+    "id": 6,
+    "name": "RESTORE"
+  },
+  {
+    "id": 7,
+    "name": "REJECT"
   }
 ]

--- a/test/integration/1_services/NotificationService.property.test.js
+++ b/test/integration/1_services/NotificationService.property.test.js
@@ -1,0 +1,319 @@
+const should = require('should');
+const sinon = require('sinon');
+const fc = require('fast-check');
+const NotificationService = require('../../../api/services/NotificationService');
+const {
+  NOTIFICATION_TYPES,
+  NOTIFICATION_ENTITIES,
+} = require('../../../api/services/NotificationService');
+
+const fakeReq = {
+  i18n: {
+    __: (message) => message,
+    getLocale: () => 'eng',
+  },
+};
+
+describe('NotificationService - Property Tests', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('Property 1: Self-notification skip', () => {
+    /**
+     * For any generated (moderatorId, authorId) pair where they are equal,
+     * calling notifyAuthor with a stubbed document SHALL NOT create a
+     * TNotification record.
+     *
+     * Validates: Requirements 2.3, 3.3
+     */
+    it('should never create a TNotification when moderatorId equals authorId', function () {
+      this.timeout(30000);
+
+      const createStub = sinon.stub(TNotification, 'create').resolves();
+      sinon.stub(TNotificationType, 'findOne').callsFake(async ({ name }) => {
+        if (name === NOTIFICATION_TYPES.REJECT) return { id: 7 };
+        return { id: 4 };
+      });
+      sinon
+        .stub(TCaver, 'findOne')
+        .resolves({ id: 1, sendNotificationByEmail: false });
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 10000 }).map((id) => ({
+            moderatorId: id,
+            authorId: id,
+          })),
+          fc.constantFrom(
+            NOTIFICATION_TYPES.VALIDATE,
+            NOTIFICATION_TYPES.REJECT
+          ),
+          async ({ moderatorId, authorId }, notificationType) => {
+            createStub.resetHistory();
+
+            const document = { id: 99, author: authorId, name: 'Test Doc' };
+            await NotificationService.notifyAuthor(
+              fakeReq,
+              document,
+              moderatorId,
+              notificationType,
+              null
+            );
+
+            should(createStub.called).be.false(
+              `TNotification.create should not be called when moderatorId (${moderatorId}) equals authorId (${authorId})`
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 2: Notifier identity', () => {
+    /**
+     * For any generated moderatorId (distinct from authorId), the notifier
+     * field on the TNotification.create call SHALL equal the moderatorId
+     * argument.
+     *
+     * Validates: Requirements 2.4, 3.4
+     */
+    it('should set the notifier field to the moderatorId argument', function () {
+      this.timeout(30000);
+
+      const createStub = sinon.stub(TNotification, 'create').resolves();
+      sinon.stub(TNotificationType, 'findOne').callsFake(async ({ name }) => {
+        if (name === NOTIFICATION_TYPES.REJECT) return { id: 7 };
+        return { id: 4 };
+      });
+      sinon
+        .stub(TCaver, 'findOne')
+        .resolves({ id: 1, sendNotificationByEmail: false });
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc
+            .tuple(
+              fc.integer({ min: 1, max: 10000 }),
+              fc.integer({ min: 1, max: 10000 })
+            )
+            .filter(([a, b]) => a !== b),
+          fc.constantFrom(
+            NOTIFICATION_TYPES.VALIDATE,
+            NOTIFICATION_TYPES.REJECT
+          ),
+          async ([moderatorId, authorId], notificationType) => {
+            createStub.resetHistory();
+
+            const document = { id: 99, author: authorId, name: 'Test Doc' };
+            await NotificationService.notifyAuthor(
+              fakeReq,
+              document,
+              moderatorId,
+              notificationType,
+              null
+            );
+
+            should(createStub.calledOnce).be.true(
+              'TNotification.create should be called once'
+            );
+
+            const createArg = createStub.firstCall.args[0];
+            should(createArg.notifier).equal(
+              moderatorId,
+              `notifier should be ${moderatorId} but was ${createArg.notifier}`
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 3: Email opt-in gate', () => {
+    /**
+     * For any generated boolean sendNotificationByEmail value on the author
+     * caver, sendNotificationEmail SHALL be called if and only if the value
+     * is true. We detect this by stubbing sails.helpers.sendEmail, which is
+     * the downstream call made by sendNotificationEmail.
+     *
+     * Validates: Requirements 4.1, 4.2
+     */
+    it('should call sendNotificationEmail iff sendNotificationByEmail is true', function () {
+      this.timeout(30000);
+
+      sinon.stub(TNotification, 'create').resolves();
+      sinon.stub(TNotificationType, 'findOne').resolves({ id: 4 });
+
+      const sendEmailWithStub = sinon.stub().returns({
+        intercept: sinon.stub().resolves(),
+      });
+      sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sendEmailWithStub,
+      });
+
+      const caverFindOneStub = sinon.stub(TCaver, 'findOne');
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.boolean(),
+          fc.constantFrom(
+            NOTIFICATION_TYPES.VALIDATE,
+            NOTIFICATION_TYPES.REJECT
+          ),
+          async (optIn, notificationType) => {
+            sendEmailWithStub.resetHistory();
+            caverFindOneStub.resolves({
+              id: 2,
+              nickname: 'TestAuthor',
+              mail: 'test@example.com',
+              sendNotificationByEmail: optIn,
+            });
+
+            const document = { id: 99, author: 2, name: 'Test Doc' };
+            await NotificationService.notifyAuthor(
+              fakeReq,
+              document,
+              1,
+              notificationType,
+              notificationType === NOTIFICATION_TYPES.REJECT
+                ? 'Some reason'
+                : null
+            );
+
+            if (optIn) {
+              should(sendEmailWithStub.calledOnce).be.true(
+                'sendNotificationEmail should be called when opt-in is true'
+              );
+            } else {
+              should(sendEmailWithStub.called).be.false(
+                'sendNotificationEmail should not be called when opt-in is false'
+              );
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 4: Rejection comment inclusion', () => {
+    /**
+     * For any generated non-empty validationComment string, when
+     * sendNotificationEmail is called with isAuthorNotification: true and
+     * NOTIFICATION_TYPES.REJECT, the call completes without error and the
+     * viewValues passed to sails.helpers.sendEmail.with include the
+     * validationComment.
+     *
+     * Validates: Requirements 4.3
+     */
+    it('should include validationComment in viewValues for rejection emails', function () {
+      this.timeout(30000);
+
+      const sendEmailWithStub = sinon.stub().returns({
+        intercept: sinon.stub().resolves(),
+      });
+      sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sendEmailWithStub,
+      });
+
+      const user = {
+        id: 1,
+        nickname: 'Test',
+        mail: 'test@test.com',
+        isAuthorNotification: true,
+        validationComment: null,
+        subscriptionName: 'France',
+        subscriptionType: 'country',
+      };
+
+      const entity = { id: 1, name: 'Test Document' };
+
+      return fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 200 }),
+          async (validationComment) => {
+            sendEmailWithStub.resetHistory();
+
+            await NotificationService.sendNotificationEmail(
+              entity,
+              NOTIFICATION_TYPES.REJECT,
+              NOTIFICATION_ENTITIES.DOCUMENT,
+              fakeReq,
+              { ...user, validationComment }
+            );
+
+            should(sendEmailWithStub.calledOnce).be.true(
+              'sails.helpers.sendEmail.with should be called once'
+            );
+
+            const callArgs = sendEmailWithStub.firstCall.args[0];
+            should(callArgs.viewValues.validationComment).equal(
+              validationComment,
+              `viewValues.validationComment should be "${validationComment}"`
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 5: Template context distinction', () => {
+    /**
+     * For any generated isAuthorNotification boolean, the sendNotificationEmail
+     * call completes without error, and the viewValues passed to
+     * sails.helpers.sendEmail.with include the correct isAuthorNotification flag.
+     *
+     * Validates: Requirements 4.5
+     */
+    it('should pass the correct isAuthorNotification flag in viewValues', function () {
+      this.timeout(30000);
+
+      const sendEmailWithStub = sinon.stub().returns({
+        intercept: sinon.stub().resolves(),
+      });
+      sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sendEmailWithStub,
+      });
+
+      const entity = { id: 1, name: 'Test Document' };
+
+      return fc.assert(
+        fc.asyncProperty(fc.boolean(), async (isAuthorNotification) => {
+          sendEmailWithStub.resetHistory();
+
+          const user = {
+            id: 1,
+            nickname: 'Test',
+            mail: 'test@test.com',
+            isAuthorNotification,
+            validationComment: isAuthorNotification ? 'Some reason' : null,
+            subscriptionName: 'France',
+            subscriptionType: 'country',
+          };
+
+          await NotificationService.sendNotificationEmail(
+            entity,
+            NOTIFICATION_TYPES.VALIDATE,
+            NOTIFICATION_ENTITIES.DOCUMENT,
+            fakeReq,
+            user
+          );
+
+          should(sendEmailWithStub.calledOnce).be.true(
+            'sails.helpers.sendEmail.with should be called once'
+          );
+
+          const callArgs = sendEmailWithStub.firstCall.args[0];
+          should(callArgs.viewValues.isAuthorNotification).equal(
+            isAuthorNotification,
+            `viewValues.isAuthorNotification should be ${isAuthorNotification}`
+          );
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/1_services/NotificationService.test.js
+++ b/test/integration/1_services/NotificationService.test.js
@@ -1,10 +1,12 @@
 const should = require('should');
+const sinon = require('sinon');
 const CaveService = require('../../../api/services/CaveService');
 const NotificationService = require('../../../api/services/NotificationService');
 const {
   NOTIFICATION_ENTITIES,
   NOTIFICATION_TYPES,
 } = require('../../../api/services/NotificationService');
+const tnotificationtypeFixture = require('../../fixtures/tnotificationtype.json');
 
 describe('NotificationService', () => {
   const fakeReq = {
@@ -13,6 +15,34 @@ describe('NotificationService', () => {
       getLocale: () => 'eng',
     },
   };
+
+  describe('REJECT notification type', () => {
+    it('should have REJECT in NOTIFICATION_TYPES with value "REJECT"', () => {
+      should(NOTIFICATION_TYPES).have.property('REJECT');
+      should(NOTIFICATION_TYPES.REJECT).equal('REJECT');
+    });
+
+    it('should have a REJECT entry with id 7 in the tnotificationtype fixture', () => {
+      const rejectEntry = tnotificationtypeFixture.find(
+        (entry) => entry.name === 'REJECT'
+      );
+      should(rejectEntry).not.be.undefined();
+      should(rejectEntry.id).equal(7);
+      should(rejectEntry.name).equal('REJECT');
+    });
+
+    it('should not throw when sendNotificationEmail is called with REJECT type', async () => {
+      const user = await TCaver.findOne(1);
+      await NotificationService.sendNotificationEmail(
+        { id: 1, name: 'test document' },
+        NOTIFICATION_TYPES.REJECT,
+        NOTIFICATION_ENTITIES.DOCUMENT,
+        fakeReq,
+        user
+      );
+    });
+  });
+
   describe('sendNotificationEmail()', () => {
     let user;
     before(async () => {
@@ -188,6 +218,40 @@ describe('NotificationService', () => {
       } catch (error) {
         should(error.message).containEql("Can't find related entity");
       }
+    });
+
+    it('should complete without error for author rejection email', async () => {
+      await NotificationService.sendNotificationEmail(
+        { id: 1, name: 'Test Document' },
+        NOTIFICATION_TYPES.REJECT,
+        NOTIFICATION_ENTITIES.DOCUMENT,
+        fakeReq,
+        {
+          ...user,
+          isAuthorNotification: true,
+          validationComment: 'Incomplete metadata',
+        }
+      );
+    });
+
+    it('should complete without error for author acceptance email', async () => {
+      await NotificationService.sendNotificationEmail(
+        { id: 1, name: 'Test Document' },
+        NOTIFICATION_TYPES.VALIDATE,
+        NOTIFICATION_ENTITIES.DOCUMENT,
+        fakeReq,
+        { ...user, isAuthorNotification: true, validationComment: null }
+      );
+    });
+
+    it('should complete without error for default subscriber email', async () => {
+      await NotificationService.sendNotificationEmail(
+        { id: 1, name: 'Test Document' },
+        NOTIFICATION_TYPES.VALIDATE,
+        NOTIFICATION_ENTITIES.DOCUMENT,
+        fakeReq,
+        { ...user, isAuthorNotification: false }
+      );
     });
   });
 
@@ -463,6 +527,202 @@ describe('NotificationService', () => {
         NOTIFICATION_ENTITIES.COMMENT
       );
       should(res).not.be.false();
+    });
+  });
+
+  describe('notifyAuthor()', () => {
+    // Document 1 has author: 1 (Admin1)
+    // Caver 3 (User1) is NOT the author — use as moderator
+    const moderatorId = 3;
+    const authorId = 1;
+    const createdNotificationIds = [];
+    let sendEmailStub;
+
+    after(async () => {
+      if (createdNotificationIds.length > 0) {
+        await TNotification.destroy({ id: createdNotificationIds });
+      }
+      // Restore sendNotificationByEmail to default for author caver
+      await TCaver.updateOne({ id: authorId }).set({
+        sendNotificationByEmail: false,
+      });
+    });
+
+    afterEach(() => {
+      if (sendEmailStub) {
+        sendEmailStub.restore();
+        sendEmailStub = null;
+      }
+    });
+
+    const trackNotifications = async (callback) => {
+      const beforeIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      const result = await callback();
+      const afterIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      const newIds = afterIds.filter((id) => !beforeIds.includes(id));
+      createdNotificationIds.push(...newIds);
+      return { newIds, result };
+    };
+
+    it('should create a VALIDATE notification for the document author on acceptance', async () => {
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+      const validateTypeId = (
+        await TNotificationType.findOne({ name: NOTIFICATION_TYPES.VALIDATE })
+      ).id;
+
+      const { newIds } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.VALIDATE,
+          null
+        )
+      );
+
+      should(newIds).have.length(1);
+      const notification = await TNotification.findOne({ id: newIds[0] });
+      should(notification.notified).equal(authorId);
+      should(notification.document).equal(document.id);
+      should(notification.notificationType).equal(validateTypeId);
+    });
+
+    it('should create a REJECT notification for the document author on rejection', async () => {
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+      const rejectTypeId = (
+        await TNotificationType.findOne({ name: NOTIFICATION_TYPES.REJECT })
+      ).id;
+
+      const { newIds } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.REJECT,
+          'Incomplete metadata'
+        )
+      );
+
+      should(newIds).have.length(1);
+      const notification = await TNotification.findOne({ id: newIds[0] });
+      should(notification.notified).equal(authorId);
+      should(notification.document).equal(document.id);
+      should(notification.notificationType).equal(rejectTypeId);
+    });
+
+    it('should skip notification when moderator is the document author', async () => {
+      // Use authorId as both moderator and author (self-notification)
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+
+      const { newIds, result } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          authorId,
+          NOTIFICATION_TYPES.VALIDATE,
+          null
+        )
+      );
+
+      should(result).equal(true);
+      should(newIds).have.length(0);
+    });
+
+    it('should set the notifier field to the moderator ID', async () => {
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+
+      const { newIds } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.VALIDATE,
+          null
+        )
+      );
+
+      should(newIds).have.length(1);
+      const notification = await TNotification.findOne({ id: newIds[0] });
+      should(notification.notifier).equal(moderatorId);
+    });
+
+    it('should return early when document has no author', async () => {
+      const document = { id: 1, name: 'Test Document' };
+
+      const { newIds, result } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.VALIDATE,
+          null
+        )
+      );
+
+      should(result).equal(true);
+      should(newIds).have.length(0);
+    });
+
+    it('should send email when author has sendNotificationByEmail: true', async () => {
+      await TCaver.updateOne({ id: authorId }).set({
+        sendNotificationByEmail: true,
+      });
+
+      sendEmailStub = sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sinon.stub().returns({
+          intercept: sinon.stub().resolves(),
+        }),
+      });
+
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+
+      const { newIds } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.REJECT,
+          'Missing references'
+        )
+      );
+
+      should(newIds).have.length(1);
+      should(sails.helpers.sendEmail.with.calledOnce).be.true();
+
+      const callArgs = sails.helpers.sendEmail.with.firstCall.args[0];
+      should(callArgs.viewValues.isAuthorNotification).equal(true);
+      should(callArgs.viewValues.validationComment).equal('Missing references');
+    });
+
+    it('should not send email when author has sendNotificationByEmail: false', async () => {
+      await TCaver.updateOne({ id: authorId }).set({
+        sendNotificationByEmail: false,
+      });
+
+      sendEmailStub = sinon.stub(sails.helpers, 'sendEmail').value({
+        with: sinon.stub().returns({
+          intercept: sinon.stub().resolves(),
+        }),
+      });
+
+      const document = { id: 1, author: authorId, name: 'Test Document' };
+
+      const { newIds } = await trackNotifications(() =>
+        NotificationService.notifyAuthor(
+          fakeReq,
+          document,
+          moderatorId,
+          NOTIFICATION_TYPES.VALIDATE,
+          null
+        )
+      );
+
+      should(newIds).have.length(1);
+      should(sails.helpers.sendEmail.with.called).be.false();
     });
   });
 });

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -162,4 +162,189 @@ describe('Document multiple-validate', () => {
       should(updated.modifiedDocJson).be.null();
     });
   });
+
+  describe('Author notifications', () => {
+    // Moderator1 (caver ID 2) validates/rejects documents
+    // VALIDATE type ID = 4, REJECT type ID = 7
+    const VALIDATE_TYPE_ID = 4;
+    const REJECT_TYPE_ID = 7;
+    const createdNotificationIds = [];
+    const createdDocumentIds = [];
+
+    after(async () => {
+      if (createdNotificationIds.length > 0) {
+        await TNotification.destroy({ id: createdNotificationIds });
+      }
+      if (createdDocumentIds.length > 0) {
+        await TDocument.destroy({ id: createdDocumentIds });
+      }
+    });
+
+    const trackNotifications = async (callback) => {
+      const beforeIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      await callback();
+      const afterIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      const newIds = afterIds.filter((id) => !beforeIds.includes(id));
+      createdNotificationIds.push(...newIds);
+      return newIds;
+    };
+
+    it('should create a VALIDATE author notification when accepting a document via batch', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: doc.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+      });
+
+      const authorNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: doc.id,
+        notificationType: VALIDATE_TYPE_ID,
+      });
+      should(authorNotification).not.be.undefined();
+      should(authorNotification.notifier).equal(2);
+    });
+
+    it('should create a REJECT author notification when rejecting a document via batch', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [
+              {
+                id: doc.id,
+                isValidated: 'false',
+                validationComment: 'Needs revision',
+              },
+            ],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+      });
+
+      const authorNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: doc.id,
+        notificationType: REJECT_TYPE_ID,
+      });
+      should(authorNotification).not.be.undefined();
+      should(authorNotification.notifier).equal(2);
+    });
+
+    it('should NOT create author notifications when moderator is the author', async () => {
+      const doc = await TDocument.create({
+        author: 2,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: doc.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+      });
+
+      const selfNotification = newIds.length
+        ? await TNotification.find({
+            id: newIds,
+            notified: 2,
+            document: doc.id,
+          })
+        : [];
+      should(selfNotification).have.length(0);
+    });
+
+    it('should create correct notification types for a mixed batch', async () => {
+      const acceptedDoc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(acceptedDoc.id);
+
+      const rejectedDoc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(rejectedDoc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [
+              { id: acceptedDoc.id, isValidated: 'true' },
+              {
+                id: rejectedDoc.id,
+                isValidated: 'false',
+                validationComment: 'Incomplete data',
+              },
+            ],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+      });
+
+      const validateNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: acceptedDoc.id,
+        notificationType: VALIDATE_TYPE_ID,
+      });
+      should(validateNotification).not.be.undefined();
+      should(validateNotification.notifier).equal(2);
+
+      const rejectNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: rejectedDoc.id,
+        notificationType: REJECT_TYPE_ID,
+      });
+      should(rejectNotification).not.be.undefined();
+      should(rejectNotification.notifier).equal(2);
+    });
+  });
 });

--- a/test/integration/4_routes/Documents/validate.test.js
+++ b/test/integration/4_routes/Documents/validate.test.js
@@ -64,11 +64,165 @@ describe('Document validate', () => {
         .set('Authorization', moderatorToken)
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
-        .expect(404);
+        .expect(200);
 
       const updated = await TDocument.findOne(doc.id);
       should(updated.isValidated).be.false();
       should(updated.validationComment).equal('Test rejection');
+    });
+  });
+
+  describe('Author notifications', () => {
+    // Moderator1 (caver ID 2) validates/rejects documents
+    // VALIDATE type ID = 4, REJECT type ID = 7
+    const VALIDATE_TYPE_ID = 4;
+    const REJECT_TYPE_ID = 7;
+    const createdNotificationIds = [];
+    const createdDocumentIds = [];
+
+    after(async () => {
+      if (createdNotificationIds.length > 0) {
+        await TNotification.destroy({ id: createdNotificationIds });
+      }
+      if (createdDocumentIds.length > 0) {
+        await TDocument.destroy({ id: createdDocumentIds });
+      }
+    });
+
+    const trackNotifications = async (callback) => {
+      const beforeIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      await callback();
+      const afterIds = (await TNotification.find().select(['id'])).map(
+        (n) => n.id
+      );
+      const newIds = afterIds.filter((id) => !beforeIds.includes(id));
+      createdNotificationIds.push(...newIds);
+      return newIds;
+    };
+
+    it('should create a VALIDATE author notification when accepting a document', async () => {
+      // Author 1 (Admin1) is different from moderator (caver 2)
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/documents/${doc.id}/validate`)
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+      });
+
+      // Find the author notification (notified = author 1, document = doc.id)
+      const authorNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: doc.id,
+        notificationType: VALIDATE_TYPE_ID,
+      });
+      should(authorNotification).not.be.undefined();
+      should(authorNotification.notifier).equal(2);
+    });
+
+    it('should create a REJECT author notification when rejecting a document', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put(
+            `/api/v1/documents/${doc.id}/validate?isValidated=false&validationComment=Needs more detail`
+          )
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+      });
+
+      const authorNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: doc.id,
+        notificationType: REJECT_TYPE_ID,
+      });
+      should(authorNotification).not.be.undefined();
+      should(authorNotification.notifier).equal(2);
+    });
+
+    it('should NOT create an author notification when moderator is the author', async () => {
+      // Create a document where author = 2 (moderator1's caver ID)
+      const doc = await TDocument.create({
+        author: 2,
+        type: 1,
+        license: 1,
+        isValidated: false,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/documents/${doc.id}/validate`)
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+      });
+
+      // No notification should exist for the author (who is the moderator)
+      const selfNotification = newIds.length
+        ? await TNotification.find({
+            id: newIds,
+            notified: 2,
+            document: doc.id,
+          })
+        : [];
+      should(selfNotification).have.length(0);
+    });
+
+    it('should still create geographic subscriber notifications on acceptance', async () => {
+      // Create a document with an entrance linked to a country with subscribers
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+        entrance: 1,
+      }).fetch();
+      createdDocumentIds.push(doc.id);
+
+      const newIds = await trackNotifications(async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/documents/${doc.id}/validate`)
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+      });
+
+      // Should have at least the author notification
+      const authorNotification = await TNotification.findOne({
+        id: newIds,
+        notified: 1,
+        document: doc.id,
+        notificationType: VALIDATE_TYPE_ID,
+      });
+      should(authorNotification).not.be.undefined();
+
+      // The geographic subscriber flow should also have run (total notifications >= 1)
+      should(newIds.length).be.greaterThanOrEqual(1);
     });
   });
 });

--- a/views/emailTemplates/notification.ejs
+++ b/views/emailTemplates/notification.ejs
@@ -10,7 +10,11 @@
         - entityType        String      Entity concerned by the notification type
         - recipientName     String      Full name or nickname of the recipient
         - subscriptionName  String      The subscription name which generated this notification
-        - subscriptionTypeame  String   The subscription type which generated this notification
+        - subscriptionType   String   The subscription type which generated this notification
+
+    Optional values:
+        - isAuthorNotification  Boolean      Whether this is an author validation notification (defaults to false)
+        - validationComment     String|null  Moderator's rejection comment (optional)
   */ %>
 
   <p>
@@ -27,6 +31,7 @@
       <% } %>
   </p>
 
+  <% if (!isAuthorNotification) { %>
   <p>
     <%if (subscriptionType === 'country') { %>
       <%- i18n.__('You are receiving this email because of your subscription to the country %s.', '<b>' +subscriptionName+'</b>') %>
@@ -35,5 +40,17 @@
       <%- i18n.__('You are receiving this email because of your subscription to the massif %s.', '<b>' +subscriptionName+'</b>') %>
     <% } %>
   </p>
+  <% } else { %>
+  <p>
+    <%- i18n.__('You are receiving this email because you are the author of this document.') %>
+  </p>
+  <% if (validationComment) { %>
+  <p>
+    <%- i18n.__('Reviewer comment:') %>
+    <br/>
+    <b><%= validationComment %></b>
+  </p>
+  <% } %>
+  <% } %>
 
   <%- include('emailFooter', { i18n: i18n }); %>


### PR DESCRIPTION
## 🤔 What

Notify the document author when a moderator validates or rejects their document.

- Add a `REJECT` notification type (constant, SQL migration, fixture)
- Add `notifyAuthor()` helper in `NotificationService` for targeted author notifications
- Integrate into both `validate.js` (single) and `multiple-validate.js` (batch) controllers
- Update `notification.ejs` email template to distinguish author notifications from geographic subscriber notifications, with rejection emails including the moderator's comment
- Fix pre-existing bug: `multiple-validate.js` passed `res` instead of `req` to `updateSearchAndNotify`

Closes #1557
Related front-end issues: GrottoCenter/grottocenter-front#1243, GrottoCenter/grottocenter-front#988

## 🤷‍♂️ Why

When a moderator validates or rejects a document, the submitting author had no way of knowing unless they checked manually. The existing `notifySubscribers` flow only notifies geographic subscribers (country/massif/region) on acceptance, and rejection triggered no notification at all.

## 🔍 How

- `notifyAuthor()` is a separate helper from `notifySubscribers()` because author notification is a single targeted recipient, not a geographic fan-out. It resolves the document's author, skips self-notification (moderator === author), creates a `TNotification` record, and optionally sends an email if the author has `sendNotificationByEmail` enabled.
- The email template uses an `isAuthorNotification` flag to switch between author context ("you are the author of this document") and the existing subscription context. Rejection emails include the `validationComment` rendered with `<%= %>` (HTML-escaped) to prevent XSS.
- Both controllers call `notifyAuthor` with `.catch()` so notification failures never break the validation response.

**Behavioral change:** The single-validate endpoint now returns 200 on rejection (previously returned 404 because `populatedDoc` was `undefined` on the rejection path). The document is now populated for both paths since `notifyAuthor` needs it.

**Front-end action needed:** The notification center UI needs to be updated to handle the new `REJECT` notification type (display it with appropriate messaging and styling, distinct from `VALIDATE`).

## 🧪 Testing

- 5 property-based tests (self-notification skip, notifier identity, email opt-in gate, rejection comment inclusion, template context distinction)
- 7 integration tests for `notifyAuthor()` service
- 3 template rendering tests
- 4 route tests for `validate.js` (accept, reject, self-skip, geographic subscriber non-regression)
- 4 route tests for `multiple-validate.js` (accept, reject, self-skip, mixed batch)

Run `npm run test` — all 2098 tests pass.

## 📸 Previews
<img width="1068" height="212" alt="Screenshot 2026-05-02 at 3 58 37 p m" src="https://github.com/user-attachments/assets/884461f9-c36c-4f9e-af19-1615074f64c8" />
<img width="1092" height="262" alt="Screenshot 2026-05-02 at 3 57 27 p m" src="https://github.com/user-attachments/assets/42d33a97-6f17-46df-b326-ed876b07592a" />
<img width="1046" height="266" alt="Screenshot 2026-05-02 at 3 50 39 p m" src="https://github.com/user-attachments/assets/9db11769-41d0-41e7-a9b3-9484b43e2659" />

