### PR TITLE
refactor(rateLimit): introduce tiered rate limiting by role

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -31,8 +31,7 @@ module.exports.http = {
   middleware: {
     // Requests limiter configuration
     generalRateLimit: rateLimiter.generalRateLimit,
-    userDeleteRateLimit: rateLimiter.userDeleteRateLimit,
-    moderatorDeleteRateLimit: rateLimiter.moderatorDeleteRateLimit,
+    deleteRateLimit: rateLimiter.deleteRateLimit,
 
     /** *************************************************************************
      *                                                                          *
@@ -46,8 +45,7 @@ module.exports.http = {
       'corsHeaders',
       'parseAuthToken',
       'generalRateLimit',
-      'userDeleteRateLimit',
-      'moderatorDeleteRateLimit',
+      'deleteRateLimit',
       'responseTimeLogger',
       'requestLogger',
       'fileMiddleware',

--- a/config/rateLimit/rateLimiter.js
+++ b/config/rateLimit/rateLimiter.js
@@ -1,130 +1,125 @@
 const rateLimit = require('express-rate-limit');
 const RightService = require('../../api/services/RightService');
 
+// 10-minute window for general requests
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+// 1-hour window for DELETE requests
+const DELETE_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+// General request limits per 10-minute window, by role.
+// Each tier can be overridden via environment variables for tuning in production.
+// We use ?? so that an explicit `0` is honoured (e.g. to fully block a tier).
+const parseLimit = (envValue, fallback) => {
+  if (envValue === undefined) return fallback;
+  const n = Number(envValue);
+  return Number.isNaN(n) ? fallback : n;
+};
+
+const VISITOR_MAX = parseLimit(process.env.VISITOR_RATE_LIMIT, 200);
+const USER_MAX = parseLimit(process.env.USER_RATE_LIMIT, 400);
+const LEADER_MAX = parseLimit(process.env.LEADER_RATE_LIMIT, 1000);
+const MODERATOR_MAX = parseLimit(process.env.MODERATOR_RATE_LIMIT, 10000);
+// Administrators are not rate-limited (skip returns true)
+
+// DELETE request limits per 1-hour window, by role
+const USER_DELETE_MAX = parseLimit(process.env.USER_DELETE_RATE_LIMIT, 1);
+const DELETE_MAX = parseLimit(process.env.DELETE_RATE_LIMIT, 20);
+// Administrators are not rate-limited on DELETEs either
+
+const isTestOrDev = () =>
+  process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+
+/**
+ * Returns the general rate limit for a request based on the caller's role.
+ * Unauthenticated visitors get the lowest cap; higher roles get progressively
+ * more headroom. Administrators are skipped entirely (see `skip`).
+ */
+const generalMax = (req) => {
+  if (!req.token) return VISITOR_MAX;
+
+  const { groups } = req.token;
+  if (RightService.hasGroup(groups, RightService.G.MODERATOR)) {
+    return MODERATOR_MAX;
+  }
+  if (RightService.hasGroup(groups, RightService.G.LEADER)) {
+    return LEADER_MAX;
+  }
+  return USER_MAX;
+};
+
+/**
+ * Returns the DELETE rate limit for a request based on the caller's role.
+ * Regular users get a very tight cap; leaders and moderators share a higher
+ * one. Administrators are skipped entirely (see `skip`).
+ *
+ * Note: all DELETE routes require `tokenAuth` (see config/policies.js), so
+ * unauthenticated requests are rejected before reaching the controller.
+ * The !req.token branch below is defense-in-depth in case a DELETE route is
+ * ever exposed without auth — it applies the most restrictive limit.
+ */
+const deleteMax = (req) => {
+  if (!req.token) return USER_DELETE_MAX;
+
+  const { groups } = req.token;
+  if (
+    RightService.hasGroup(groups, RightService.G.MODERATOR) ||
+    RightService.hasGroup(groups, RightService.G.LEADER)
+  ) {
+    return DELETE_MAX;
+  }
+  return USER_DELETE_MAX;
+};
+
 module.exports = {
   generalRateLimit: rateLimit({
-    windowMs: process.env.RATE_LIMIT_WINDOW
-      ? process.env.RATE_LIMIT_WINDOWS
-      : 1 * 30 * 1000, // 30 seconds
-    max: process.env.RATE_LIMIT_PER_WINDOW
-      ? process.env.RATE_LIMIT_PER_WINDOW
-      : 100, // limit each IP to 100 requests per windowMs
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    max: generalMax,
     message: 'Too many requests with the same IP, try again later.',
     standardHeaders: true,
     statusCode: 429,
-    skip: async (req) => {
-      // Ignore OPTIONS request
-      if (req.method.toUpperCase() === 'OPTIONS') {
-        return true;
-      }
+    skip: (req) => {
+      if (req.method.toUpperCase() === 'OPTIONS') return true;
+      if (isTestOrDev()) return true;
 
-      // Ignore limiting when in test or development
+      // Administrators bypass general rate limiting
       if (
-        process.env.NODE_ENV === 'test' ||
-        process.env.NODE_ENV === 'development'
+        req.token &&
+        RightService.hasGroup(req.token.groups, RightService.G.ADMINISTRATOR)
       ) {
         return true;
       }
 
-      // If you are not authenticated, you are limited
-      if (!req.token) {
-        return false;
-      }
-      const hasNoRequestLimit =
-        RightService.hasGroup(req.token.groups, RightService.G.ADMINISTRATOR) ||
-        RightService.hasGroup(req.token.groups, RightService.G.MODERATOR);
-
-      return hasNoRequestLimit;
+      return false;
     },
   }),
 
-  userDeleteRateLimit: rateLimit({
-    windowMs: process.env.USER_DELETE_RATE_LIMIT_WINDOWS
-      ? process.env.USER_DELETE_RATE_LIMIT_WINDOWS
-      : 12 * 60 * 60 * 1000, // 12h
-    max: process.env.USER_DELETE_RATE_LIMIT_PER_WINDOW
-      ? process.env.USER_DELETE_RATE_LIMIT_PER_WINDOW
-      : 1, // limit each IP to 1 request per windowMs
-    message:
-      'Too many DELETE requests with the same IP as an user, try again later.',
+  deleteRateLimit: rateLimit({
+    windowMs: DELETE_RATE_LIMIT_WINDOW_MS,
+    max: deleteMax,
+    message: 'Too many DELETE requests with the same IP, try again later.',
     standardHeaders: true,
     statusCode: 429,
-    skip: async (req) => {
-      // Ignore request others than DELETE
-      if (req.method.toUpperCase() !== 'DELETE') {
-        return true;
-      }
-      // Skip rate limiting in development/test
+    skip: (req) => {
+      if (req.method.toUpperCase() !== 'DELETE') return true;
+      if (isTestOrDev()) return true;
+
+      // Administrators bypass DELETE rate limiting
       if (
-        process.env.NODE_ENV === 'test' ||
-        process.env.NODE_ENV === 'development'
+        req.token &&
+        RightService.hasGroup(req.token.groups, RightService.G.ADMINISTRATOR)
       ) {
         return true;
       }
-      // If you are not authenticated, you are limited
-      if (!req.token) {
-        return false;
-      }
-      // If the request doesn't come from our main client, you are limited
-      if (req.headers.origin !== sails.config.custom.baseUrl) {
+
+      // Third-party origins are always limited (handled by generalRateLimit)
+      if (req.token && req.headers.origin !== sails.config.custom.baseUrl) {
         sails.log.error(
-          `User ${req.token.nickname} (id=${req.token.id}) is being limited because the request doesn't come from our main client app.`
+          `User ${req.token.nickname} (id=${req.token.id}) is being limited on DELETE requests because the request doesn't come from our main client app.`
         );
         return false;
       }
 
-      const hasNoRequestLimit =
-        RightService.hasGroup(req.token.groups, RightService.G.ADMINISTRATOR) ||
-        RightService.hasGroup(req.token.groups, RightService.G.MODERATOR);
-      if (!hasNoRequestLimit) {
-        sails.log.error(
-          `User ${req.token.nickname} (id=${req.token.id}) is being limited on DELETE requests as an user.`
-        );
-      }
-
-      return hasNoRequestLimit;
-    },
-  }),
-
-  moderatorDeleteRateLimit: rateLimit({
-    windowMs: process.env.MODERATOR_DELETE_RATE_LIMIT_WINDOWS
-      ? process.env.MODERATOR_DELETE_RATE_LIMIT_WINDOWS
-      : 1 * 60 * 60 * 1000, // 1h
-    max: process.env.MODERATOR_DELETE_RATE_LIMIT_PER_WINDOW
-      ? process.env.MODERATOR_DELETE_RATE_LIMIT_PER_WINDOW
-      : 20, // limit each IP to  request per windowMs
-    message:
-      'Too many DELETE requests with the same IP as a moderator, try again later.',
-    standardHeaders: true,
-    statusCode: 429,
-    skip: async (req) => {
-      // Ignore request others than DELETE
-      if (req.method.toUpperCase() !== 'DELETE') {
-        return true;
-      }
-      // Skip rate limiting in development/test
-      if (
-        process.env.NODE_ENV === 'test' ||
-        process.env.NODE_ENV === 'development'
-      ) {
-        return true;
-      }
-      if (!req.token) {
-        return false;
-      }
-
-      const hasNoRequestLimit = RightService.hasGroup(
-        req.token.groups,
-        RightService.G.ADMINISTRATOR
-      );
-
-      if (!hasNoRequestLimit) {
-        sails.log.error(
-          `User ${req.token.nickname} (id=${req.token.id}) is being limited on DELETE requests as an user.`
-        );
-      }
-
-      return hasNoRequestLimit;
+      return false;
     },
   }),
 };

--- a/test/integration/2_utils/rateLimiter.test.js
+++ b/test/integration/2_utils/rateLimiter.test.js
@@ -3,15 +3,44 @@ const should = require('should');
 const express = require('express');
 const supertest = require('supertest');
 
+// Use low limits in tests to avoid socket exhaustion from too many requests
+const TEST_VISITOR_LIMIT = 10;
+const TEST_USER_LIMIT = 20;
+const TEST_MODERATOR_LIMIT = 40;
+const TEST_DELETE_LIMIT = 5;
+const TEST_USER_DELETE_LIMIT = 1;
+
+const freshRateLimiter = () => {
+  delete require.cache[
+    require.resolve('../../../config/rateLimit/rateLimiter')
+  ];
+  return require('../../../config/rateLimit/rateLimiter');
+};
+
 describe('Rate Limiter', () => {
   let originalEnv;
+  const envBackup = {};
 
   before(() => {
     originalEnv = process.env.NODE_ENV;
+    [
+      'VISITOR_RATE_LIMIT',
+      'USER_RATE_LIMIT',
+      'LEADER_RATE_LIMIT',
+      'MODERATOR_RATE_LIMIT',
+      'DELETE_RATE_LIMIT',
+      'USER_DELETE_RATE_LIMIT',
+    ].forEach((key) => {
+      envBackup[key] = process.env[key];
+    });
   });
 
   after(() => {
     process.env.NODE_ENV = originalEnv;
+    Object.entries(envBackup).forEach(([key, val]) => {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    });
     delete require.cache[
       require.resolve('../../../config/rateLimit/rateLimiter')
     ];
@@ -20,12 +49,9 @@ describe('Rate Limiter', () => {
   describe('in test environment', () => {
     it('should skip rate limiting', async () => {
       process.env.NODE_ENV = 'test';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
+      const rateLimiter = freshRateLimiter();
 
       const app = express();
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
       app.use(rateLimiter.generalRateLimit);
       app.get('/test', (req, res) => res.status(200).send('ok'));
 
@@ -37,119 +63,234 @@ describe('Rate Limiter', () => {
   });
 
   describe('in production environment', () => {
-    it('should not rate limit unauthenticated requests if under the limit', async () => {
-      process.env.NODE_ENV = 'production';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
+    let sailsBackup;
 
-      const app = express();
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
-      app.use(rateLimiter.generalRateLimit);
-      app.get('/test', (req, res) => res.status(200).send('ok'));
-
-      const agent = supertest.agent(app);
-      for (let i = 0; i < 50; i += 1) {
-        await agent.get('/test').expect(200);
-      }
+    before(() => {
+      sailsBackup = global.sails;
     });
 
-    it('should rate limit unauthenticated requests', async () => {
-      process.env.NODE_ENV = 'production';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
-
-      const app = express();
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
-      app.use(rateLimiter.generalRateLimit);
-      app.get('/test', (req, res) => res.status(200).send('ok'));
-
-      const agent = supertest.agent(app);
-      const responses = [];
-      for (let i = 0; i < 105; i += 1) {
-        const res = await agent.get('/test');
-        responses.push(res.status);
-      }
-
-      // Should have some 429 responses
-      should(responses.filter((s) => s === 429).length).be.above(0);
+    after(() => {
+      global.sails = sailsBackup;
     });
 
-    it('should not rate limit unauthenticated requests with OPTIONS even when above the limit', async () => {
+    beforeEach(() => {
       process.env.NODE_ENV = 'production';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
+      process.env.VISITOR_RATE_LIMIT = TEST_VISITOR_LIMIT;
+      process.env.USER_RATE_LIMIT = TEST_USER_LIMIT;
+      process.env.MODERATOR_RATE_LIMIT = TEST_MODERATOR_LIMIT;
+      process.env.DELETE_RATE_LIMIT = TEST_DELETE_LIMIT;
+      process.env.USER_DELETE_RATE_LIMIT = TEST_USER_DELETE_LIMIT;
 
-      const app = express();
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
-      app.use(rateLimiter.generalRateLimit);
-      app.options('/test', (req, res) => res.status(200).send('ok'));
-
-      const agent = supertest.agent(app);
-      for (let i = 0; i < 105; i += 1) {
-        await agent.options('/test').expect(200);
-      }
+      // Mock the sails global used by deleteRateLimit.skip for origin checks
+      global.sails = {
+        config: { custom: { baseUrl: 'http://localhost:1337' } },
+        log: { error: () => {}, info: () => {} },
+      };
     });
 
-    it('should not rate limit moderators when under the moderatorDeleteRateLimit', async () => {
-      process.env.NODE_ENV = 'production';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
+    describe('generalRateLimit', () => {
+      it('should not rate limit visitors under the limit', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
 
-      const app = express();
-      const RightService = require('../../../api/services/RightService');
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
-
-      app.use((req, res, next) => {
-        req.token = {
-          groups: [RightService.G.MODERATOR],
-          nickname: 'Mod',
-          id: 2,
-        };
-        next();
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_VISITOR_LIMIT - 2; i += 1) {
+          await agent.get('/test').expect(200);
+        }
       });
-      app.use(rateLimiter.moderatorDeleteRateLimit);
-      app.delete('/test', (req, res) => res.status(200).send('ok'));
 
-      const agent = supertest.agent(app);
-      for (let i = 0; i < 10; i += 1) {
-        await agent.delete('/test').expect(200);
-      }
+      it('should rate limit visitors who exceed the limit', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        const responses = [];
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 5; i += 1) {
+          const res = await agent.get('/test');
+          responses.push(res.status);
+        }
+
+        should(responses.filter((s) => s === 429).length).be.above(0);
+      });
+
+      it('should not rate limit OPTIONS requests even above the limit', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.options('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 5; i += 1) {
+          await agent.options('/test').expect(200);
+        }
+      });
+
+      it('should give authenticated users a higher limit than visitors', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = { groups: [], nickname: 'User', id: 10 };
+          next();
+        });
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        // Users get TEST_USER_LIMIT which is higher than TEST_VISITOR_LIMIT
+        // Send more than visitor limit but under user limit — all should pass
+        for (let i = 0; i < TEST_USER_LIMIT - 2; i += 1) {
+          await agent.get('/test').expect(200);
+        }
+      });
+
+      it('should rate limit authenticated users who exceed their limit', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = { groups: [], nickname: 'User', id: 10 };
+          next();
+        });
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        const responses = [];
+        for (let i = 0; i < TEST_USER_LIMIT + 5; i += 1) {
+          const res = await agent.get('/test');
+          responses.push(res.status);
+        }
+
+        should(responses.filter((s) => s === 429).length).be.above(0);
+      });
+
+      it('should skip rate limiting for administrators', async () => {
+        const RightService = require('../../../api/services/RightService');
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = {
+            groups: [{ name: RightService.G.ADMINISTRATOR }],
+            nickname: 'Admin',
+            id: 1,
+          };
+          next();
+        });
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        // Admins are skipped — send well above the moderator limit
+        for (let i = 0; i < TEST_MODERATOR_LIMIT + 10; i += 1) {
+          await agent.get('/test').expect(200);
+        }
+      });
     });
 
-    it('should rate limit moderators with moderatorDeleteRateLimit', async () => {
-      process.env.NODE_ENV = 'production';
-      delete require.cache[
-        require.resolve('../../../config/rateLimit/rateLimiter')
-      ];
+    describe('deleteRateLimit', () => {
+      it('should skip non-DELETE requests', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.deleteRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
 
-      const app = express();
-      const RightService = require('../../../api/services/RightService');
-      const rateLimiter = require('../../../config/rateLimit/rateLimiter');
-
-      app.use((req, res, next) => {
-        req.token = {
-          groups: [RightService.G.MODERATOR],
-          nickname: 'Mod',
-          id: 2,
-        };
-        next();
+        const agent = supertest.agent(app);
+        for (let i = 0; i < 15; i += 1) {
+          await agent.get('/test').expect(200);
+        }
       });
-      app.use(rateLimiter.moderatorDeleteRateLimit);
-      app.delete('/test', (req, res) => res.status(200).send('ok'));
 
-      const agent = supertest.agent(app);
-      const responses = [];
-      for (let i = 0; i < 25; i += 1) {
-        const res = await agent.delete('/test');
-        responses.push(res.status);
-      }
+      it('should rate limit unauthenticated DELETE requests after 1', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete('/test', (req, res) => res.status(200).send('ok'));
 
-      // Should have some 429 responses
-      should(responses.filter((s) => s === 429).length).be.above(0);
+        const agent = supertest.agent(app);
+        const responses = [];
+        for (let i = 0; i < 5; i += 1) {
+          const res = await agent.delete('/test');
+          responses.push(res.status);
+        }
+
+        should(responses.filter((s) => s === 429).length).be.above(0);
+      });
+
+      it('should not rate limit moderators under the delete limit', async () => {
+        const RightService = require('../../../api/services/RightService');
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = {
+            groups: [{ name: RightService.G.MODERATOR }],
+            nickname: 'Mod',
+            id: 2,
+          };
+          next();
+        });
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_DELETE_LIMIT - 1; i += 1) {
+          await agent.delete('/test').expect(200);
+        }
+      });
+
+      it('should rate limit moderators who exceed the delete limit', async () => {
+        const RightService = require('../../../api/services/RightService');
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = {
+            groups: [{ name: RightService.G.MODERATOR }],
+            nickname: 'Mod',
+            id: 2,
+          };
+          next();
+        });
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        const responses = [];
+        for (let i = 0; i < TEST_DELETE_LIMIT + 3; i += 1) {
+          const res = await agent.delete('/test');
+          responses.push(res.status);
+        }
+
+        should(responses.filter((s) => s === 429).length).be.above(0);
+      });
+
+      it('should skip rate limiting for administrators on DELETE', async () => {
+        const RightService = require('../../../api/services/RightService');
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+
+        app.use((req, res, next) => {
+          req.token = {
+            groups: [{ name: RightService.G.ADMINISTRATOR }],
+            nickname: 'Admin',
+            id: 1,
+          };
+          next();
+        });
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_DELETE_LIMIT + 10; i += 1) {
+          await agent.delete('/test').expect(200);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

Replaces the binary skip/limit rate limiting with graduated, role-based rate limits. Consolidates the two separate DELETE rate limiters into one.

Supersedes #1223.

- Closes #1157

## 🤷‍♂️ Why

The previous rate limiter had two problems:

1. **Flat limits** — everyone below Moderator got the same cap (100 req/30s), with Moderators and Admins skipping entirely. No middle ground for Leaders or regular authenticated users.
2. **Too-short window** — a 30-second window with 100 requests is easy to hit on the homepage alone (~25 API calls per load). A 10-minute window with tiered limits better matches real usage patterns.

Issue #1157 requested tiered limits per role to prevent bulk data scraping while keeping the site usable for normal visitors.

## 🔍 How

**`config/rateLimit/rateLimiter.js`** — Rewrote with two middleware:

| Middleware | Window | Visitor | User | Leader | Moderator | Admin |
|---|---|---|---|---|---|---|
| `generalRateLimit` | 10 min | 200 | 400 | 1,000 | 10,000 | skip |
| `deleteRateLimit` | 1 hour | 1 | 1 | 20 | 20 | skip |

Uses `express-rate-limit`'s `max` as a function to return different limits based on `req.token.groups`. All limits are overridable via environment variables (`VISITOR_RATE_LIMIT`, `USER_RATE_LIMIT`, etc.) for production tuning.

**`config/http.js`** — Replaced the three middleware entries (`generalRateLimit`, `userDeleteRateLimit`, `moderatorDeleteRateLimit`) with two (`generalRateLimit`, `deleteRateLimit`).

**`test/integration/2_utils/rateLimiter.test.js`** — Rewrote tests to cover all tiers. Tests use low env-var overrides to avoid socket exhaustion from too many supertest requests.

## 🧪 Testing

```shell
npm run test -- --grep "Rate Limiter"   # 12 tests
npm run test                             # Full suite — 2081 passing
```

## 📸 Previews

N/A — backend-only change.
