### PR TITLE
fix(search): handle string array filters as multi-value exact match

### DIFF
--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -39,11 +39,20 @@ function buildFilter(filter, isLogicalCompareAnd = true) {
 
       let vFmt = trimmed;
       let operator = ':'; // Partial equal
-      if (Array.isArray(trimmed))
-        vFmt = `[${trimmed.join('..')}]`; // Range
-      else if (typeof trimmed === 'boolean' || typeof trimmed === 'number')
+      if (Array.isArray(trimmed)) {
+        if (trimmed.length === 0) return []; // Skip empty arrays
+        const isNumericRange =
+          trimmed.length === 2 && trimmed.every((el) => typeof el === 'number');
+        if (isNumericRange) {
+          vFmt = `[${trimmed.join('..')}]`; // Numeric range
+        } else {
+          // Multi-value exact match (non-numeric-range arrays)
+          operator = ':=';
+          vFmt = `[${trimmed.map((el) => `\`${String(el).replace(/`/g, '')}\``).join(',')}]`;
+        }
+      } else if (typeof trimmed === 'boolean' || typeof trimmed === 'number')
         operator = ':='; // Exact equal
-      else vFmt = `\`${trimmed}\``;
+      else vFmt = `\`${trimmed.replace(/`/g, '')}\``;
       return [`${k}${operator}${vFmt}`];
     });
   return {

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -481,7 +481,7 @@ describe('SearchService', () => {
       should(call.args[1].filter_by).equal('count:=5');
     });
 
-    it('should handle array values as range', async () => {
+    it('should handle two-number array values as numeric range', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
         .resolves({ hits: [] });
@@ -493,6 +493,94 @@ describe('SearchService', () => {
 
       const call = typesenseStub.search.getCall(0);
       should(call.args[1].filter_by).equal('year:[2020..2024]');
+    });
+
+    it('should handle string array values as multi-value exact match', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { 'massifs.name': ['Vercors (massif du)'] },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'massifs.name:=[`Vercors (massif du)`]'
+      );
+    });
+
+    it('should skip empty arrays and produce no filter', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { 'massifs.name': [] },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).be.undefined();
+    });
+
+    it('should handle single-element numeric array as multi-value exact match', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { depth: [5] },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal('depth:=[`5`]');
+    });
+
+    it('should strip backtick characters from string values to prevent malformed filters', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { city: 'foo`bar' },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal('city:`foobar`');
+    });
+
+    it('should strip backtick characters from array element values', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { 'massifs.name': ['foo`bar', 'baz`qux'] },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal('massifs.name:=[`foobar`,`bazqux`]');
+    });
+
+    it('should handle multiple string array values as multi-value exact match', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ hits: [] });
+
+      await SearchService.collectionSearch({
+        entity: 'entrances',
+        filter: { 'massifs.name': ['Vercors (massif du)', 'Chartreuse'] },
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].filter_by).equal(
+        'massifs.name:=[`Vercors (massif du)`,`Chartreuse`]'
+      );
     });
 
     it('should filter out null but keep false and zero as valid filter values', async () => {


### PR DESCRIPTION
## 🤔 What

- Fix `buildFilter` in `SearchService` to correctly handle string array filter values in advanced search.
- Previously, passing a string array (e.g. `"massifs.name": ["Vercors (massif du)"]`) produced invalid Typesense filter syntax.

## 🤷‍♂️ Why

The `buildFilter` function treated all arrays as numeric ranges using `[min..max]` syntax. When the front-end sends a string array for facet filtering (e.g. filtering entrances by massif name), Typesense rejected the malformed filter, causing the request to fail.

## 🔍 How

The function now distinguishes between:
- **Two-number arrays** → numeric range filter: `field:[min..max]` (existing behavior preserved)
- **String arrays** (or any other array shape) → multi-value exact match: `field:=[\`value1\`,\`value2\`]`

This matches Typesense's expected syntax for filtering on `string[]` fields.

## 🧪 Testing

```bash
# String array filter (the fix)
curl -s -X POST http://localhost:1337/api/v1/advanced-search \
  -H "Content-Type: application/json" \
  -d '{"query":"","entity":"entrances","filter":{"massifs.name":["Géoparc du Chablais"]},"matchAllFields":true,"page":1,"size":5}'

# Numeric range filter (still works)
curl -s -X POST http://localhost:1337/api/v1/advanced-search \
  -H "Content-Type: application/json" \
  -d '{"query":"","entity":"entrances","filter":{"altitude":[1000,2000]},"matchAllFields":true,"page":1,"size":5}'
```

Unit tests added for both single and multiple string array values.
