### PR TITLE
fix(document): return 400 when issue field is set on unsupported type

### DIFF
--- a/api/controllers/v1/document/create.js
+++ b/api/controllers/v1/document/create.js
@@ -2,6 +2,9 @@ const ControllerService = require('../../../services/ControllerService');
 const DocumentService = require('../../../services/DocumentService');
 const { toDocument } = require('../../../services/mapping/converters');
 const FileService = require('../../../services/FileService');
+const {
+  TYPES_ALLOWING_ISSUE,
+} = require('../../../../config/constants/document');
 
 module.exports = async (req, res) => {
   const documentData = await DocumentService.getConvertedDataFromClient(
@@ -11,6 +14,17 @@ module.exports = async (req, res) => {
     req.body,
     req.token.id
   );
+
+  // Validate that the issue field is only set for types that support it
+  if (
+    documentData.issue != null &&
+    !TYPES_ALLOWING_ISSUE.includes(documentData.type)
+  ) {
+    return res.badRequest(
+      'The "issue" field is only allowed for documents of type Book or Issue. ' +
+        'Articles should be linked to a parent document of type Issue instead.'
+    );
+  }
 
   const cleanedData = {
     ...documentData,

--- a/api/controllers/v1/document/update.js
+++ b/api/controllers/v1/document/update.js
@@ -4,6 +4,9 @@ const NotificationService = require('../../../services/NotificationService');
 const FileService = require('../../../services/FileService');
 const RightService = require('../../../services/RightService');
 const { toDocument } = require('../../../services/mapping/converters');
+const {
+  TYPES_ALLOWING_ISSUE,
+} = require('../../../../config/constants/document');
 
 const { INVALID_FORMAT, INVALID_NAME, ERROR_DURING_UPLOAD_TO_AZURE } =
   FileService;
@@ -24,6 +27,21 @@ module.exports = async (req, res) => {
         `You are not authorized to update a document with modifications waiting a moderator approval.`
       );
     }
+  }
+
+  // Validate that the issue field is only set for types that support it
+  // (must run before file upload to avoid Azure side effects on invalid requests)
+  const documentDataForValidation =
+    await DocumentService.getConvertedDataFromClient(req.body);
+  const effectiveType = documentDataForValidation.type ?? document.type;
+  if (
+    documentDataForValidation.issue != null &&
+    !TYPES_ALLOWING_ISSUE.includes(effectiveType)
+  ) {
+    return res.badRequest(
+      'The "issue" field is only allowed for documents of type Book or Issue. ' +
+        'Articles should be linked to a parent document of type Issue instead.'
+    );
   }
 
   // Add new files
@@ -64,10 +82,9 @@ module.exports = async (req, res) => {
 
   const authorId = req.token.id;
 
-  // Update json data (upcoming modifications which need to be validated)
-  const documentData = await DocumentService.getConvertedDataFromClient(
-    req.body
-  );
+  // Reuse the already-converted data from the pre-upload validation
+  const documentData = documentDataForValidation;
+
   const descriptionData = DocumentService.getDescriptionDataFromClient(
     req.body,
     authorId

--- a/config/constants/document.js
+++ b/config/constants/document.js
@@ -1,0 +1,20 @@
+/**
+ * Document type constants.
+ *
+ * IDs correspond to the t_type table (seeded in sql/2_2021_09_26_1_doc_types.sql).
+ */
+
+const DOCUMENT_TYPE_IDS = {
+  BOOK: 16,
+  ISSUE: 17,
+  ARTICLE: 18,
+};
+
+// Document types whose DB column `issue` may be non-NULL.
+// Matches the t_document_check constraint in sql/0_tables.sql.
+const TYPES_ALLOWING_ISSUE = [DOCUMENT_TYPE_IDS.BOOK, DOCUMENT_TYPE_IDS.ISSUE];
+
+module.exports = {
+  DOCUMENT_TYPE_IDS,
+  TYPES_ALLOWING_ISSUE,
+};

--- a/test/integration/4_routes/Documents/create.test.js
+++ b/test/integration/4_routes/Documents/create.test.js
@@ -88,5 +88,24 @@ describe('Document create', () => {
         createdDocIds.push(res.body.id);
       });
     });
+
+    describe('Article with issue field', () => {
+      it('should return 400 when an Article is created with an issue value', async () => {
+        await supertest(sails.hooks.http.app)
+          .post('/api/v1/documents')
+          .send({
+            description: 'An article about a cave.',
+            title: 'Test Article with Issue',
+            type: 'Article',
+            issue: '102',
+            parent: { id: 1 },
+            editor: { id: 2 },
+          })
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400);
+      });
+    });
   });
 });

--- a/test/integration/4_routes/Documents/update.test.js
+++ b/test/integration/4_routes/Documents/update.test.js
@@ -113,5 +113,28 @@ describe('Document update', () => {
 
       should(res.body).have.property('id');
     });
+
+    describe('Article with issue field', () => {
+      it('should return 400 when setting issue on an Article type document', async () => {
+        const articleDoc = await TDocument.create({
+          author: 1,
+          type: 18, // Article
+          license: 1,
+          isValidated: true,
+        }).fetch();
+
+        try {
+          await supertest(sails.hooks.http.app)
+            .put(`/api/v1/documents/${articleDoc.id}`)
+            .send({ issue: '102' })
+            .set('Authorization', userToken)
+            .set('Content-type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(400);
+        } finally {
+          await TDocument.destroy({ id: articleDoc.id });
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Add API-level validation that returns a **400 Bad Request** when the `issue` field is set on a document type that doesn't support it (anything other than Book or Issue)
- Closes #1615

## 🤷‍♂️ Why

A user submitted an Article (type 18) with `issue: "102"`, which violated the `t_document_check` PostgreSQL constraint and caused an unhandled **500 Internal Server Error**. The DB constraint is correct — articles don't carry the `issue` field directly; they reference a parent document of type Issue instead. The API should reject this upfront with a clear error message.

## 🔍 How

- Created `config/constants/document.js` with named document type IDs (`BOOK`, `ISSUE`, `ARTICLE`) and a derived `TYPES_ALLOWING_ISSUE` array
- Added validation in `api/controllers/v1/document/create.js` before calling `createDocument`
- Added the same validation in `api/controllers/v1/document/update.js` (using the existing document's type as fallback when type isn't being changed)
- Both return `res.badRequest(...)` with a message explaining the business rule

## 🧪 Testing

- Added integration test in `create.test.js`: Article with `issue` → expects 400
- Added integration test in `update.test.js`: setting `issue` on an existing Article → expects 400
- Full test suite passes (2458 tests, 0 failures)

## 📸 Previews

N/A — backend-only change.
