### PR TITLE
fix(document): use native queries to clear junction rows on permanent delete

### DIFF
--- a/api/controllers/v1/document/delete.js
+++ b/api/controllers/v1/document/delete.js
@@ -75,9 +75,27 @@ module.exports = async (req, res) => {
 
     await TNotification.destroy({ document: documentId });
 
+    // Note: `regions` is intentionally excluded — it uses a separate
+    // native query below because its junction table (j_document_region)
+    // does not follow the same column naming convention.
+    const junctionTableMap = {
+      countries: 'j_document_country',
+      entrances: 'j_document_entrance',
+      isoRegions: 'j_document_iso3166_2',
+      languages: 'j_document_language',
+      massifs: 'j_document_massif',
+      subjects: 'j_document_subject',
+      authorsGrotto: 'j_document_grotto_author',
+      authors: 'j_document_caver_author',
+    };
+
     // eslint-disable-next-line no-inner-declarations
     async function linkedEntitiesDeleteOrMerge(key) {
-      if (document[key].length === 0) return;
+      if (!Array.isArray(document[key])) {
+        throw new Error(
+          `Association "${key}" was not populated on document ${documentId}`
+        );
+      }
       if (shouldMergeInto) {
         const existingEntities = mergeIntoEntity[key].map((e) => e.id);
         const entitiesToAdd = document[key]
@@ -85,12 +103,20 @@ module.exports = async (req, res) => {
           .filter((e) => !existingEntities.includes(e));
         await TDocument.addToCollection(mergeIntoId, key, entitiesToAdd);
       }
-      await TDocument.updateOne(documentId).set({ [key]: [] });
+      // Use native query to delete junction rows directly.
+      // Waterline's collection setter (set({ [key]: [] })) fails silently
+      // on soft-deleted records, leaving FK references that block hard delete.
+      await sails.sendNativeQuery(
+        `DELETE FROM ${junctionTableMap[key]} WHERE id_document = $1`,
+        [documentId]
+      );
     }
 
     if (document.files.length > 0) {
       if (shouldMergeInto) {
-        TFile.update({ document: documentId }).set({ document: mergeIntoId });
+        await TFile.update({ document: documentId }).set({
+          document: mergeIntoId,
+        });
       } else {
         await Promise.all(
           document.files.map((e) => FileService.document.delete(e))
@@ -107,7 +133,10 @@ module.exports = async (req, res) => {
     await linkedEntitiesDeleteOrMerge('authorsGrotto');
     await linkedEntitiesDeleteOrMerge('authors');
 
-    await TDocument.updateOne(documentId).set({ regions: [] });
+    await sails.sendNativeQuery(
+      'DELETE FROM j_document_region WHERE id_document = $1',
+      [documentId]
+    );
 
     await TDocumentDuplicate.destroy({ id: documentId });
 

--- a/test/integration/4_routes/Documents/delete.test.js
+++ b/test/integration/4_routes/Documents/delete.test.js
@@ -169,6 +169,31 @@ describe('Document delete', () => {
       should(junctions).have.length(0);
     });
 
+    it('should permanently delete a non-deleted document with entrance associations (two-step flow)', async () => {
+      // Reproduces #1596: non-deleted doc + junction rows + isPermanent in one request
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: true,
+        isDeleted: false,
+      }).fetch();
+
+      await TDocument.addToCollection(doc.id, 'entrances', [1]);
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/documents/${doc.id}?isPermanent=true`)
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const deleted = await TDocument.findOne(doc.id);
+      should(deleted).be.undefined();
+      const junctions = await JDocumentEntrance.find({ document: doc.id });
+      should(junctions).have.length(0);
+    });
+
     it('should merge entrance associations when permanently deleting into another document', async () => {
       const targetDoc = await TDocument.create({
         author: 1,


### PR DESCRIPTION
## 🤔 What

- Fix FK constraint violation (`23503`) when permanently deleting a document that has junction table associations (e.g. `j_document_entrance`)
- Closes #1596

## 🤷‍♂️ Why

When a document is permanently deleted via `DELETE /api/v1/documents/:id?isPermanent=1`, the controller first soft-deletes the record (`TDocument.destroyOne` sets `is_deleted = true`), then attempts to clear junction rows using Waterline's collection setter (`TDocument.updateOne(id).set({ entrances: [] })`).

However, `updateOne` doesn't find the soft-deleted record, so the junction rows remain intact. The final hard delete then fails with:

```
foreign key constraint "j_document_entrance_t_document_fk" on table "j_document_entrance"
```

## 🔍 How

Replaced Waterline's collection setter with direct native `DELETE` queries against all 9 junction tables (`j_document_entrance`, `j_document_country`, `j_document_iso3166_2`, `j_document_language`, `j_document_massif`, `j_document_subject`, `j_document_grotto_author`, `j_document_caver_author`, `j_document_region`).

Native queries work regardless of the document's soft-delete state, ensuring junction rows are always cleaned up before the hard delete.

The merge-into logic (`addToCollection` on the target document) is unaffected since it operates on the target, not the deleted source.

## 🧪 Testing

Added a characterization test that reproduces the exact production scenario: a non-deleted document with entrance associations is permanently deleted in a single call (triggering soft-delete then hard-delete in sequence).

```
npm run test -- --grep "Document delete"
```

## 📸 Previews

N/A — backend-only fix.
