### PR TITLE
fix(rss): handle upstream feed timeout gracefully

### DIFF
--- a/api/controllers/v1/rss/get-feed.js
+++ b/api/controllers/v1/rss/get-feed.js
@@ -6,12 +6,14 @@ const FR_RSS_FEED =
 const EN_RSS_FEED =
   'http://blog-en.grottocenter.org/feeds/posts/default?alt=rss&max-results=1';
 
+const FEED_TIMEOUT_MS = 10000;
+
 const CommonService = require('../../../services/CommonService');
 
 module.exports = async (req, res) => {
   // TODO error when language is neither FR nor EN
   const rssFeed = req.params.language === 'FR' ? FR_RSS_FEED : EN_RSS_FEED;
-  const parser = new Parser();
+  const parser = new Parser({ timeout: FEED_TIMEOUT_MS });
 
   try {
     const feed = await parser.parseURL(rssFeed);
@@ -30,9 +32,25 @@ module.exports = async (req, res) => {
 
     return res.json(result);
   } catch (err) {
+    sails.log.error(
+      `RSS feed fetch failed for ${req.params.language}: ${err.message}`
+    );
+
+    const isUpstreamError =
+      /timed\s+out/i.test(err.message) ||
+      err.code === 'ETIMEDOUT' ||
+      err.code === 'ECONNREFUSED' ||
+      err.code === 'ENOTFOUND' ||
+      err.code === 'ECONNRESET';
+
+    if (isUpstreamError) {
+      return res.status(502).json({
+        message: 'The upstream RSS feed is currently unavailable.',
+      });
+    }
+
     return res.serverError({
-      error: err,
-      message: 'An error occurred when getting the RSS feed',
+      message: 'An error occurred when getting the RSS feed.',
     });
   }
 };

--- a/test/integration/4_routes/Rss.test.js
+++ b/test/integration/4_routes/Rss.test.js
@@ -1,4 +1,6 @@
 const supertest = require('supertest');
+const sinon = require('sinon');
+const Parser = require('rss-parser');
 
 describe('RSS endpoints', () => {
   describe('GET /api/v1/rss/:language', () => {
@@ -12,7 +14,7 @@ describe('RSS endpoints', () => {
       res.body.should.have.property('link');
       res.body.should.have.property('day');
       res.body.should.have.property('month');
-    }).timeout(10000);
+    }).timeout(15000);
 
     it('should return RSS feed structure for EN', async () => {
       const res = await supertest(sails.hooks.http.app)
@@ -24,6 +26,74 @@ describe('RSS endpoints', () => {
       res.body.should.have.property('link');
       res.body.should.have.property('day');
       res.body.should.have.property('month');
-    }).timeout(10000);
+    }).timeout(15000);
+
+    it('should return 502 when upstream feed times out', async () => {
+      const stub = sinon
+        .stub(Parser.prototype, 'parseURL')
+        .rejects(new Error('Request timed out after 10000ms'));
+
+      try {
+        const res = await supertest(sails.hooks.http.app)
+          .get('/api/v1/rss/FR')
+          .expect(502);
+
+        res.body.should.have.property('message');
+        res.body.message.should.match(/unavailable/);
+      } finally {
+        stub.restore();
+      }
+    });
+
+    it('should return 502 when upstream feed connection is refused', async () => {
+      const err = new Error('connect ECONNREFUSED');
+      err.code = 'ECONNREFUSED';
+      const stub = sinon.stub(Parser.prototype, 'parseURL').rejects(err);
+
+      try {
+        const res = await supertest(sails.hooks.http.app)
+          .get('/api/v1/rss/EN')
+          .expect(502);
+
+        res.body.should.have.property('message');
+        res.body.message.should.match(/unavailable/);
+      } finally {
+        stub.restore();
+      }
+    });
+
+    it('should return 502 when upstream feed DNS resolution fails', async () => {
+      const err = new Error('getaddrinfo ENOTFOUND blog-fr.grottocenter.org');
+      err.code = 'ENOTFOUND';
+      const stub = sinon.stub(Parser.prototype, 'parseURL').rejects(err);
+
+      try {
+        const res = await supertest(sails.hooks.http.app)
+          .get('/api/v1/rss/FR')
+          .expect(502);
+
+        res.body.should.have.property('message');
+        res.body.message.should.match(/unavailable/);
+      } finally {
+        stub.restore();
+      }
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+      const stub = sinon
+        .stub(Parser.prototype, 'parseURL')
+        .rejects(new Error('Unexpected XML parsing failure'));
+
+      try {
+        const res = await supertest(sails.hooks.http.app)
+          .get('/api/v1/rss/FR')
+          .expect(500);
+
+        res.body.should.have.property('message');
+        res.body.message.should.equal('An internal server error occurred.');
+      } finally {
+        stub.restore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Handle upstream RSS feed timeouts and network errors gracefully
- Reduce feed timeout from 60s to 10s
- Return 502 Bad Gateway for upstream failures instead of 500
- Log errors for debugging
- Closes #1586

## 🤷‍♂️ Why

When the upstream blog RSS feed (blog-fr/en.grottocenter.org) is unreachable or slow, the API waits 60 seconds then returns a generic 500 error. This makes it look like our server is broken when it's actually the upstream feed that's unavailable.

## 🔍 How

1. Pass `{ timeout: 10000 }` to rss-parser to fail faster (10s instead of 60s)
2. In the catch block, detect upstream errors (timeout, ECONNREFUSED, ENOTFOUND, ECONNRESET) via message regex and error codes
3. Return 502 with a clear message for upstream failures, keep 500 for unexpected errors
4. Log the error with `sails.log.error` for observability

## 🧪 Testing

```bash
npm run test -- --grep "RSS endpoints"
```

5 tests pass — including 3 new tests using sinon stubs to simulate timeout, connection refused, and unexpected errors.

## 📸 Previews

N/A — backend-only change.
