### PR TITLE
fix(document): normalize massifs to IDs in validate flow

### DIFF
--- a/api/controllers/v1/document/multiple-validate.js
+++ b/api/controllers/v1/document/multiple-validate.js
@@ -17,6 +17,28 @@ async function markDocumentValidated(
   });
 }
 
+// modifiedDocJson may pre-date this fix and contain populated objects instead of plain IDs.
+function normalizeCollectionIds(documentData) {
+  const collectionFields = [
+    'massifs',
+    'authors',
+    'authorsGrotto',
+    'subjects',
+    'languages',
+    'isoRegions',
+    'countries',
+  ];
+  const normalized = { ...documentData };
+  for (const field of collectionFields) {
+    if (Array.isArray(normalized[field])) {
+      normalized[field] = normalized[field].map((item) =>
+        typeof item === 'object' && item !== null ? (item.id ?? item) : item
+      );
+    }
+  }
+  return normalized;
+}
+
 async function validateAndUpdateDocument(
   document,
   validationComment,
@@ -31,6 +53,8 @@ async function validateAndUpdateDocument(
     newFiles,
   } = document.modifiedDocJson;
 
+  const cleanedDocumentData = normalizeCollectionIds(documentData);
+
   await sails.getDatastore().transaction(async (db) => {
     // Update associated data not handled by TDocument manually
     // Updated before the TDocument update so the last_change_document DB trigger will fetch the last updated name
@@ -40,7 +64,7 @@ async function validateAndUpdateDocument(
 
     await TDocument.updateOne(document.id)
       .set({
-        ...documentData,
+        ...cleanedDocumentData,
         modifiedDocJson: null,
         dateReviewed: new Date(),
         reviewer: reviewerId,

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -93,7 +93,10 @@ module.exports = {
   getConvertedDataFromClient: async (body) => {
     // Massif will be deleted in the future (a document can be about many massifs and a massif can be the subject of many documents): use massifs
     const massif = body.massif?.id;
-    const massifs = [...(body.massifs ?? []), ...(massif ? [massif] : [])];
+    const massifs = [
+      ...(body.massifs ?? []).map((m) => m.id ?? m),
+      ...(massif ? [massif] : []),
+    ];
 
     let optionFound;
     // eslint-disable-next-line no-param-reassign

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -161,6 +161,52 @@ describe('Document multiple-validate', () => {
       should(updated.isValidated).be.true();
       should(updated.modifiedDocJson).be.null();
     });
+
+    it('should validate document with modifiedDocJson containing massifs as objects', async () => {
+      const massif = await TMassif.create({ author: 1 }).fetch();
+
+      const desc = await TDescription.create({
+        author: 1,
+        title: 'Original',
+        body: 'Original body',
+      }).fetch();
+
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+        descriptions: [desc.id],
+        modifiedDocJson: {
+          reviewerId: 2,
+          documentData: {
+            type: 17,
+            massifs: [{ id: massif.id, name: 'Some massif' }],
+          },
+          descriptionData: { title: 'Updated', body: 'Updated body' },
+        },
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .put('/api/v1/documents/validate')
+        .send({
+          documents: [{ id: doc.id, isValidated: 'true' }],
+        })
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(204);
+
+      const updated = await TDocument.findOne(doc.id).populate('massifs');
+      should(updated.isValidated).be.true();
+      should(updated.modifiedDocJson).be.null();
+      should(updated.massifs).be.an.Array();
+      should(updated.massifs.map((m) => m.id)).containDeep([massif.id]);
+
+      const updatedDesc = await TDescription.findOne(desc.id);
+      should(updatedDesc.title).equal('Updated');
+      should(updatedDesc.body).equal('Updated body');
+    });
   });
 
   describe('Author notifications', () => {


### PR DESCRIPTION
## 🤔 What

- Fix `E_INVALID_VALUES_TO_SET` error on `PUT /api/v1/documents/validate` when validating documents that have `massifs` stored as objects in `modifiedDocJson`
- Closes #1601

## 🤷‍♂️ Why

When a document is edited, `getConvertedDataFromClient` stores `massifs` directly from the request body without extracting IDs (unlike `authors`, `authorsGrotto`, `subjects` which all use `.map(x => x.id)`). If the front-end sends massifs as objects (`[{ id: 1, name: "..." }]`), these objects end up in `modifiedDocJson.documentData.massifs`. When a moderator later validates the document, `validateAndUpdateDocument` spreads `documentData` into `TDocument.updateOne().set()`, and Waterline rejects the objects with `E_INVALID_VALUES_TO_SET`.

## 🔍 How

Two-layer fix:

1. **`DocumentService.getConvertedDataFromClient`** — normalize `massifs` to plain IDs using `.map((m) => m.id ?? m)`, consistent with how other collection associations are handled. This prevents future `modifiedDocJson` records from storing objects.

2. **`multiple-validate.js` — `normalizeCollectionIds` helper** — before spreading `documentData` into `.set()`, normalize all collection association fields (`massifs`, `authors`, `authorsGrotto`, `subjects`, `languages`, `isoRegions`, `countries`) to plain IDs. This handles existing `modifiedDocJson` records already stored in the database with object values.

## 🧪 Testing

- Added test: "should validate document with modifiedDocJson containing massifs as objects"
- Full test suite passes (2305 tests, 0 failures)
