### PR TITLE
fix(massif): validate polygon geometry before area computation

### DIFF
--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -41,11 +41,10 @@ module.exports = async (req, res) => {
 
   // Convert polygon and validate area before the transaction
   const wkt = await MassifService.geoJsonToWKT(req.body.geogPolygon);
-  const areaKm2 = await MassifService.computePolygonAreaKm2(wkt);
-  if (areaKm2 > MassifService.MAX_AREA_KM2) {
-    return res.badRequest(
-      `The massif polygon area (${areaKm2.toFixed(0)} km²) exceeds the maximum allowed size of ${MassifService.MAX_AREA_KM2} km².`
-    );
+
+  const polygonError = await MassifService.validatePolygon(wkt);
+  if (polygonError) {
+    return res.badRequest(polygonError);
   }
 
   const rawData = MassifService.getConvertedDataFromClientRequest(req);

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -17,13 +17,12 @@ module.exports = async (req, res) => {
     cleanedData.geogPolygon = await MassifService.geoJsonToWKT(
       cleanedData.geogPolygon
     );
-    const areaKm2 = await MassifService.computePolygonAreaKm2(
+
+    const polygonError = await MassifService.validatePolygon(
       cleanedData.geogPolygon
     );
-    if (areaKm2 > MassifService.MAX_AREA_KM2) {
-      return res.badRequest(
-        `The massif polygon area (${areaKm2.toFixed(0)} km²) exceeds the maximum allowed size of ${MassifService.MAX_AREA_KM2} km².`
-      );
+    if (polygonError) {
+      return res.badRequest(polygonError);
     }
   }
   // Sensitivity is managed exclusively via mark-sensitive / unmark-sensitive

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -7,6 +7,84 @@ const coerceBool = require('../utils/coerceBool');
 
 const MAX_AREA_KM2 = 35000;
 
+// Maps PostGIS/GEOS error keywords to structured error responses.
+// Each entry is [keyword to match, error code, user-facing message].
+// Error codes follow the pattern: POLYGON_<CATEGORY>
+const POLYGON_ERROR_MESSAGES = [
+  // ST_IsValid failures (GEOS)
+  [
+    'Self-intersection',
+    'POLYGON_SELF_INTERSECTION',
+    'The polygon edges cross each other. Please redraw without self-intersections.',
+  ],
+  [
+    'Too few points',
+    'POLYGON_TOO_FEW_POINTS',
+    'The polygon does not have enough points. A valid polygon needs at least 4 coordinates.',
+  ],
+  [
+    'Hole lies outside shell',
+    'POLYGON_HOLE_OUTSIDE',
+    'A hole is located outside the outer boundary. Please ensure all holes are within the polygon.',
+  ],
+  [
+    'Nested holes',
+    'POLYGON_NESTED_HOLES',
+    'The polygon contains holes within holes. Please flatten the hole structure.',
+  ],
+  [
+    'Disconnected interior',
+    'POLYGON_DISCONNECTED',
+    'The polygon interior is split into disconnected parts. Please draw it as separate polygons.',
+  ],
+  [
+    'Duplicate Rings',
+    'POLYGON_DUPLICATE_RINGS',
+    'The polygon contains duplicate rings. Please remove the repeated boundary.',
+  ],
+  // ST_Area geography failures (PostGIS XX000)
+  [
+    'lwgeom_area_spher',
+    'POLYGON_INVALID_WINDING',
+    'The polygon rings have an invalid winding order. Exterior rings must be counter-clockwise and holes must be clockwise.',
+  ],
+  [
+    'Antipodal',
+    'POLYGON_ANTIPODAL_EDGE',
+    'The polygon contains an edge that spans exactly 180°. Please split it into smaller segments.',
+  ],
+  [
+    'crosses equator',
+    'POLYGON_CROSSES_EQUATOR',
+    'The polygon contains a ring that crosses the equator. Please split it into separate northern and southern polygons.',
+  ],
+];
+
+const POLYGON_AREA_EXCEEDED = 'POLYGON_AREA_EXCEEDED';
+const POLYGON_INVALID = 'POLYGON_INVALID';
+
+/**
+ * Find the first matching error for a raw PostGIS/GEOS error string.
+ * Note: keyword matching is case-sensitive and relies on PostGIS/GEOS error
+ * wording which is stable within a major version but could change across
+ * upgrades. Re-verify keyword casing when upgrading PostGIS.
+ * @param {string} raw - raw error string to match against
+ * @returns {{ code: string, message: string }} structured error
+ */
+function matchPolygonError(raw) {
+  const match = POLYGON_ERROR_MESSAGES.find(([keyword]) =>
+    raw.includes(keyword)
+  );
+  if (match) {
+    return { code: match[1], message: match[2] };
+  }
+  return {
+    code: POLYGON_INVALID,
+    message:
+      'The polygon could not be processed. Please simplify or redraw it.',
+  };
+}
+
 const FIND_NETWORKS_IN_MASSIF = `
   SELECT c.*, c.length AS "caveLength", count(e.id_cave) as "nbEntrances"
   FROM t_entrance AS e
@@ -61,6 +139,7 @@ async function safeDBQuery(sql, param) {
 
 module.exports = {
   MAX_AREA_KM2,
+  matchPolygonError,
 
   /**
    * Compute the area of a polygon in square kilometers using PostGIS geodesic calculation.
@@ -72,6 +151,58 @@ module.exports = {
     const query = `SELECT ST_Area($1::geography) / 1000000 AS area_km2`;
     const result = await CommonService.query(query, [wktPolygon]);
     return parseFloat(result.rows[0].area_km2);
+  },
+
+  /**
+   * Validate a polygon's geometry and area constraints.
+   * Checks basic validity (ST_IsValid), geographic computability (ST_Area on
+   * geography), and maximum area limit.
+   * @param {string} wktPolygon - WKT representation of the polygon
+   * @returns {Promise<{code: string, message: string}|null>} null if valid, error object if invalid
+   */
+  async validatePolygon(wktPolygon) {
+    // Check basic geometry validity (self-intersections, etc.)
+    // ST_IsValidDetail performs a single GEOS pass and returns both the
+    // validity flag and the reason, avoiding a redundant traversal.
+    const validityQuery = `SELECT valid AS is_valid, reason FROM ST_IsValidDetail($1::geometry)`;
+    const validityResult = await CommonService.query(validityQuery, [
+      wktPolygon,
+    ]);
+    const { is_valid: isValid, reason } = validityResult.rows[0];
+    if (!isValid) {
+      sails.log.warn(`Polygon validation failed (ST_IsValid): ${reason}`);
+      return matchPolygonError(reason);
+    }
+
+    // Compute area — also catches geometry errors that only manifest when
+    // casting to geography (e.g. invalid winding order, antipodal edges).
+    // Error structure: Waterline wraps pg errors as OperationalError with
+    // e.raw.error being a pg-protocol DatabaseError (has .code, .message,
+    // .severity, .routine, etc.). The XX000 code is PostgreSQL's generic
+    // "internal_error" used by PostGIS for computation failures.
+    // Note: keyword matching depends on PostGIS error wording which could
+    // change across versions; the fallback message handles unknown cases.
+    let areaKm2;
+    try {
+      areaKm2 = await module.exports.computePolygonAreaKm2(wktPolygon);
+    } catch (e) {
+      const pgCode = e.raw && e.raw.error && e.raw.error.code;
+      if (pgCode === 'XX000') {
+        const pgMessage = (e.raw && e.raw.error && e.raw.error.message) || '';
+        sails.log.warn(`Polygon validation failed (XX000): ${pgMessage}`);
+        return matchPolygonError(pgMessage);
+      }
+      throw e;
+    }
+
+    if (areaKm2 > MAX_AREA_KM2) {
+      return {
+        code: POLYGON_AREA_EXCEEDED,
+        message: `The massif polygon area (${areaKm2.toFixed(0)} km²) exceeds the maximum allowed size of ${MAX_AREA_KM2} km².`,
+      };
+    }
+
+    return null;
   },
 
   getConvertedDataFromClientRequest: (req) => ({

--- a/test/integration/1_services/MassifPolygonValidation.test.js
+++ b/test/integration/1_services/MassifPolygonValidation.test.js
@@ -1,0 +1,76 @@
+const should = require('should');
+const MassifService = require('../../../api/services/MassifService');
+
+describe('MassifService', () => {
+  describe('matchPolygonError', () => {
+    it('should map self-intersection errors', () => {
+      const err = MassifService.matchPolygonError('Self-intersection[0.5 0.5]');
+      should(err.code).equal('POLYGON_SELF_INTERSECTION');
+      should(err.message).match(/edges cross each other/);
+    });
+
+    it('should map too few points errors', () => {
+      const err = MassifService.matchPolygonError(
+        'Too few points in geometry component[0 0]'
+      );
+      should(err.code).equal('POLYGON_TOO_FEW_POINTS');
+      should(err.message).match(/not have enough points/);
+    });
+
+    it('should map hole lies outside shell errors', () => {
+      const err = MassifService.matchPolygonError(
+        'Hole lies outside shell[1 1]'
+      );
+      should(err.code).equal('POLYGON_HOLE_OUTSIDE');
+      should(err.message).match(/hole is located outside/);
+    });
+
+    it('should map nested holes errors', () => {
+      const err = MassifService.matchPolygonError('Nested holes[2 2]');
+      should(err.code).equal('POLYGON_NESTED_HOLES');
+      should(err.message).match(/holes within holes/);
+    });
+
+    it('should map disconnected interior errors', () => {
+      const err = MassifService.matchPolygonError('Disconnected interior');
+      should(err.code).equal('POLYGON_DISCONNECTED');
+      should(err.message).match(/split into disconnected parts/);
+    });
+
+    it('should map duplicate rings errors', () => {
+      const err = MassifService.matchPolygonError('Duplicate Rings[0 0]');
+      should(err.code).equal('POLYGON_DUPLICATE_RINGS');
+      should(err.message).match(/duplicate rings/);
+    });
+
+    it('should map lwgeom_area_spher errors', () => {
+      const err = MassifService.matchPolygonError(
+        'lwgeom_area_spher(oid) returned area < 0.0'
+      );
+      should(err.code).equal('POLYGON_INVALID_WINDING');
+      should(err.message).match(/invalid winding order/);
+    });
+
+    it('should map antipodal edge errors', () => {
+      const err = MassifService.matchPolygonError(
+        'Antipodal (180 degrees long) edge detected!'
+      );
+      should(err.code).equal('POLYGON_ANTIPODAL_EDGE');
+      should(err.message).match(/spans exactly 180/);
+    });
+
+    it('should map crosses equator errors', () => {
+      const err = MassifService.matchPolygonError(
+        'ptarray_area_spheroid: cannot handle ptarray that crosses equator'
+      );
+      should(err.code).equal('POLYGON_CROSSES_EQUATOR');
+      should(err.message).match(/crosses the equator/);
+    });
+
+    it('should return fallback for unknown errors', () => {
+      const err = MassifService.matchPolygonError('some unknown PostGIS error');
+      should(err.code).equal('POLYGON_INVALID');
+      should(err.message).match(/could not be processed/);
+    });
+  });
+});

--- a/test/integration/4_routes/Massifs/FAKE_DATA.js
+++ b/test/integration/4_routes/Massifs/FAKE_DATA.js
@@ -97,11 +97,90 @@ const geoJsonOversized = {
   ],
 };
 
+// A MultiPolygon that mimics the Martinique bug (#1606). The two polygons
+// share an edge, which PostGIS detects as a self-intersection. In the old code
+// (without ST_IsValid check), this reached ST_Area() which threw an unhandled
+// XX000 error. With the fix, ST_IsValid catches it first as POLYGON_SELF_INTERSECTION.
+const geoJsonSharedEdgeMultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      // Polygon 1: small valid CCW exterior ring
+      [
+        [-61.0, 14.5],
+        [-60.9, 14.5],
+        [-60.9, 14.6],
+        [-61.0, 14.6],
+        [-61.0, 14.5],
+      ],
+    ],
+    [
+      // Polygon 2: shares edge with Polygon 1 (causes self-intersection)
+      [
+        [-61.0, 14.4],
+        [-61.0, 14.5],
+        [-60.9, 14.5],
+        [-60.9, 14.4],
+        [-61.0, 14.4],
+      ],
+      // Inner ring: large bounding area extending far away
+      [
+        [-61.3, 14.2],
+        [-62.8, 14.1],
+        [-62.8, 15.0],
+        [-57.9, 16.2],
+        [-57.5, 16.5],
+        [-57.5, 16.0],
+        [-58.2, 15.8],
+        [-59.3, 14.8],
+        [-60.0, 14.1],
+        [-61.3, 14.2],
+      ],
+    ],
+  ],
+};
+
+// A polygon with an edge spanning exactly 180° of longitude.
+// This passes ST_IsValid (valid in 2D geometry) but fails ST_Area on geography
+// with "Antipodal (180 degrees long) edge detected!" — testing the XX000
+// catch path for errors that ST_IsValid cannot detect.
+const geoJsonAntipodalEdge = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 0],
+      [180, 0],
+      [180, 80],
+      [0, 80],
+      [0, 0],
+    ],
+  ],
+};
+
+// A small polygon with a self-intersection (bowtie shape). This tests that
+// validation rejects geometrically invalid polygons with a 400 instead of
+// letting them through to potentially cause errors downstream.
+const geoJsonSelfIntersecting = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [2.0, 43.0],
+      [2.1, 43.1],
+      [2.1, 43.0],
+      [2.0, 43.1],
+      [2.0, 43.0],
+    ],
+  ],
+};
+
 const massifPolygon = {
   geoJson1,
   geoJson2,
   geoJsonSmall,
   geoJsonOversized,
+  geoJsonSharedEdgeMultiPolygon,
+  geoJsonAntipodalEdge,
+  geoJsonSelfIntersecting,
   geoJson1ToString: JSON.stringify(geoJson1),
   geoJson2ToString: JSON.stringify(geoJson2),
   geoJsonSmallToString: JSON.stringify(geoJsonSmall),

--- a/test/integration/4_routes/Massifs/create.test.js
+++ b/test/integration/4_routes/Massifs/create.test.js
@@ -58,9 +58,74 @@ describe('Massif features', () => {
           .expect(400)
           .end((err, res) => {
             if (err) return done(err);
-            should(res.text).match(
+            should(res.body.code).equal('POLYGON_AREA_EXCEEDED');
+            should(res.body.message).match(
               /exceeds the maximum allowed size of 35000 km²/
             );
+            return done();
+          });
+      });
+    });
+
+    describe('Shared-edge MultiPolygon (#1606)', () => {
+      it('should return 400 with POLYGON_SELF_INTERSECTION for shared-edge MultiPolygon', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/massifs')
+          .send({
+            name: 'Martinique - 1',
+            descriptionAndNameLanguage: { id: 'fra' },
+            geogPolygon: massifPolygon.geoJsonSharedEdgeMultiPolygon,
+          })
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400)
+          .end((err, res) => {
+            if (err) return done(err);
+            should(res.body.code).equal('POLYGON_SELF_INTERSECTION');
+            should(res.body.message).match(/edges cross each other/);
+            return done();
+          });
+      });
+
+      it('should return 400 with POLYGON_ANTIPODAL_EDGE for 180° edge polygon', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/massifs')
+          .send({
+            name: 'Antipodal Massif',
+            descriptionAndNameLanguage: { id: 'fra' },
+            geogPolygon: massifPolygon.geoJsonAntipodalEdge,
+          })
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400)
+          .end((err, res) => {
+            if (err) return done(err);
+            should(res.body.code).equal('POLYGON_ANTIPODAL_EDGE');
+            should(res.body.message).match(/spans exactly 180/);
+            return done();
+          });
+      });
+    });
+
+    describe('Self-intersecting polygon', () => {
+      it('should return 400 for a self-intersecting polygon', (done) => {
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/massifs')
+          .send({
+            name: 'Self-Intersecting Massif',
+            descriptionAndNameLanguage: { id: 'fra' },
+            geogPolygon: massifPolygon.geoJsonSelfIntersecting,
+          })
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400)
+          .end((err, res) => {
+            if (err) return done(err);
+            should(res.body.code).equal('POLYGON_SELF_INTERSECTION');
+            should(res.body.message).match(/edges cross each other/);
             return done();
           });
       });

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -121,9 +121,28 @@ describe('Massif features', () => {
         .expect(400)
         .end((err, res) => {
           if (err) return done(err);
-          should(res.text).match(
+          should(res.body.code).equal('POLYGON_AREA_EXCEEDED');
+          should(res.body.message).match(
             /exceeds the maximum allowed size of 35000 km²/
           );
+          return done();
+        });
+    });
+
+    it('should return 400 when polygon has invalid geometry (#1606)', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({
+          geogPolygon: massifPolygon.geoJsonSharedEdgeMultiPolygon,
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.body.code).equal('POLYGON_SELF_INTERSECTION');
+          should(res.body.message).match(/edges cross each other/);
           return done();
         });
     });


### PR DESCRIPTION
## 🤔 What

- Validate polygon geometry before computing area in massif create/update endpoints
- Return structured 400 errors with machine-readable `code` + user-friendly `message`
- Closes #1606

## 🤷‍♂️ Why

A user submitted a complex MultiPolygon for Martinique with invalid winding order. PostGIS `ST_Area()` on geography type threw an internal `XX000` error (`lwgeom_area_spher(oid) returned area < 0.0`), causing an unhandled 500 response.

## 🔍 How

- Added `MassifService.validatePolygon(wkt)` that consolidates all polygon checks:
  1. `ST_IsValid` — catches self-intersections, too few points, holes outside shell, etc.
  2. `computePolygonAreaKm2` wrapped in try/catch — catches PostGIS geography errors (invalid winding, antipodal edges, equator crossing)
  3. Area limit check (35,000 km²)
- A single `POLYGON_ERROR_MESSAGES` map translates PostGIS/GEOS error keywords into structured `{ code, message }` responses
- Both `create.js` and `update.js` controllers now call `validatePolygon` and return `res.badRequest(error)` if invalid
- Raw PostGIS errors are logged server-side via `sails.log.warn` for debugging
- Error codes are documented in-code via the `POLYGON_ERROR_MESSAGES` map

### Response format

```json
{
  "code": "POLYGON_SELF_INTERSECTION",
  "message": "The polygon edges cross each other. Please redraw without self-intersections."
}
```

## 🧪 Testing

- `npm run test` — all 2,320 tests pass
- New tests:
  - `test/integration/1_services/MassifPolygonValidation.test.js` — 10 unit tests for `matchPolygonError` mapping
  - `test/integration/4_routes/Massifs/create.test.js` — regression tests for self-intersection (#1606), antipodal edge, and self-intersecting bowtie
  - `test/integration/4_routes/Massifs/update.test.js` — regression test for invalid geometry on PUT

### curl examples

Replace `$TOKEN` with a valid JWT bearer token (e.g. `Bearer eyJ...`).

**POLYGON_SELF_INTERSECTION** — edges cross each other (reproduces #1606):

```bash
curl -s -X POST http://localhost:1337/api/v1/massifs \
  -H "Authorization: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Self-Intersection",
    "descriptionAndNameLanguage": {"id": "fra"},
    "geogPolygon": {
      "type": "MultiPolygon",
      "coordinates": [
        [[[-61.0,14.5],[-60.9,14.5],[-60.9,14.6],[-61.0,14.6],[-61.0,14.5]]],
        [[[-61.0,14.4],[-61.0,14.5],[-60.9,14.5],[-60.9,14.4],[-61.0,14.4]],[[-61.3,14.2],[-62.8,14.1],[-62.8,15.0],[-57.9,16.2],[-57.5,16.5],[-57.5,16.0],[-58.2,15.8],[-59.3,14.8],[-60.0,14.1],[-61.3,14.2]]]
      ]
    }
  }' | jq .
# → {"code":"POLYGON_SELF_INTERSECTION","message":"The polygon edges cross each other. Please redraw without self-intersections."}
```

**POLYGON_SELF_INTERSECTION** — bowtie polygon:

```bash
curl -s -X POST http://localhost:1337/api/v1/massifs \
  -H "Authorization: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Bowtie",
    "descriptionAndNameLanguage": {"id": "fra"},
    "geogPolygon": {
      "type": "Polygon",
      "coordinates": [[[2.0,43.0],[2.1,43.1],[2.1,43.0],[2.0,43.1],[2.0,43.0]]]
    }
  }' | jq .
# → {"code":"POLYGON_SELF_INTERSECTION","message":"The polygon edges cross each other. Please redraw without self-intersections."}
```

**POLYGON_ANTIPODAL_EDGE** — edge spans exactly 180°:

```bash
curl -s -X POST http://localhost:1337/api/v1/massifs \
  -H "Authorization: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Antipodal",
    "descriptionAndNameLanguage": {"id": "fra"},
    "geogPolygon": {
      "type": "Polygon",
      "coordinates": [[[0,0],[180,0],[180,80],[0,80],[0,0]]]
    }
  }' | jq .
# → {"code":"POLYGON_ANTIPODAL_EDGE","message":"The polygon contains an edge that spans exactly 180°. Please split it into smaller segments."}
```

**POLYGON_AREA_EXCEEDED** — polygon too large:

```bash
curl -s -X POST http://localhost:1337/api/v1/massifs \
  -H "Authorization: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Oversized",
    "descriptionAndNameLanguage": {"id": "fra"},
    "geogPolygon": {
      "type": "Polygon",
      "coordinates": [[[0,0],[2,0],[2,2],[0,2],[0,0]]]
    }
  }' | jq .
# → {"code":"POLYGON_AREA_EXCEEDED","message":"The massif polygon area (49478 km²) exceeds the maximum allowed size of 35000 km²."}
```

**Valid polygon** — success (200):

```bash
curl -s -X POST http://localhost:1337/api/v1/massifs \
  -H "Authorization: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Valid",
    "descriptionAndNameLanguage": {"id": "fra"},
    "geogPolygon": {
      "type": "Polygon",
      "coordinates": [[[2.0,43.0],[2.1,43.0],[2.1,43.1],[2.0,43.1],[2.0,43.0]]]
    }
  }' | jq .
# → 200 with the created massif object
```

## 📸 Previews

N/A (API-only change)

