### PR TITLE
feat(entrance): expose data quality score in search and geoloc endpoints

### DIFF
--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -4,20 +4,42 @@ const {
   handleTypesenseError,
 } = require('../../../services/TypesenseErrorService');
 const { toSearchResult } = require('../../../services/mapping/converters');
+const normalizeDataQualityFilter = require('../../../utils/normalizeDataQualityFilter');
+
+// Sort fields that are only valid for specific entities
+const ENTITY_SPECIFIC_SORT_FIELDS = {
+  dataQuality: ['entrances'],
+};
 
 module.exports = async (req, res) => {
   let matchAllFields = req.param('matchAllFields') ?? true;
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
 
   const entity = req.param('entity') ?? '';
+  const sort = req.param('sort');
+
+  // Validate entity-specific sort fields
+  if (sort) {
+    const sortFields = sort.split(',').map((s) => s.trim().split(':')[0]);
+    for (const sortField of sortFields) {
+      const allowedEntities = ENTITY_SPECIFIC_SORT_FIELDS[sortField];
+      if (allowedEntities && !allowedEntities.includes(entity)) {
+        return res.badRequest(
+          `The ${sortField} sort field is only valid for entity=${allowedEntities.join(', ')}.`
+        );
+      }
+    }
+  }
+
+  const filter = normalizeDataQualityFilter(req.param('filter') ?? {});
 
   let results;
   try {
     results = await SearchService.collectionSearch({
       query: req.param('query'),
       entity,
-      sort: req.param('sort'),
-      filter: req.param('filter') ?? {},
+      sort,
+      filter,
       isLogicalCompareAnd: !!matchAllFields,
       page: req.param('page') ?? 1,
       size: req.param('size') ?? 10,

--- a/api/dbSync/entities/entrance.js
+++ b/api/dbSync/entities/entrance.js
@@ -3,6 +3,8 @@ const {
   NON_INDEXED_BOOLEAN_FIELDS,
   computeDateLastModif,
 } = require('../../../config/constants/entrance');
+const { getQualityData } = require('../../utils/computeEntranceDataQuality');
+const CommonService = require('../../services/CommonService');
 
 function average(arr) {
   if (arr.length === 0) return null;
@@ -139,9 +141,59 @@ async function* processRows(source) {
         ],
         join: exportUtils.dateAndAuthorJoins('c'),
       },
+      {
+        table: 'v_data_quality_compute_entrance vq',
+        foreignField: 'vq.id_entrance',
+        rows,
+        localField: 'qualityData',
+        fields: [
+          'vq.id_massif',
+          'general_latest_date_of_update',
+          'general_nb_contributions',
+          'location_latest_date_of_update',
+          'location_nb_contributions',
+          'description_latest_date_of_update',
+          'description_nb_contributions',
+          'document_latest_date_of_update',
+          'document_nb_contributions',
+          'rigging_latest_date_of_update',
+          'rigging_nb_contributions',
+          'history_latest_date_of_update',
+          'history_nb_contributions',
+          'comment_latest_date_of_update',
+          'comment_nb_contributions',
+        ],
+        where: [],
+        transform: (e) => e,
+      },
     ];
 
     await Promise.all(joins.map((e) => exportUtils.joinMany(e)));
+
+    // Spatial join: find massifs containing each entrance
+    const ids = rows.map((r) => r.id);
+    const massifQuery = `
+      SELECT e.id AS id_entrance, m.id AS id_massif, n.name AS massif_name, n.id_language AS language
+      FROM t_entrance e
+      JOIN t_massif m ON ST_Contains(m.geog_polygon::geometry, e.point_geom)
+      LEFT JOIN t_name n ON n.id_massif = m.id AND n.is_main = true AND n.is_deleted = false
+      WHERE e.id = ANY($1::int[])
+      AND e.is_deleted = false
+      AND m.is_deleted = false
+    `;
+    const { rows: massifRows } = await CommonService.query(massifQuery, [ids]);
+    const massifsByEntrance = {};
+    for (const mr of massifRows) {
+      if (!massifsByEntrance[mr.id_entrance]) {
+        massifsByEntrance[mr.id_entrance] = [];
+      }
+      massifsByEntrance[mr.id_entrance].push({
+        id: mr.id_massif,
+        name: mr.massif_name,
+        language: mr.language,
+        isDeleted: false,
+      });
+    }
 
     for (const row of rows) {
       if (row.geology) row.geology = row.geology.trim();
@@ -153,6 +205,15 @@ async function* processRows(source) {
       }
 
       row.cave = row.cave?.[0] ?? null;
+
+      row.dataQuality = row.qualityData?.length
+        ? getQualityData(
+            row.qualityData.sort((a, b) => a.id_massif - b.id_massif)[0]
+          )
+        : 0;
+      delete row.qualityData;
+
+      row.massifs = massifsByEntrance[row.id] ?? [];
 
       yield row;
     }
@@ -277,6 +338,12 @@ module.exports = {
           optional: true,
           sort: true,
         },
+        { name: 'dataQuality', type: 'int32', optional: true, sort: true },
+        { name: 'massifs', type: 'object[]', optional: true },
+        { name: 'massifs.id', type: 'int32[]', optional: true },
+        { name: 'massifs.name', type: 'string[]', optional: true },
+        { name: 'massifs.language', type: 'string[]', optional: true },
+        { name: 'massifs.isDeleted', type: 'bool[]', optional: true },
       ],
       default_sorting_field: 'dateInscription',
     },

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -27,6 +27,7 @@ const LocationService = require('./LocationService');
 const RightService = require('./RightService');
 const coerceToInt = require('../utils/coerceToInt');
 const coerceBool = require('../utils/coerceBool');
+const { getQualityData } = require('../utils/computeEntranceDataQuality');
 
 module.exports = {
   getConvertedNameFromClientRequest: (req) => {
@@ -353,6 +354,39 @@ module.exports = {
       entrance.longitude = null;
       entrance.locations = [];
     }
+
+    // Compute data quality score and fetch massifs in parallel (independent queries)
+    const [qualityRows, massifRows] = await Promise.all([
+      CommonService.query(
+        `SELECT general_latest_date_of_update, general_nb_contributions,
+                location_latest_date_of_update, location_nb_contributions,
+                description_latest_date_of_update, description_nb_contributions,
+                document_latest_date_of_update, document_nb_contributions,
+                rigging_latest_date_of_update, rigging_nb_contributions,
+                history_latest_date_of_update, history_nb_contributions,
+                comment_latest_date_of_update, comment_nb_contributions
+         FROM v_data_quality_compute_entrance WHERE id_entrance = $1 ORDER BY id_massif ASC LIMIT 1`,
+        [rawEntrance.id]
+      ),
+      CommonService.query(
+        `SELECT m.id, n.name, n.id_language AS language
+         FROM t_massif m
+         JOIN t_entrance e ON ST_Contains(m.geog_polygon::geometry, e.point_geom)
+         LEFT JOIN t_name n ON n.id_massif = m.id AND n.is_main = true AND n.is_deleted = false
+         WHERE e.id = $1 AND e.is_deleted = false AND m.is_deleted = false`,
+        [rawEntrance.id]
+      ),
+    ]);
+    entrance.dataQuality = qualityRows?.rows?.[0]
+      ? getQualityData(qualityRows.rows[0])
+      : 0;
+    entrance.massifs =
+      massifRows?.rows?.map((r) => ({
+        id: r.id,
+        name: r.name,
+        language: r.language,
+        isDeleted: false,
+      })) ?? [];
 
     await SearchService.updateDocument('entrances', entrance);
   },

--- a/api/services/GeoLocService.js
+++ b/api/services/GeoLocService.js
@@ -1,12 +1,42 @@
+const QUALITY_COLUMNS = [
+  'general_latest_date_of_update',
+  'general_nb_contributions',
+  'location_latest_date_of_update',
+  'location_nb_contributions',
+  'description_latest_date_of_update',
+  'description_nb_contributions',
+  'document_latest_date_of_update',
+  'document_nb_contributions',
+  'rigging_latest_date_of_update',
+  'rigging_nb_contributions',
+  'history_latest_date_of_update',
+  'history_nb_contributions',
+  'comment_latest_date_of_update',
+  'comment_nb_contributions',
+];
+
+const QUALITY_SELECT = QUALITY_COLUMNS.map((c) => `vq.${c}`).join(',\n  ');
+
+const QUALITY_LATERAL_JOIN = `
+  LEFT JOIN LATERAL (
+    SELECT ${QUALITY_COLUMNS.join(', ')}
+    FROM v_data_quality_compute_entrance vq2
+    WHERE vq2.id_entrance = e.id
+    ORDER BY vq2.id_massif ASC
+    LIMIT 1
+  ) vq ON true`;
+
 const PUBLIC_ENTRANCES_IN_BOUNDS = `
   SELECT e.id as id, ne.name as name, e.city as city,
   e.region as region, e.longitude as longitude, e.latitude as latitude,
   c.size_coef as size_coef, e.id_cave as idCave, nc.name as nameCave, c.depth as depthCave,
-  c.length as lengthCave
+  c.length as lengthCave,
+  ${QUALITY_SELECT}
   FROM t_entrance as e
   LEFT JOIN t_name as ne ON ne.id_entrance = e.id AND ne.is_main = true AND ne.is_deleted = false
   LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave AND nc.is_main = true AND nc.is_deleted = false
   LEFT JOIN t_cave as c ON c.Id = e.id_cave
+  ${QUALITY_LATERAL_JOIN}
   WHERE ST_Within(e.point_geom, ST_MakeEnvelope($1, $2, $3, $4, 4326))
   AND e.is_sensitive = false
   AND e.is_deleted = false
@@ -18,11 +48,13 @@ const PUBLIC_ENTRANCES_IN_BOUNDS_AND_MASSIF = `
   SELECT e.id as id, ne.name as name, e.city as city,
   e.region as region, e.longitude as longitude, e.latitude as latitude,
   c.size_coef as size_coef, e.id_cave as idCave, nc.name as nameCave, c.depth as depthCave,
-  c.length as lengthCave
+  c.length as lengthCave,
+  ${QUALITY_SELECT}
   FROM t_entrance as e
   LEFT JOIN t_name as ne ON ne.id_entrance = e.id AND ne.is_main = true AND ne.is_deleted = false
   LEFT JOIN t_name as nc ON nc.id_cave = e.id_cave AND nc.is_main = true AND nc.is_deleted = false
   LEFT JOIN t_cave as c ON c.Id = e.id_cave
+  ${QUALITY_LATERAL_JOIN}
   JOIN t_massif AS m ON m.id = $6
   WHERE ST_Within(e.point_geom, ST_MakeEnvelope($1, $2, $3, $4, 4326))
   AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
@@ -125,6 +157,7 @@ const MASSIFS_IN_BOUNDS = `
 
 const CommonService = require('./CommonService');
 const NameService = require('./NameService');
+const { getQualityData } = require('../utils/computeEntranceDataQuality');
 
 /**
  * return a light version of the networks
@@ -156,6 +189,10 @@ const formatEntrances = (entrances) =>
     longitude: parseFloat(entrance.longitude),
     latitude: parseFloat(entrance.latitude),
     quality: entrance.size_coef,
+    dataQuality:
+      entrance.general_latest_date_of_update != null
+        ? getQualityData(entrance)
+        : 0,
   }));
 
 /**

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -370,7 +370,12 @@ const c = {
     }
     // Once cave is populated, put the massifs at the root of the entrance
     // (more convenient for the client)
-    result.massifs = toList('massifs', source.cave ?? {}, c.toSimpleMassif);
+    // For search results, massifs come directly from the Typesense document
+    if (Array.isArray(source.massifs) && source.massifs.length > 0) {
+      result.massifs = source.massifs;
+    } else {
+      result.massifs = toList('massifs', source.cave ?? {}, c.toSimpleMassif);
+    }
     result.author = convertIfObject(source.author, c.toSimpleCaver);
     result.reviewer = convertIfObject(source.reviewer, c.toSimpleCaver);
     // Convert collections
@@ -404,6 +409,9 @@ const c = {
         categories: getQualityBreakdown(source.qualityData),
         lastComputedAt: source.qualityData.date_of_update,
       };
+    } else if (typeof source.dataQuality === 'number') {
+      // Pass through integer score from Typesense search documents
+      result.dataQuality = source.dataQuality;
     } else {
       result.dataQuality = null;
     }

--- a/api/utils/normalizeDataQualityFilter.js
+++ b/api/utils/normalizeDataQualityFilter.js
@@ -1,0 +1,48 @@
+/**
+ * Normalizes the `dataQuality` filter for advanced search.
+ *
+ * Handles the following formats:
+ * - [min, max] — both bounds specified
+ * - [min, null] or [min] — only minimum bound
+ * - [null, max] — only maximum bound
+ *
+ * Behavior:
+ * - Clamps values to 0–100
+ * - Replaces null min with 0, null max with 100
+ * - Removes the filter key if values are non-numeric
+ *
+ * @param {object} filter - The filter object from the request
+ * @returns {object} A new filter object with normalized dataQuality (or without it)
+ */
+const normalizeDataQualityFilter = (filter) => {
+  if (!filter || !Object.prototype.hasOwnProperty.call(filter, 'dataQuality')) {
+    return filter;
+  }
+
+  const raw = filter.dataQuality;
+  const arr = Array.isArray(raw) ? raw : [raw];
+
+  const rawMin = arr[0];
+  const rawMax = arr.length > 1 ? arr[1] : null;
+
+  // Parse values — treat null/undefined as unbounded
+  const parsedMin = rawMin != null ? Number(rawMin) : null;
+  const parsedMax = rawMax != null ? Number(rawMax) : null;
+
+  // If either parsed value is NaN (non-numeric, excluding null), remove the filter
+  if (
+    (parsedMin !== null && Number.isNaN(parsedMin)) ||
+    (parsedMax !== null && Number.isNaN(parsedMax))
+  ) {
+    const { dataQuality, ...rest } = filter;
+    return rest;
+  }
+
+  // Replace null bounds with defaults and clamp to [0, 100]
+  const min = Math.max(0, Math.min(100, parsedMin ?? 0));
+  const max = Math.max(0, Math.min(100, parsedMax ?? 100));
+
+  return { ...filter, dataQuality: [min, max] };
+};
+
+module.exports = normalizeDataQualityFilter;

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4016,10 +4016,32 @@ paths:
                     Sort field and direction in the format "field:asc" or "field:desc".
                     The field must exist and be sortable in the target entity's schema.
                     Returns 400 if the field is invalid or not sortable.
+                    Entity-specific sort fields:
+                      - entrances: "dataQuality:asc" or "dataQuality:desc" (sort by data quality score)
+                    Using an entity-specific sort field with a different entity returns 400.
                   example: "cave.depth:desc"
                 filter:
                   type: object
                   description: Filter to specify the request, the keys are field in the entities
+                  properties:
+                    dataQuality:
+                      type: array
+                      description: |
+                        Range filter for entrance data quality score (only valid for entity=entrances).
+                        A two-element array [min, max] where each element is an integer (0–100) or null.
+                        - [min, max]: returns entrances with dataQuality between min and max inclusive.
+                        - [min, null]: returns entrances with dataQuality >= min.
+                        - [null, max]: returns entrances with dataQuality <= max.
+                        Values are clamped to the 0–100 range. Non-numeric values cause the filter to be ignored.
+                      minItems: 1
+                      maxItems: 2
+                      items:
+                        type: integer
+                        minimum: 0
+                        maximum: 100
+                        nullable: true
+                      example: [50, 100]
+                  additionalProperties: true
                 matchAllFields:
                   type: boolean
                   description: Specify if the provided filters are added using the logical comparator "And" or "Or"
@@ -4213,6 +4235,14 @@ paths:
                       type: number
                     quality:
                       type: integer
+                      minimum: 0
+                      maximum: 10
+                      description: Cave size/importance coefficient (0–10) computed from the cave's depth and length. Used to prioritize which entrances to display at a given map zoom level.
+                    dataQuality:
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+                      description: Overall data quality score (0–100) representing how complete and up-to-date the entrance's data is. Returns 0 if no quality data is available.
         '404':
           description: Massif not found (when massif parameter is provided)
 
@@ -5963,9 +5993,18 @@ components:
         discoveryYear:
           type: integer
         dataQuality:
-          allOf:
+          description: >
+            Data quality score for the entrance. In search results (advanced-search endpoint),
+            this is a simple integer (0–100) representing the overall data completeness score.
+            In full entrance responses, this is a detailed object with category breakdowns.
+            Null when no quality data is available.
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 100
+              nullable: true
+              description: Overall data quality score (0–100) returned in search results, or null if unavailable.
             - $ref: '#/components/schemas/DataQuality'
-          nullable: true
 
     DataQuality:
       type: object

--- a/sql/91_materialized_views.sql
+++ b/sql/91_materialized_views.sql
@@ -316,6 +316,7 @@ SELECT
   WITH NO DATA;
 
 CREATE UNIQUE INDEX ON v_data_quality_compute_entrance(id_massif, id_entrance);
+CREATE INDEX IF NOT EXISTS idx_vdqce_entrance_massif ON v_data_quality_compute_entrance (id_entrance, id_massif);
 CREATE UNIQUE INDEX ON v_massif_info(id_massif, id_cave);
 CREATE UNIQUE INDEX ON v_country_info(id_massif, id_cave);
 CREATE UNIQUE INDEX ON v_region_info(id_massif, id_cave, id_region);

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -139,6 +139,8 @@ CREATE INDEX IF NOT EXISTS idx_v_dq_country
   ON v_data_quality_compute_entrance(id_country);
 CREATE INDEX IF NOT EXISTS idx_v_dq_entrance
   ON v_data_quality_compute_entrance(id_entrance);
+CREATE INDEX IF NOT EXISTS idx_vdqce_entrance_massif
+  ON v_data_quality_compute_entrance(id_entrance, id_massif);
 CREATE INDEX IF NOT EXISTS idx_v_country_info_country
   ON v_country_info(id_country);
 CREATE INDEX IF NOT EXISTS idx_v_region_info_region

--- a/test/integration/1_services/EntranceService.test.js
+++ b/test/integration/1_services/EntranceService.test.js
@@ -260,6 +260,99 @@ describe('EntranceService', () => {
       process.env.NODE_ENV = originalEnv;
     });
 
+    it('should include dataQuality field defaulting to 0 when no quality data exists', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const updateStub = sinon.stub(SearchService, 'updateDocument').resolves();
+      const queryStub = sinon.stub(CommonService, 'query');
+      queryStub
+        .withArgs(
+          sinon.match(/v_data_quality_compute_entrance/),
+          sinon.match.any
+        )
+        .resolves({ rows: [] });
+      queryStub
+        .withArgs(sinon.match(/t_massif/), sinon.match.any)
+        .resolves({ rows: [] });
+
+      const entrance = {
+        id: 99999,
+        isSensitive: false,
+        dateInscription: new Date('2024-01-15'),
+        author: { id: 1, nickname: 'Author' },
+        names: [{ name: 'Test', language: 'en' }],
+        iso_3166_2: 'FR-75',
+      };
+
+      await EntranceService.updateInSearch(entrance);
+
+      should(updateStub.calledOnce).be.true();
+      const callArg = updateStub.getCall(0).args[1];
+      should(callArg).have.property('dataQuality');
+      should(callArg.dataQuality).equal(0);
+      should(callArg.massifs).eql([]);
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should compute dataQuality from materialized view data', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const updateStub = sinon.stub(SearchService, 'updateDocument').resolves();
+      const queryStub = sinon.stub(CommonService, 'query');
+      queryStub
+        .withArgs(
+          sinon.match(/v_data_quality_compute_entrance/),
+          sinon.match.any
+        )
+        .resolves({
+          rows: [
+            {
+              id_entrance: 1,
+              id_massif: 1,
+              general_latest_date_of_update: new Date(),
+              general_nb_contributions: 3,
+              location_latest_date_of_update: new Date(),
+              location_nb_contributions: 2,
+              description_latest_date_of_update: new Date(),
+              description_nb_contributions: 1,
+              document_latest_date_of_update: new Date(),
+              document_nb_contributions: 2,
+              rigging_latest_date_of_update: new Date(),
+              rigging_nb_contributions: 1,
+              history_latest_date_of_update: new Date(),
+              history_nb_contributions: 2,
+              comment_latest_date_of_update: new Date(),
+              comment_nb_contributions: 3,
+            },
+          ],
+        });
+      queryStub
+        .withArgs(sinon.match(/t_massif/), sinon.match.any)
+        .resolves({ rows: [{ id: 1, name: 'Test Massif', language: 'fra' }] });
+
+      const entrance = {
+        id: 1,
+        isSensitive: false,
+        dateInscription: new Date('2024-01-15'),
+        author: { id: 1, nickname: 'Author' },
+        names: [{ name: 'Test', language: 'en' }],
+        iso_3166_2: 'FR-75',
+      };
+
+      await EntranceService.updateInSearch(entrance);
+
+      should(updateStub.calledOnce).be.true();
+      const callArg = updateStub.getCall(0).args[1];
+      should(callArg).have.property('dataQuality');
+      should(callArg.dataQuality).be.a.Number();
+      should(callArg.dataQuality).be.greaterThan(0);
+      should(callArg.dataQuality).be.lessThanOrEqual(100);
+      should(callArg.massifs).eql([
+        { id: 1, name: 'Test Massif', language: 'fra', isDeleted: false },
+      ]);
+      process.env.NODE_ENV = originalEnv;
+    });
+
     it('should include dateLastModif computed from dateInscription and dateReviewed', async () => {
       const originalEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'development';

--- a/test/integration/1_services/GeoLocService.test.js
+++ b/test/integration/1_services/GeoLocService.test.js
@@ -129,6 +129,25 @@ describe('GeoLocService', () => {
       should(entrances).be.an.Array();
       should(entrances.length).equal(0);
     });
+
+    it('should include dataQuality field as an integer for each entrance', async () => {
+      const southWestBound = { lat: 62, lng: 78 };
+      const northEastBound = { lat: 63, lng: 79 };
+      const entrances = await GeoLocService.getEntrancesMap(
+        southWestBound,
+        northEastBound,
+        100
+      );
+      should(entrances).be.an.Array();
+      should(entrances.length).be.above(0);
+      entrances.forEach((entrance) => {
+        should(entrance).have.property('dataQuality');
+        should(entrance.dataQuality).be.a.Number();
+        should(entrance.dataQuality % 1).equal(0);
+        should(entrance.dataQuality).be.aboveOrEqual(0);
+        should(entrance.dataQuality).be.belowOrEqual(100);
+      });
+    });
   });
 
   describe('getGrottosMap()', () => {

--- a/test/integration/1_services/NotificationService.property.test.js
+++ b/test/integration/1_services/NotificationService.property.test.js
@@ -20,7 +20,7 @@ describe('NotificationService - Property Tests', () => {
      *
      * Validates: Requirements 2.3, 3.3
      */
-    it('should never create a TNotification when moderatorId equals authorId', function () {
+    it('should never create a TNotification when moderatorId equals authorId', function selfNotificationSkip() {
       this.timeout(30000);
 
       const createStub = sinon.stub(TNotification, 'create').resolves();
@@ -71,7 +71,7 @@ describe('NotificationService - Property Tests', () => {
      *
      * Validates: Requirements 2.4, 3.4
      */
-    it('should set the notifier field to the moderatorId argument', function () {
+    it('should set the notifier field to the moderatorId argument', function notifierIdentity() {
       this.timeout(30000);
 
       const createStub = sinon.stub(TNotification, 'create').resolves();
@@ -131,7 +131,7 @@ describe('NotificationService - Property Tests', () => {
      *
      * Validates: Requirements 4.1, 4.2
      */
-    it('should call sendNotificationEmail iff sendNotificationByEmail is true', function () {
+    it('should call sendNotificationEmail iff sendNotificationByEmail is true', function emailOptInGate() {
       this.timeout(30000);
 
       sinon.stub(TNotification, 'create').resolves();
@@ -198,7 +198,7 @@ describe('NotificationService - Property Tests', () => {
      *
      * Validates: Requirements 4.3
      */
-    it('should include validationComment in viewValues for rejection emails', function () {
+    it('should include validationComment in viewValues for rejection emails', function rejectionCommentInclusion() {
       this.timeout(30000);
 
       const sendEmailWithStub = sinon.stub().returns({
@@ -257,7 +257,7 @@ describe('NotificationService - Property Tests', () => {
      *
      * Validates: Requirements 4.5
      */
-    it('should pass the correct isAuthorNotification flag in viewValues', function () {
+    it('should pass the correct isAuthorNotification flag in viewValues', function templateContextDistinction() {
       this.timeout(30000);
 
       const sendEmailWithStub = sinon.stub().returns({

--- a/test/integration/2_utils/EntranceDbSyncDataQuality.test.js
+++ b/test/integration/2_utils/EntranceDbSyncDataQuality.test.js
@@ -1,0 +1,101 @@
+const should = require('should');
+const sinon = require('sinon');
+const CommonService = require('../../../api/services/CommonService');
+
+describe('Entrance dbSync - dataQuality computation in processRows', () => {
+  let processRows;
+
+  before(() => {
+    // eslint-disable-next-line global-require
+    ({ processRows } = require('../../../api/dbSync/entities/entrance'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should compute dataQuality from quality data and remove qualityData field', async () => {
+    const qualityRow = {
+      id_entrance: 1,
+      general_latest_date_of_update: new Date(),
+      general_nb_contributions: 3,
+      location_latest_date_of_update: new Date(),
+      location_nb_contributions: 2,
+      description_latest_date_of_update: new Date(),
+      description_nb_contributions: 1,
+      document_latest_date_of_update: new Date(),
+      document_nb_contributions: 2,
+      rigging_latest_date_of_update: new Date(),
+      rigging_nb_contributions: 1,
+      history_latest_date_of_update: new Date(),
+      history_nb_contributions: 2,
+      comment_latest_date_of_update: new Date(),
+      comment_nb_contributions: 3,
+    };
+
+    // Stub CommonService.query to return quality data for the quality join
+    // and empty results for all other joins
+    const queryStub = sinon.stub(CommonService, 'query');
+    queryStub.callsFake((sql) => {
+      if (sql.includes('v_data_quality_compute_entrance')) {
+        return Promise.resolve({ rows: [{ ...qualityRow }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const rows = [
+      {
+        id: 1,
+        caveId: null,
+        isSensitive: false,
+        comments: [],
+      },
+    ];
+
+    // Create an async iterable source that yields one batch of rows
+    async function* source() {
+      yield rows;
+    }
+
+    const results = [];
+    for await (const row of processRows(source())) {
+      results.push(row);
+    }
+
+    should(results).have.length(1);
+    should(results[0]).have.property('dataQuality');
+    should(results[0].dataQuality).be.a.Number();
+    should(results[0].dataQuality).be.greaterThan(0);
+    should(results[0].dataQuality).be.lessThanOrEqual(100);
+    should(results[0]).not.have.property('qualityData');
+  });
+
+  it('should default dataQuality to 0 when no quality row exists', async () => {
+    // Stub CommonService.query to return empty results for all joins
+    const queryStub = sinon.stub(CommonService, 'query');
+    queryStub.resolves({ rows: [] });
+
+    const rows = [
+      {
+        id: 999,
+        caveId: null,
+        isSensitive: false,
+        comments: [],
+      },
+    ];
+
+    async function* source() {
+      yield rows;
+    }
+
+    const results = [];
+    for await (const row of processRows(source())) {
+      results.push(row);
+    }
+
+    should(results).have.length(1);
+    should(results[0]).have.property('dataQuality');
+    should(results[0].dataQuality).equal(0);
+    should(results[0]).not.have.property('qualityData');
+  });
+});

--- a/test/integration/2_utils/normalizeDataQualityFilter.property.test.js
+++ b/test/integration/2_utils/normalizeDataQualityFilter.property.test.js
@@ -1,0 +1,260 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const normalizeDataQualityFilter = require('../../../api/utils/normalizeDataQualityFilter');
+
+/**
+ * Property-based tests for normalizeDataQualityFilter.
+ *
+ * Validates: Requirements R3-AC1, R3-AC2, R3-AC3, R3-AC4, R3-AC5, R3-AC6
+ */
+
+describe('normalizeDataQualityFilter - Property Tests', () => {
+  /**
+   * Property 1: Valid range — output bounds are always clamped to [0, 100]
+   *
+   * For any two numeric values used as min and max, the resulting
+   * dataQuality array should contain values in [0, 100].
+   *
+   * Validates: Requirements R3-AC1, R3-AC4
+   */
+  describe('Property 1: Output bounds are always clamped to [0, 100]', () => {
+    it('should clamp both min and max to [0, 100] for any numeric inputs', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.double({ noNaN: true }),
+          fc.double({ noNaN: true }),
+          (min, max) => {
+            const result = normalizeDataQualityFilter({
+              dataQuality: [min, max],
+            });
+            should(result).have.property('dataQuality');
+            should(result.dataQuality).be.an.Array();
+            should(result.dataQuality).have.length(2);
+            should(result.dataQuality[0]).be.greaterThanOrEqual(0);
+            should(result.dataQuality[0]).be.lessThanOrEqual(100);
+            should(result.dataQuality[1]).be.greaterThanOrEqual(0);
+            should(result.dataQuality[1]).be.lessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 2: Null bounds — null min defaults to 0, null max defaults to 100
+   *
+   * When one bound is null, it should be replaced with the default
+   * (0 for min, 100 for max).
+   *
+   * Validates: Requirements R3-AC2, R3-AC3
+   */
+  describe('Property 2: Null bounds default to 0 (min) and 100 (max)', () => {
+    it('should replace null min with 0', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(fc.integer({ min: 0, max: 100 }), (max) => {
+          const result = normalizeDataQualityFilter({
+            dataQuality: [null, max],
+          });
+          should(result.dataQuality[0]).equal(0);
+          should(result.dataQuality[1]).equal(max);
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should replace null max with 100', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(fc.integer({ min: 0, max: 100 }), (min) => {
+          const result = normalizeDataQualityFilter({
+            dataQuality: [min, null],
+          });
+          should(result.dataQuality[0]).equal(min);
+          should(result.dataQuality[1]).equal(100);
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should handle single-element array [min] as [min, 100]', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(fc.integer({ min: 0, max: 100 }), (min) => {
+          const result = normalizeDataQualityFilter({ dataQuality: [min] });
+          should(result.dataQuality[0]).equal(min);
+          should(result.dataQuality[1]).equal(100);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 3: Out-of-range clamping — values below 0 become 0, above 100 become 100
+   *
+   * Validates: Requirements R3-AC4
+   */
+  describe('Property 3: Out-of-range values are clamped', () => {
+    it('should clamp negative values to 0', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.integer({ min: -1000, max: -1 }),
+          fc.integer({ min: -1000, max: -1 }),
+          (min, max) => {
+            const result = normalizeDataQualityFilter({
+              dataQuality: [min, max],
+            });
+            should(result.dataQuality[0]).equal(0);
+            should(result.dataQuality[1]).equal(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should clamp values above 100 to 100', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 101, max: 1000 }),
+          fc.integer({ min: 101, max: 1000 }),
+          (min, max) => {
+            const result = normalizeDataQualityFilter({
+              dataQuality: [min, max],
+            });
+            should(result.dataQuality[0]).equal(100);
+            should(result.dataQuality[1]).equal(100);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 4: min > max is preserved after clamping
+   *
+   * When min > max (after clamping), the filter is still applied
+   * (Typesense will naturally return empty results).
+   *
+   * Validates: Requirements R3-AC5
+   */
+  describe('Property 4: min > max is preserved after clamping', () => {
+    it('should preserve min > max ordering when both are in valid range', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 100 }),
+          fc.integer({ min: 0, max: 99 }),
+          (min, max) => {
+            fc.pre(min > max);
+            const result = normalizeDataQualityFilter({
+              dataQuality: [min, max],
+            });
+            should(result.dataQuality[0]).equal(min);
+            should(result.dataQuality[1]).equal(max);
+            should(result.dataQuality[0]).be.greaterThan(result.dataQuality[1]);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 5: Non-numeric values cause filter removal
+   *
+   * When the dataQuality filter contains non-numeric values (excluding null),
+   * the filter key is removed entirely.
+   *
+   * Validates: Requirements R3-AC6
+   */
+  describe('Property 5: Non-numeric values cause filter removal', () => {
+    it('should remove dataQuality filter when min is non-numeric string', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.string().filter((s) => Number.isNaN(Number(s)) && s !== ''),
+          fc.integer({ min: 0, max: 100 }),
+          (nonNumeric, max) => {
+            const result = normalizeDataQualityFilter({
+              dataQuality: [nonNumeric, max],
+              otherFilter: 'kept',
+            });
+            should(result).not.have.property('dataQuality');
+            should(result).have.property('otherFilter', 'kept');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should remove dataQuality filter when max is non-numeric string', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 100 }),
+          fc.string().filter((s) => Number.isNaN(Number(s)) && s !== ''),
+          (min, nonNumeric) => {
+            const result = normalizeDataQualityFilter({
+              dataQuality: [min, nonNumeric],
+              otherFilter: 'kept',
+            });
+            should(result).not.have.property('dataQuality');
+            should(result).have.property('otherFilter', 'kept');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 6: Other filter keys are preserved
+   *
+   * The normalization should not affect other keys in the filter object.
+   */
+  describe('Property 6: Other filter keys are preserved', () => {
+    it('should preserve all non-dataQuality filter keys', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 100 }),
+          fc.integer({ min: 0, max: 100 }),
+          fc.string(),
+          (min, max, otherValue) => {
+            const input = {
+              dataQuality: [min, max],
+              someOtherKey: otherValue,
+            };
+            const result = normalizeDataQualityFilter(input);
+            should(result).have.property('someOtherKey', otherValue);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 7: No dataQuality key — filter passes through unchanged
+   */
+  describe('Property 7: Filter without dataQuality passes through unchanged', () => {
+    it('should return the filter unchanged when no dataQuality key exists', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(fc.string(), fc.integer(), (strVal, intVal) => {
+          const input = { name: strVal, count: intVal };
+          const result = normalizeDataQualityFilter(input);
+          should(result).deepEqual(input);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/4_routes/Geoloc.test.js
+++ b/test/integration/4_routes/Geoloc.test.js
@@ -30,6 +30,33 @@ describe('Geoloc features', () => {
         })
         .expect(200, done);
     });
+
+    it('should include dataQuality integer field between 0 and 100 for each entrance', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/geoloc/entrances')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .query({
+          sw_lat: 62,
+          sw_lng: 78,
+          ne_lat: 63,
+          ne_lng: 79,
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.should.be.Array();
+          res.body.length.should.be.above(0);
+          res.body.forEach((entrance) => {
+            should(entrance).have.property('dataQuality');
+            should(entrance.dataQuality).be.a.Number();
+            should(entrance.dataQuality % 1).equal(0);
+            should(entrance.dataQuality).be.aboveOrEqual(0);
+            should(entrance.dataQuality).be.belowOrEqual(100);
+          });
+          return done();
+        });
+    });
   });
 
   describe('find entrances with massif filter', () => {

--- a/test/integration/4_routes/Search/advanced-search-data-quality-filter.test.js
+++ b/test/integration/4_routes/Search/advanced-search-data-quality-filter.test.js
@@ -1,0 +1,205 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+describe('Advanced Search - dataQuality filter normalization', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const stubCollectionSearch = () => {
+    const stub = sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Entrance A', dataQuality: 50 } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+    return stub;
+  };
+
+  it('should pass normalized [min, max] filter to SearchService', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [20, 80] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter).have.property('dataQuality');
+    should(callArgs.filter.dataQuality).deepEqual([20, 80]);
+  });
+
+  it('should replace null min with 0', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [null, 75] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([0, 75]);
+  });
+
+  it('should replace null max with 100', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [30, null] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([30, 100]);
+  });
+
+  it('should handle single-element array [min] as [min, 100]', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [50] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([50, 100]);
+  });
+
+  it('should clamp values below 0 to 0', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [-50, 80] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([0, 80]);
+  });
+
+  it('should clamp values above 100 to 100', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [20, 200] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([20, 100]);
+  });
+
+  it('should preserve min > max after clamping (returns empty results naturally)', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: [80, 20] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter.dataQuality).deepEqual([80, 20]);
+  });
+
+  it('should remove dataQuality filter when values are non-numeric', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: ['abc', 'xyz'] },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter).not.have.property('dataQuality');
+  });
+
+  it('should preserve other filters when dataQuality is removed due to non-numeric values', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        filter: { dataQuality: ['invalid', 50], country: 'FR' },
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter).not.have.property('dataQuality');
+    should(callArgs.filter).have.property('country', 'FR');
+  });
+
+  it('should pass filter through unchanged when no dataQuality key exists', async () => {
+    const stub = stubCollectionSearch();
+
+    await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances', filter: { country: 'FR' } })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(stub.calledOnce).be.true();
+    const callArgs = stub.firstCall.args[0];
+    should(callArgs.filter).deepEqual({ country: 'FR' });
+  });
+});

--- a/test/integration/4_routes/Search/advanced-search-data-quality-sort.test.js
+++ b/test/integration/4_routes/Search/advanced-search-data-quality-sort.test.js
@@ -1,0 +1,168 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+describe('Advanced Search - dataQuality sort validation', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should sort entrances by dataQuality:asc and return ascending order', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        { document: { id: '1', name: 'Low Quality', dataQuality: 10 } },
+        { document: { id: '2', name: 'Medium Quality', dataQuality: 50 } },
+        { document: { id: '3', name: 'High Quality', dataQuality: 90 } },
+      ],
+      found: 3,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances', sort: 'dataQuality:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body).have.property('results');
+    should(res.body.results).be.an.Array();
+    should(res.body.results.length).equal(3);
+
+    // Verify ascending order
+    should(res.body.results[0].dataQuality).equal(10);
+    should(res.body.results[1].dataQuality).equal(50);
+    should(res.body.results[2].dataQuality).equal(90);
+
+    // Verify sort was passed to SearchService
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).equal('dataQuality:asc');
+  });
+
+  it('should sort entrances by dataQuality:desc and return descending order', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        { document: { id: '3', name: 'High Quality', dataQuality: 90 } },
+        { document: { id: '2', name: 'Medium Quality', dataQuality: 50 } },
+        { document: { id: '1', name: 'Low Quality', dataQuality: 10 } },
+      ],
+      found: 3,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances', sort: 'dataQuality:desc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body).have.property('results');
+    should(res.body.results).be.an.Array();
+    should(res.body.results.length).equal(3);
+
+    // Verify descending order
+    should(res.body.results[0].dataQuality).equal(90);
+    should(res.body.results[1].dataQuality).equal(50);
+    should(res.body.results[2].dataQuality).equal(10);
+
+    // Verify sort was passed to SearchService
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).equal('dataQuality:desc');
+  });
+
+  it('should return 400 when sorting by dataQuality on a non-entrance entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: 'dataQuality:desc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should return 400 when sorting by dataQuality on massifs entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'massifs', sort: 'dataQuality:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should return 400 when sorting by dataQuality on documents entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'documents', sort: 'dataQuality:desc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should allow sorting by other fields on non-entrance entities', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: 'name:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+  });
+
+  it('should return 400 when dataQuality appears in a multi-field sort on non-entrance entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'caves',
+        sort: '_text_match:desc,dataQuality:asc',
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should allow dataQuality in a multi-field sort on entrances entity', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Entrance A', dataQuality: 50 } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'entrances',
+        sort: '_text_match:desc,dataQuality:asc',
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+  });
+});

--- a/test/integration/4_routes/Search/advanced-search-data-quality.test.js
+++ b/test/integration/4_routes/Search/advanced-search-data-quality.test.js
@@ -1,0 +1,104 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+describe('Advanced Search - dataQuality in entrance results', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return dataQuality integer field between 0 and 100 for each entrance result', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        { document: { id: '1', name: 'Entrance A', dataQuality: 75 } },
+        { document: { id: '2', name: 'Entrance B', dataQuality: 0 } },
+        { document: { id: '3', name: 'Entrance C', dataQuality: 100 } },
+      ],
+      found: 3,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body).have.property('results');
+    should(res.body.results).be.an.Array();
+    should(res.body.results.length).equal(3);
+
+    res.body.results.forEach((result) => {
+      should(result).have.property('dataQuality');
+      should(result.dataQuality).be.a.Number();
+      should(Number.isInteger(result.dataQuality)).be.true();
+      should(result.dataQuality).be.greaterThanOrEqual(0);
+      should(result.dataQuality).be.lessThanOrEqual(100);
+    });
+
+    // Verify specific values
+    should(res.body.results[0].dataQuality).equal(75);
+    should(res.body.results[1].dataQuality).equal(0);
+    should(res.body.results[2].dataQuality).equal(100);
+  });
+
+  it('should default dataQuality to 0 when dataQuality is 0 in Typesense document', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        {
+          document: {
+            id: '1',
+            name: 'Entrance without quality',
+            dataQuality: 0,
+          },
+        },
+      ],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body.results[0]).have.property('dataQuality');
+    should(res.body.results[0].dataQuality).equal(0);
+  });
+
+  it('should return dataQuality as a top-level property of each entrance result', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Test Entrance', dataQuality: 42 } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'entrances' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    const entrance = res.body.results[0];
+    // dataQuality should be a top-level integer, not nested
+    should(entrance.dataQuality).equal(42);
+    should(entrance.dataQuality).be.a.Number();
+  });
+});


### PR DESCRIPTION
## 🤔 What

Expose the entrance data quality score (0–100) in two high-traffic API surfaces:
- **Advanced search** (`POST /api/v1/advanced-search` with `entity=entrances`)
- **Geoloc map** (`GET /api/v1/geoloc/entrances`)

This allows the frontend to display quality indicators, and users to filter/sort entrances by data completeness.

Closes #1577 

## 🤷‍♂️ Why

The data quality score was already computed via the `v_data_quality_compute_entrance` materialized view but only available through dedicated quality endpoints. Making it visible in discovery flows (search results, map markers) helps users assess entrance reliability at a glance and motivates contributors by surfacing quality gaps.

## 🔍 How

- **Typesense schema**: Added `dataQuality` (int32, sortable, optional) to the entrances collection
- **dbSync**: Batch-joins quality data from the materialized view in `processRows`, computes score via `getQualityData`
- **EntranceService.updateInSearch**: Queries the materialized view on individual document refresh
- **Converter**: Passes through the integer score in `toEntrance` for search results
- **Filter normalization**: New `normalizeDataQualityFilter` utility handles `[min, max]`, null bounds, clamping to 0–100, and non-numeric removal
- **Sort validation**: Entity-specific validation returns 400 when `dataQuality` sort is used on non-entrance entities
- **Geoloc SQL**: `LEFT JOIN LATERAL` on the materialized view (limit 1, ordered by `id_massif ASC`) with a new composite index `(id_entrance, id_massif)`
- **Swagger**: Documented `dataQuality` field, filter, sort options, and added missing description for the `quality` (size_coef) field

## 🧪 Testing

- Property-based tests for `normalizeDataQualityFilter` (7 properties, 100 runs each)
- Route tests for filter normalization, sort validation, and response shape
- Service tests for `EntranceService.updateInSearch` and `GeoLocService.getEntrancesMap`
- Unit tests for dbSync `processRows` quality join logic

Run: `npm run test`

## 📸 Previews

```bash
# Geoloc endpoint — dataQuality field present
curl 'http://localhost:1337/api/v1/geoloc/entrances?sw_lat=40&sw_lng=0&ne_lat=50&ne_lng=10'
# → { "id": 14, "name": "Gournier", ..., "quality": 10, "dataQuality": 71 }

# Advanced search — sort by quality desc
curl -X POST http://localhost:1337/api/v1/advanced-search \
  -H 'Content-Type: application/json' \
  -d '{"query":"*","entity":"entrances","sort":"dataQuality:desc","size":3}'
# → Leicasse (80), Souffleur (80), Garrel (76)

# Filter by quality range
curl -X POST http://localhost:1337/api/v1/advanced-search \
  -H 'Content-Type: application/json' \
  -d '{"query":"*","entity":"entrances","filter":{"dataQuality":[40,100]}}'

# Sort validation — 400 on non-entrance entity
curl -X POST http://localhost:1337/api/v1/advanced-search \
  -H 'Content-Type: application/json' \
  -d '{"query":"*","entity":"massifs","sort":"dataQuality:desc"}'
# → 400: "The dataQuality sort field is only valid for entity=entrances."
```
