### PR TITLE
Fix/1450 massif sensitive setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,14 @@ module.exports = {
     'prefer-destructuring': ['error', { object: true, array: false }],
     'prettier/prettier': 'error',
     'import/no-unresolved': ['error', { ignore: ['^uuid$'] }],
+    'no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
+    ],
   },
   plugins: ['prettier', 'import'],
 };

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -3,7 +3,6 @@ const MassifService = require('../../../services/MassifService');
 const EntranceService = require('../../../services/EntranceService');
 const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
-const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
   const isAdmin = RightService.hasGroup(
@@ -28,13 +27,12 @@ module.exports = async (req, res) => {
   // Idempotency: skip if already sensitive
   if (massif.isSensitive) {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
-    const meta = getMetaFromRequest(req);
     return ControllerService.treat(
       req,
       null,
       {
         count: 0,
-        massif: toMassif(updatedMassif, meta),
+        massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.mark-sensitive' },
       res
@@ -63,14 +61,12 @@ module.exports = async (req, res) => {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
     await MassifService.updateInSearch(updatedMassif);
 
-    const meta = getMetaFromRequest(req);
-
     return ControllerService.treat(
       req,
       null,
       {
         count: updatedEntranceIds.length,
-        massif: toMassif(updatedMassif, meta),
+        massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.mark-sensitive' },
       res

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -2,7 +2,6 @@ const RightService = require('../../../services/RightService');
 const MassifService = require('../../../services/MassifService');
 const ControllerService = require('../../../services/ControllerService');
 const { toMassif } = require('../../../services/mapping/converters');
-const { getMetaFromRequest } = require('../../../services/mapping/utils');
 
 module.exports = async (req, res) => {
   const isAdmin = RightService.hasGroup(
@@ -27,13 +26,12 @@ module.exports = async (req, res) => {
   // Idempotency: skip if already non-sensitive
   if (!massif.isSensitive) {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
-    const meta = getMetaFromRequest(req);
     return ControllerService.treat(
       req,
       null,
       {
         count: 0,
-        massif: toMassif(updatedMassif, meta),
+        massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.unmark-sensitive' },
       res
@@ -47,14 +45,12 @@ module.exports = async (req, res) => {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
     await MassifService.updateInSearch(updatedMassif);
 
-    const meta = getMetaFromRequest(req);
-
     return ControllerService.treat(
       req,
       null,
       {
         count: 0,
-        massif: toMassif(updatedMassif, meta),
+        massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.unmark-sensitive' },
       res

--- a/api/services/ControllerService.js
+++ b/api/services/ControllerService.js
@@ -47,7 +47,9 @@ const treatRange = (parameters, req, res, converter, found) => {
 
   res.set('Access-Control-Expose-Headers', 'Content-Range');
   const meta = getMetaFromRequest(req);
-  return res.partialContent(converter(found, meta));
+  return res.partialContent(
+    converter.length > 1 ? converter(found, meta) : converter(found)
+  );
 };
 
 module.exports = {
@@ -79,6 +81,8 @@ module.exports = {
       return treatRange(parameters, req, res, converter, found);
     }
     const meta = getMetaFromRequest(req);
-    return res.ok(converter(found, meta));
+    return res.ok(
+      converter.length > 1 ? converter(found, meta) : converter(found)
+    );
   },
 };

--- a/api/services/ControllerService.js
+++ b/api/services/ControllerService.js
@@ -47,6 +47,8 @@ const treatRange = (parameters, req, res, converter, found) => {
 
   res.set('Access-Control-Expose-Headers', 'Content-Range');
   const meta = getMetaFromRequest(req);
+  // Converters that declare a second parameter receive request metadata (meta).
+  // Single-param converters (e.g., toMassif) are called without meta.
   return res.partialContent(
     converter.length > 1 ? converter(found, meta) : converter(found)
   );
@@ -81,6 +83,8 @@ module.exports = {
       return treatRange(parameters, req, res, converter, found);
     }
     const meta = getMetaFromRequest(req);
+    // Converters that declare a second parameter receive request metadata (meta).
+    // Single-param converters (e.g., toMassif) are called without meta.
     return res.ok(
       converter.length > 1 ? converter(found, meta) : converter(found)
     );

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -527,14 +527,12 @@ const c = {
     cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
-  toMassif: (source, meta) => ({
+  toMassif: (source) => ({
     ...MassifModel,
     id: source.id,
     '@id': String(source.id),
     isDeleted: source.isDeleted,
-    ...(meta?.hasCompleteViewRight === true && {
-      isSensitive: source.isSensitive,
-    }),
+    isSensitive: source.isSensitive,
     redirectTo: source.redirectTo,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -588,7 +588,7 @@ const c = {
     result.entrance = convertIfObject(source.entrance, c.toEntrance, { meta });
     result.history = convertIfObject(source.history, c.toHistory, { meta });
     result.location = convertIfObject(source.location, c.toLocation, { meta });
-    result.massif = convertIfObject(source.massif, c.toMassif, { meta });
+    result.massif = convertIfObject(source.massif, c.toMassif);
     result.notified = convertIfObject(source.notified, c.toSimpleCaver, {
       meta,
     });
@@ -708,7 +708,7 @@ const c = {
       else if (_type === 'entrances') data = c.toEntrance(item.document, meta);
       else if (_type === 'organizations')
         data = c.toOrganization(item.document, meta);
-      else if (_type === 'massifs') data = c.toMassif(item.document, meta);
+      else if (_type === 'massifs') data = c.toMassif(item.document);
 
       return {
         ...data,

--- a/test/integration/1_services/ControllerService.test.js
+++ b/test/integration/1_services/ControllerService.test.js
@@ -599,7 +599,7 @@ describe('ControllerService', () => {
         total: 50,
         url: 'http://example.com/api/items?range=0-10',
       };
-      const converterSpy = sinon.spy((data) => data);
+      const converterSpy = sinon.spy((data, meta) => data); // eslint-disable-line no-unused-vars
 
       ControllerService.treatAndConvert(
         req,

--- a/test/integration/1_services/ControllerService.test.js
+++ b/test/integration/1_services/ControllerService.test.js
@@ -599,7 +599,7 @@ describe('ControllerService', () => {
         total: 50,
         url: 'http://example.com/api/items?range=0-10',
       };
-      const converterSpy = sinon.spy((data, meta) => data); // eslint-disable-line no-unused-vars
+      const converterSpy = sinon.spy((data, _meta) => data);
 
       ControllerService.treatAndConvert(
         req,

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -1,7 +1,6 @@
 const supertest = require('supertest');
 const should = require('should');
 const massifPolygon = require('./FAKE_DATA');
-const AuthTokenService = require('../../AuthTokenService');
 
 // Fields visible to any user (no auth required)
 const MASSIF_PROPERTIES = [
@@ -15,40 +14,25 @@ const MASSIF_PROPERTIES = [
   'documents',
   'geogPolygon',
   'name',
+  'isSensitive',
   'author',
   'reviewer',
+  'networks',
 ];
 
 describe('Massif features', () => {
-  let adminToken;
+  describe('GET /api/v1/massifs/:id', () => {
+    [987654321, 0, -1].forEach((id) => {
+      it(`should return code 404 for invalid or non-existent ID: ${id}`, (done) => {
+        supertest(sails.hooks.http.app)
+          .get(`/api/v1/massifs/${id}`)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(404, done);
+      });
+    });
 
-  before(async () => {
-    adminToken = await AuthTokenService.getRawBearerAdminToken();
-  });
-
-  describe('find', () => {
-    it('should return code 404 for non-existent massif', (done) => {
-      supertest(sails.hooks.http.app)
-        .get('/api/v1/massifs/987654321')
-        .set('Content-type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(404, done);
-    });
-    it('should return code 404 for massif ID 0', (done) => {
-      supertest(sails.hooks.http.app)
-        .get('/api/v1/massifs/0')
-        .set('Content-type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(404, done);
-    });
-    it('should return code 404 for negative massif ID', (done) => {
-      supertest(sails.hooks.http.app)
-        .get('/api/v1/massifs/-1')
-        .set('Content-type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(404, done);
-    });
-    it('should return code 200', (done) => {
+    it('should return 200 and the expected massif shape for a valid ID', (done) => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/massifs/1')
         .set('Content-type', 'application/json')
@@ -57,57 +41,12 @@ describe('Massif features', () => {
         .end((err, res) => {
           if (err) return done(err);
           const { body: massif } = res;
+
           should(massif).have.properties(MASSIF_PROPERTIES);
-          should(massif).not.have.property('isSensitive');
+          should(massif).not.have.property('entrances');
           should(massif.geogPolygon).equal(massifPolygon.geoJson1ToString);
           should(massif.name).not.be.empty();
-          return done();
-        });
-    });
-    it('should return isSensitive for admin', (done) => {
-      supertest(sails.hooks.http.app)
-        .get('/api/v1/massifs/1')
-        .set('Authorization', adminToken)
-        .set('Content-type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200)
-        .end((err, res) => {
-          if (err) return done(err);
-          should(res.body).have.property('isSensitive');
-          return done();
-        });
-    });
-  });
 
-  describe('GET response shape excludes entrances and includes domain fields', () => {
-    const EXPECTED_FIELDS = [
-      'id',
-      'name',
-      'descriptions',
-      'documents',
-      'networks',
-      'geogPolygon',
-      'author',
-      'reviewer',
-    ];
-
-    it('should contain expected fields and not contain entrances for massif 1', (done) => {
-      supertest(sails.hooks.http.app)
-        .get('/api/v1/massifs/1')
-        .set('Content-type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200)
-        .end((err, res) => {
-          if (err) return done(err);
-          const massif = res.body;
-
-          EXPECTED_FIELDS.forEach((field) => {
-            should(massif).have.property(field);
-          });
-
-          // isSensitive is only returned for admins
-          should(massif).not.have.property('isSensitive');
-          should(massif).not.have.property('entrances');
           return done();
         });
     });

--- a/test/integration/4_routes/Massifs/find.test.js
+++ b/test/integration/4_routes/Massifs/find.test.js
@@ -43,6 +43,7 @@ describe('Massif features', () => {
           const { body: massif } = res;
 
           should(massif).have.properties(MASSIF_PROPERTIES);
+          should(massif.isSensitive).be.a.Boolean();
           should(massif).not.have.property('entrances');
           should(massif.geogPolygon).equal(massifPolygon.geoJson1ToString);
           should(massif.name).not.be.empty();


### PR DESCRIPTION
## 🤔 What

At the request of Frédéric, this PR would push a fix to expose the isSensitive status for massifs to all users and refactors the corresponding integration tests to take into account this new behavior

## 🔍 How

**API Change:** Updated the toMassif converter to always return the isSensitive property, removing any previous access restrictions.
**Test Refactoring:** Consolidated the find.test.js suite by merging overlapping describe blocks and field verification lists for the GET /api/v1/massifs/:id endpoint.


## 🧪 Testing

N/A

## 📸 Previews

N/A
