### PR TITLE
fix(document): use TMassif and normalize IDs in populateJSON

### DIFF
--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -9,6 +9,10 @@ const {
   distantFileDownload,
 } = require('../utils/csvHelper');
 
+// Normalize a collection value to a plain ID (handles both raw IDs and objects).
+const normalizeToId = (item) =>
+  item != null && typeof item === 'object' ? (item.id ?? item) : item;
+
 module.exports = {
   async deleteInSearch(documentId) {
     await SearchService.deleteDocument('documents', documentId);
@@ -373,15 +377,18 @@ module.exports = {
       ...otherSimpleData
     } = documentData;
 
+    // Normalize collections and join the tables
+    const toIds = (arr) => arr.map(normalizeToId);
+
     // Join the tables
     const doc = { ...otherSimpleData, id: documentId };
     doc.identifierType = identifierType
       ? await TIdentifierType.findOne(identifierType)
       : null;
     doc.author = author ? await TCaver.findOne(author) : null;
-    doc.authors = authors ? await TCaver.find({ id: authors }) : [];
+    doc.authors = authors ? await TCaver.find({ id: toIds(authors) }) : [];
     doc.authorsGrotto = authorsGrotto
-      ? await TGrotto.find({ id: authorsGrotto })
+      ? await TGrotto.find({ id: toIds(authorsGrotto) })
       : [];
     doc.reviewer = reviewer ? await TCaver.findOne(reviewer) : null;
     doc.editor = editor ? await TGrotto.findOne(editor) : null;
@@ -389,17 +396,25 @@ module.exports = {
 
     doc.type = type ? await TType.findOne(type) : null;
     // descriptions is a special case
-    doc.subjects = subjects ? await TSubject.find({ id: subjects }) : [];
+    doc.subjects = subjects ? await TSubject.find({ id: toIds(subjects) }) : [];
     doc.license = license ? await TLicense.findOne(license) : null;
     doc.option = option ? await TOption.findOne(option) : null;
-    doc.languages = languages ? await TLanguage.find({ id: languages }) : [];
+    doc.languages = languages
+      ? await TLanguage.find({ id: toIds(languages) })
+      : [];
 
     // TODO files ?
-    doc.countries = countries ? await TCountry.find({ id: countries }) : [];
-    doc.isoRegions = isoRegions ? await TISO31662.find({ id: isoRegions }) : [];
+    doc.countries = countries
+      ? await TCountry.find({ id: toIds(countries) })
+      : [];
+    doc.isoRegions = isoRegions
+      ? await TISO31662.find({ id: toIds(isoRegions) })
+      : [];
     doc.cave = cave ? await TCave.findOne(cave) : null;
-    doc.entrances = entrances ? await TEntrance.find({ id: entrances }) : [];
-    doc.massifs = massifs ? await TCountry.find({ id: massifs }) : [];
+    doc.entrances = entrances
+      ? await TEntrance.find({ id: toIds(entrances) })
+      : [];
+    doc.massifs = massifs ? await TMassif.find({ id: toIds(massifs) }) : [];
     doc.parent = parent
       ? (await module.exports.getDocuments([parent]))[0]
       : null;
@@ -505,4 +520,6 @@ module.exports = {
 
     return module.exports.getDocuments(collectionIds);
   },
+
+  normalizeToId,
 };

--- a/test/integration/4_routes/Documents/find.test.js
+++ b/test/integration/4_routes/Documents/find.test.js
@@ -103,6 +103,49 @@ describe('Document find', () => {
         });
     });
 
+    it('should return modified document with massifs as objects in modifiedDocJson', async () => {
+      const desc = await TDescription.create({
+        author: 1,
+        title: 'Test',
+        body: 'Test body',
+      }).fetch();
+
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        license: 1,
+        isValidated: false,
+        descriptions: [desc.id],
+        modifiedDocJson: {
+          reviewerId: 2,
+          documentData: {
+            type: 17,
+            massifs: [{ id: 1, name: 'Some massif' }],
+          },
+          descriptionData: { title: 'Updated', body: 'Updated body' },
+        },
+      }).fetch();
+
+      // Inline cleanup: this test creates its own fixture data independent of the shared before/after hooks.
+      try {
+        await supertest(sails.hooks.http.app)
+          .get(`/api/v1/documents/${doc.id}?requireUpdate=true`)
+          .set('Authorization', moderatorToken)
+          .set('Accept', 'application/json')
+          .expect(200)
+          .then((res) => {
+            should(res.body).have.property('id');
+            should(res.body).have.property('massifs');
+            should(res.body.massifs).be.an.Array();
+            should(res.body.massifs).not.be.empty();
+            should(res.body.massifs).containDeep([{ id: 1 }]);
+          });
+      } finally {
+        await TDocument.destroy({ id: doc.id });
+        await TDescription.destroy({ id: desc.id });
+      }
+    });
+
     it('should return base document when requireUpdate is false', (done) => {
       supertest(sails.hooks.http.app)
         .get(`/api/v1/documents/${testDocId}?requireUpdate=false`)


### PR DESCRIPTION
## 🤔 What

- Fix `E_INVALID_CRITERIA` error on `GET /api/v1/documents/:id?requireUpdate=true` when `modifiedDocJson.documentData` contains `massifs` (or other collection associations) as objects
- Fix wrong model usage: `populateJSON` was querying `TCountry` instead of `TMassif` for the massifs field
- Closes #1602

## 🤷‍♂️ Why

`DocumentService.populateJSON` is called when a moderator fetches a document with pending modifications (`requireUpdate=true`). It receives `documentData` from `modifiedDocJson` and queries related tables to build a populated response.

Two bugs existed:
1. **Wrong model**: `doc.massifs = await TCountry.find({ id: massifs })` — should be `TMassif`
2. **Objects instead of IDs**: `massifs` (and potentially other collection fields) stored in `modifiedDocJson` may contain objects like `[{ id: 1, name: "..." }]` rather than plain IDs. Passing these to `{ id: massifs }` causes Waterline to reject the criteria with `E_INVALID_CRITERIA`.

## 🔍 How

- Added a `toIds` helper inside `populateJSON` that normalizes any collection field to plain IDs: `(arr) => arr.map(item => item.id ?? item)`
- Applied `toIds` to all collection association queries (`authors`, `authorsGrotto`, `subjects`, `languages`, `countries`, `isoRegions`, `entrances`, `massifs`)
- Changed `TCountry.find` to `TMassif.find` for the massifs field

## 🧪 Testing

- Added test: "should return modified document with massifs as objects in modifiedDocJson"
- Full test suite passes (2306 tests, 0 failures)
