### PR TITLE
fix(entrance): make add-document endpoint idempotent

### DIFF
--- a/api/controllers/v1/entrance/add-document.js
+++ b/api/controllers/v1/entrance/add-document.js
@@ -19,12 +19,21 @@ module.exports = async (req, res) => {
     entrance: entranceId,
   });
   if (existingLink > 0) {
-    return res.badRequest({
-      message: `Document ${documentId} is already linked to entrance ${entranceId}.`,
-    });
+    return res.ok();
   }
 
-  await TEntrance.addToCollection(entranceId, 'documents', documentId);
+  try {
+    await TEntrance.addToCollection(entranceId, 'documents', documentId);
+  } catch (err) {
+    if (err.code === 'E_UNIQUE') {
+      sails.log.debug(
+        `Race-condition duplicate: entrance ${entranceId} / document ${documentId} link already exists.`
+      );
+      return res.ok();
+    }
+    throw err;
+  }
+
   await TDocument.updateOne(documentId).set({
     dateReviewed: new Date(),
   });

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3642,7 +3642,7 @@ paths:
       tags:
         - entrances
         - documents
-      description: Add a document to an entrance.
+      description: Add a document to an entrance. This operation is idempotent — linking an already-linked document returns 204 without error.
       parameters:
         - name: entranceId
           in: path
@@ -3657,7 +3657,7 @@ paths:
             type: string
       responses:
         '204':
-          description: Successful operation
+          description: Successful operation (also returned if the link already exists)
         '404':
           description: Could not find entrance with the entrance id you provided or could not find the document with the document id you provided.
         '403':

--- a/test/integration/4_routes/Entrances/addDocument.test.js
+++ b/test/integration/4_routes/Entrances/addDocument.test.js
@@ -79,7 +79,7 @@ describe('Entrance add document features', () => {
         await JDocumentEntrance.destroy({ document: testDocumentId });
       });
 
-      it('should return 400 when adding same document twice to same entrance', async () => {
+      it('should return 204 idempotently across two identical PUT calls', async () => {
         await supertest(sails.hooks.http.app)
           .put(
             `/api/v1/entrances/${testEntranceId}/documents/${testDocumentId}`
@@ -87,14 +87,42 @@ describe('Entrance add document features', () => {
           .set('Authorization', userToken)
           .expect(204);
 
-        const response = await supertest(sails.hooks.http.app)
+        await supertest(sails.hooks.http.app)
           .put(
             `/api/v1/entrances/${testEntranceId}/documents/${testDocumentId}`
           )
           .set('Authorization', userToken)
-          .expect(400);
+          .expect(204);
 
-        should(response.body.message).match(/already linked to entrance/);
+        const links = await JDocumentEntrance.find({
+          document: testDocumentId,
+          entrance: testEntranceId,
+        });
+        should(links).have.length(1);
+      });
+
+      it('should not update dateReviewed on duplicate PUT', async () => {
+        // First PUT creates the link and sets dateReviewed
+        await supertest(sails.hooks.http.app)
+          .put(
+            `/api/v1/entrances/${testEntranceId}/documents/${testDocumentId}`
+          )
+          .set('Authorization', userToken)
+          .expect(204);
+
+        const docAfterFirst = await TDocument.findOne(testDocumentId);
+        const dateReviewedAfterFirst = docAfterFirst.dateReviewed;
+
+        // Second PUT is a duplicate — dateReviewed must remain unchanged
+        await supertest(sails.hooks.http.app)
+          .put(
+            `/api/v1/entrances/${testEntranceId}/documents/${testDocumentId}`
+          )
+          .set('Authorization', userToken)
+          .expect(204);
+
+        const docAfterSecond = await TDocument.findOne(testDocumentId);
+        should(docAfterSecond.dateReviewed).deepEqual(dateReviewedAfterFirst);
       });
     });
 


### PR DESCRIPTION
## 🤔 What

- Make `PUT /api/v1/entrances/:entranceId/documents/:documentId` idempotent
- Return 204 (success) when the document-entrance link already exists, instead of 400
- Add a try/catch around `addToCollection` to handle `E_UNIQUE` race conditions gracefully
- Update Swagger spec to document the idempotent behavior
- Closes #1572

## 🤷‍♂️ Why

When a user attempts to link a document that is already associated with an entrance, the API was returning a 500 error due to a PostgreSQL uniqueness constraint violation (`E_UNIQUE` on `jdocumententrance`). A previous fix returned 400, but PUT operations should be idempotent — repeating the same request should produce the same result without error.

## 🔍 How

1. The existing `JDocumentEntrance.count()` pre-check now returns `res.ok()` (204) instead of `res.badRequest()` when the link already exists
2. A try/catch wraps `addToCollection` to handle the race condition where a concurrent request inserts the row between the count check and the insert — also returns 204
3. Only truly new links trigger the `dateReviewed` update on the document

## 🧪 Testing

```bash
npm run test -- --grep "Entrance add document"
```

All 8 tests pass, including the updated duplicate test that now expects 204.

## 📸 Previews

N/A — backend-only change.
