### PR TITLE
fix(document): clean up entrances and bibliographic metadata on permanent delete

### DIFF
--- a/api/controllers/v1/document/delete.js
+++ b/api/controllers/v1/document/delete.js
@@ -99,6 +99,7 @@ module.exports = async (req, res) => {
     }
 
     await linkedEntitiesDeleteOrMerge('countries');
+    await linkedEntitiesDeleteOrMerge('entrances');
     await linkedEntitiesDeleteOrMerge('isoRegions');
     await linkedEntitiesDeleteOrMerge('languages');
     await linkedEntitiesDeleteOrMerge('massifs');
@@ -116,6 +117,10 @@ module.exports = async (req, res) => {
     await TDescription.destroy({ document: documentId });
 
     await HDocument.destroy({ t_id: documentId });
+    await sails.sendNativeQuery(
+      'DELETE FROM t_bibliographic_metadata WHERE id_document = $1',
+      [documentId]
+    );
     await TDocument.destroyOne({ id: documentId }); // Hard delete
   }
 

--- a/scripts/snapshot-test-db.js
+++ b/scripts/snapshot-test-db.js
@@ -31,76 +31,6 @@ const templateDbName = `${testDbName}_template`;
 url.pathname = '/postgres';
 const maintenanceUrl = url.toString();
 
-function runFullBootstrap() {
-  return new Promise((resolve, reject) => {
-    // eslint-disable-next-line global-require
-    const sails = require('sails');
-    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-    const Fixted = require('fixted');
-    // eslint-disable-next-line global-require
-    const sailsPostGreAdapter = require('sails-postgresql');
-    // eslint-disable-next-line global-require
-    const customSQL = require('../test/customSQL');
-    // eslint-disable-next-line global-require
-    const CommonService = require('../api/services/CommonService');
-    // eslint-disable-next-line global-require
-    const FIXTURE_ORDER = require('../test/fixtureOrder');
-
-    sails.lift(
-      {
-        log: { level: 'error' },
-        datastores: {
-          default: { adapter: sailsPostGreAdapter, url: testUrl },
-        },
-        models: { migrate: 'drop' },
-        csrf: false,
-        async bootstrap() {
-          await CommonService.query(customSQL.ALTER_MASSIF_COLUMN_GEOG_POLYGON);
-          await CommonService.query(customSQL.ALTER_ENTRANCE_COLUMN_POINT_GEOM);
-          await CommonService.query(
-            customSQL.CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER
-          );
-        },
-      },
-      // eslint-disable-next-line consistent-return
-      async (liftErr) => {
-        if (liftErr) return reject(liftErr);
-
-        const fixted = new Fixted();
-        fixted.populate(
-          FIXTURE_ORDER,
-          // eslint-disable-next-line consistent-return
-          (fixtedError) => {
-            if (fixtedError) {
-              sails.lower(() => reject(fixtedError));
-              return;
-            }
-
-            CommonService.query(
-              [
-                customSQL.UPDATE_SEQUENCES_QUERY,
-                customSQL.POPULATE_ENTRANCE_POINT_GEOM,
-                customSQL.INDEX_OPTIMIZATION_MIGRATION,
-                customSQL.QUERY_PERFORMANCE_FIXES_MIGRATION,
-              ].join('\n')
-            )
-              .then(() => {
-                sails.lower((lowerErr) => {
-                  if (lowerErr) reject(lowerErr);
-                  else resolve();
-                });
-              })
-              .catch((sqlErr) => {
-                sails.lower(() => reject(sqlErr));
-              });
-          },
-          false
-        );
-      }
-    );
-  });
-}
-
 async function seed() {
   console.log(`[snapshot] Seeding template "${templateDbName}"...`);
 
@@ -114,7 +44,17 @@ async function seed() {
   });
 
   console.log('[snapshot] Running full bootstrap (migrate:drop + fixtures)...');
-  await runFullBootstrap();
+
+  // eslint-disable-next-line global-require
+  const seedDatabase = require('../test/seed-database');
+  const sails = await seedDatabase({ testUrl });
+  await new Promise((resolve, reject) => {
+    sails.lower((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+
   console.log('[snapshot] Bootstrap complete. Creating template...');
 
   await withClient(maintenanceUrl, async (client) => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,11 +1,8 @@
 const sails = require('sails');
-const Fixted = require('fixted');
 const sailsPostGreAdapter = require('sails-postgresql');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { Client } = require('pg');
-const customSQL = require('./customSQL');
-const CommonService = require('../api/services/CommonService');
-const FIXTURE_ORDER = require('./fixtureOrder');
+const seedDatabase = require('./seed-database');
 const { DEFAULT_TEST_URL } = require('./test-config');
 
 const testUrl = process.env.POSTGRE_TEST_URL || DEFAULT_TEST_URL;
@@ -142,59 +139,14 @@ function liftSafe(label) {
 /**
  * Full path: drop all tables, load fixtures, run migrations.
  */
-function liftFull() {
-  return new Promise((resolve, reject) => {
-    console.log(
-      '[bootstrap] Full bootstrap (migrate:drop + fixtures). ' +
-        'Run `npm run test:snapshot` for faster runs.'
-    );
+async function liftFull() {
+  console.log(
+    '[bootstrap] Full bootstrap (migrate:drop + fixtures). ' +
+      'Run `npm run test:snapshot` for faster runs.'
+  );
 
-    sails.lift(
-      {
-        log: { level: 'error' },
-        datastores: {
-          default: { adapter: sailsPostGreAdapter, url: testUrl },
-        },
-        models: { migrate: 'drop' },
-        csrf: false,
-        async bootstrap() {
-          // Replace the normal bootstrap.js
-          await CommonService.query(customSQL.ALTER_MASSIF_COLUMN_GEOG_POLYGON);
-          await CommonService.query(customSQL.ALTER_ENTRANCE_COLUMN_POINT_GEOM);
-          await CommonService.query(
-            customSQL.CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER
-          );
-        },
-      },
-      // eslint-disable-next-line consistent-return
-      async (liftErr) => {
-        if (liftErr) return reject(liftErr);
-        configureServer();
-
-        const fixted = new Fixted();
-        fixted.populate(
-          FIXTURE_ORDER,
-          // eslint-disable-next-line consistent-return
-          (fixtedError) => {
-            if (fixtedError) return reject(fixtedError);
-
-            CommonService.query(
-              [
-                customSQL.UPDATE_SEQUENCES_QUERY,
-                customSQL.POPULATE_ENTRANCE_POINT_GEOM,
-                customSQL.INDEX_OPTIMIZATION_MIGRATION,
-                customSQL.QUERY_PERFORMANCE_FIXES_MIGRATION,
-                customSQL.DROP_HISTORY_PARENT_FK_CONSTRAINTS,
-              ].join('\n')
-            )
-              .then(() => resolve())
-              .catch(reject);
-          },
-          false
-        );
-      }
-    );
-  });
+  await seedDatabase({ testUrl });
+  configureServer();
 }
 
 // ─── Bootstrap strategy ──────────────────────────────────────────────────────

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -178,6 +178,49 @@ CREATE INDEX IF NOT EXISTS idx_t_comment_entrance ON t_comment(id_entrance);
 CREATE INDEX IF NOT EXISTS idx_t_comment_cave ON t_comment(id_cave);
 `;
 
+// Create t_bibliographic_metadata table (no Waterline model exists for this
+// table, so migrate:drop does not create it). Required for testing permanent
+// document deletion which must clean up bibliographic metadata FK references.
+const CREATE_BIBLIOGRAPHIC_METADATA_TABLE = `
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 't_bibliographic_metadata'
+  ) THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'e_metadata_status') THEN
+      CREATE TYPE e_metadata_status AS ENUM ('registered', 'deleted');
+    END IF;
+    CREATE TABLE t_bibliographic_metadata (
+      id_document int4 NOT NULL,
+      oai_identifier varchar(50) NOT NULL,
+      last_update timestamp NOT NULL DEFAULT now(),
+      list_sets text[] NULL,
+      dc_title text NULL,
+      dc_creators text[] NULL,
+      dc_contributor text NULL,
+      dc_publisher text NULL,
+      dc_date date NULL,
+      dc_languages bpchar(3)[] NULL,
+      dc_descriptions text[] NULL,
+      dc_coverages text[] NULL,
+      dc_subjects text[] NULL,
+      dc_formats text[] NULL,
+      dc_identifiers text[] NULL,
+      dc_relations text[] NULL,
+      dc_sources text[] NULL,
+      dc_rights text[] NULL,
+      dc_types text[] NULL,
+      has_been_updated bool NOT NULL DEFAULT false,
+      metadata_status e_metadata_status NOT NULL DEFAULT 'registered',
+      children int4[] NULL,
+      CONSTRAINT t_record_pk PRIMARY KEY (id_document),
+      CONSTRAINT t_record_t_document_fk FOREIGN KEY (id_document) REFERENCES t_document(id)
+    );
+  END IF;
+END $$;
+`;
+
 // Drop FK constraints on history tables that reference their parent t_ table.
 // These are auto-created by Waterline's migrate:drop but do NOT exist in
 // production (where the schema comes from SQL migrations). Dropping them
@@ -221,5 +264,6 @@ module.exports = {
   POPULATE_ENTRANCE_POINT_GEOM,
   INDEX_OPTIMIZATION_MIGRATION,
   QUERY_PERFORMANCE_FIXES_MIGRATION,
+  CREATE_BIBLIOGRAPHIC_METADATA_TABLE,
   DROP_HISTORY_PARENT_FK_CONSTRAINTS,
 };

--- a/test/integration/4_routes/Documents/delete.test.js
+++ b/test/integration/4_routes/Documents/delete.test.js
@@ -144,5 +144,100 @@ describe('Document delete', () => {
       const deleted = await TDocument.findOne(doc.id);
       should(deleted).be.undefined();
     });
+
+    it('should permanently delete a document with entrance associations', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: true,
+        isDeleted: true,
+      }).fetch();
+
+      await TDocument.addToCollection(doc.id, 'entrances', [1]);
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/documents/${doc.id}?isPermanent=true`)
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const deleted = await TDocument.findOne(doc.id);
+      should(deleted).be.undefined();
+      const junctions = await JDocumentEntrance.find({ document: doc.id });
+      should(junctions).have.length(0);
+    });
+
+    it('should merge entrance associations when permanently deleting into another document', async () => {
+      const targetDoc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: true,
+      }).fetch();
+
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: true,
+        isDeleted: true,
+      }).fetch();
+
+      await TDocument.addToCollection(doc.id, 'entrances', [1]);
+
+      await supertest(sails.hooks.http.app)
+        .delete(
+          `/api/v1/documents/${doc.id}?isPermanent=true&entityId=${targetDoc.id}`
+        )
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const deleted = await TDocument.findOne(doc.id);
+      should(deleted).be.undefined();
+      const sourceJunctions = await JDocumentEntrance.find({
+        document: doc.id,
+      });
+      should(sourceJunctions).have.length(0);
+      const targetWithEntrances = await TDocument.findOne(
+        targetDoc.id
+      ).populate('entrances');
+      const entranceIds = targetWithEntrances.entrances.map((e) => e.id);
+      should(entranceIds).containEql(1);
+    });
+
+    it('should permanently delete a document with bibliographic metadata', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: true,
+        isDeleted: true,
+      }).fetch();
+
+      await sails.sendNativeQuery(
+        `INSERT INTO t_bibliographic_metadata (id_document, oai_identifier, last_update, metadata_status)
+         VALUES ($1, $2, NOW(), 'registered')`,
+        [doc.id, `oai:grottocenter.org:${doc.id}`]
+      );
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/documents/${doc.id}?isPermanent=true`)
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const deleted = await TDocument.findOne(doc.id);
+      should(deleted).be.undefined();
+      const { rows } = await sails.sendNativeQuery(
+        'SELECT * FROM t_bibliographic_metadata WHERE id_document = $1',
+        [doc.id]
+      );
+      should(rows).have.length(0);
+    });
   });
 });

--- a/test/seed-database.js
+++ b/test/seed-database.js
@@ -1,0 +1,90 @@
+/**
+ * Shared database seeding logic.
+ *
+ * Lifts Sails with migrate:drop, loads fixtures, and runs post-fixture SQL
+ * migrations. Used by both the test bootstrap (bootstrap.test.js) and the
+ * snapshot script (scripts/snapshot-test-db.js) to avoid duplicating the
+ * bootstrap sequence.
+ *
+ * @param {object} options
+ * @param {string} options.testUrl - PostgreSQL connection URL for the test DB
+ * @returns {Promise<object>} Resolves with the lifted `sails` instance
+ */
+
+const sails = require('sails');
+const Fixted = require('fixted');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const sailsPostGreAdapter = require('sails-postgresql');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { Client } = require('pg');
+const customSQL = require('./customSQL');
+const CommonService = require('../api/services/CommonService');
+const FIXTURE_ORDER = require('./fixtureOrder');
+
+/**
+ * Drop tables that are not managed by Waterline but have FK references to
+ * Waterline-managed tables. Without this, migrate:drop fails because it
+ * cannot drop the referenced tables.
+ */
+async function dropNonWaterlineTables(testUrl) {
+  const client = new Client({ connectionString: testUrl });
+  await client.connect();
+  try {
+    await client.query('DROP TABLE IF EXISTS t_bibliographic_metadata');
+    await client.query('DROP TYPE IF EXISTS e_metadata_status');
+  } finally {
+    await client.end();
+  }
+}
+
+async function seedDatabase({ testUrl }) {
+  await dropNonWaterlineTables(testUrl);
+  return new Promise((resolve, reject) => {
+    sails.lift(
+      {
+        log: { level: 'error' },
+        datastores: {
+          default: { adapter: sailsPostGreAdapter, url: testUrl },
+        },
+        models: { migrate: 'drop' },
+        csrf: false,
+        async bootstrap() {
+          await CommonService.query(customSQL.ALTER_MASSIF_COLUMN_GEOG_POLYGON);
+          await CommonService.query(customSQL.ALTER_ENTRANCE_COLUMN_POINT_GEOM);
+          await CommonService.query(
+            customSQL.CREATE_ENTRANCE_POINT_GEOM_INSERT_TRIGGER
+          );
+        },
+      },
+      // eslint-disable-next-line consistent-return
+      async (liftErr) => {
+        if (liftErr) return reject(liftErr);
+
+        const fixted = new Fixted();
+        fixted.populate(
+          FIXTURE_ORDER,
+          // eslint-disable-next-line consistent-return
+          (fixtedError) => {
+            if (fixtedError) return reject(fixtedError);
+
+            CommonService.query(
+              [
+                customSQL.UPDATE_SEQUENCES_QUERY,
+                customSQL.POPULATE_ENTRANCE_POINT_GEOM,
+                customSQL.INDEX_OPTIMIZATION_MIGRATION,
+                customSQL.QUERY_PERFORMANCE_FIXES_MIGRATION,
+                customSQL.CREATE_BIBLIOGRAPHIC_METADATA_TABLE,
+                customSQL.DROP_HISTORY_PARENT_FK_CONSTRAINTS,
+              ].join('\n')
+            )
+              .then(() => resolve(sails))
+              .catch(reject);
+          },
+          false
+        );
+      }
+    );
+  });
+}
+
+module.exports = seedDatabase;


### PR DESCRIPTION
## 🤔 What

- Fix FK violations when permanently deleting a document (`DELETE /api/v1/documents/:id?isPermanent=1`)
- Add cleanup for `j_document_entrance` and `t_bibliographic_metadata` before hard delete
- Refactor duplicated test bootstrap logic into a shared `test/seed-database.js` module
- Closes #1571

## 🤷‍♂️ Why

Permanently deleting a document failed with a 500 error due to two missing FK cleanup steps:
1. `j_document_entrance` — the `entrances` many-to-many association was not being cleared/merged, unlike all other junction tables
2. `t_bibliographic_metadata` — this table has no Waterline model but holds a FK to `t_document`, so it must be cleaned up via raw SQL

The bootstrap refactor was needed because the fix required adding `t_bibliographic_metadata` table creation to the test DB setup, and the seeding logic was duplicated between `test/bootstrap.test.js` and `scripts/snapshot-test-db.js` — making it easy to forget one (which is exactly how the original divergence happened).

## 🔍 How

**Controller fix** (`api/controllers/v1/document/delete.js`):
- Added `await linkedEntitiesDeleteOrMerge('entrances')` alongside the other junction table cleanups
- Added `sails.sendNativeQuery('DELETE FROM t_bibliographic_metadata WHERE id_document = $1', [documentId])` before the hard delete

**Test infrastructure** (`test/seed-database.js`):
- Extracted the shared Sails lift + fixture load + post-fixture SQL sequence into a single module
- Both `bootstrap.test.js` and `snapshot-test-db.js` now call `seedDatabase({ testUrl })` instead of duplicating the logic
- Added `CREATE_BIBLIOGRAPHIC_METADATA_TABLE` to `test/customSQL.js` since this table has no Waterline model
- Added `dropNonWaterlineTables()` pre-step to handle the chicken-and-egg problem where `migrate:drop` can't drop `t_document` if `t_bibliographic_metadata` already exists from a previous run

## 🧪 Testing

```bash
npm run test:snapshot   # Rebuild template (required once)
npm run test            # All 2212 tests pass
npm run test -- --grep "Document delete"  # 10 tests, including 3 new ones
```

New test cases:
- Permanently delete a document with entrance associations
- Merge entrance associations when permanently deleting into another document
- Permanently delete a document with bibliographic metadata

## 📸 Previews

N/A — backend-only change.
