### PR TITLE
chore(ci): group all dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: 'monthly'
-    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+    ignore:
+      # ESLint must stay at v8 — eslint-config-airbnb-base does not support flat config (v9+)
+      - dependency-name: 'eslint'
+        versions: ['>=9.0.0']
+      # eslint-config-airbnb-base is coupled to ESLint v8; a major bump may require flat config (v9+)
+      - dependency-name: 'eslint-config-airbnb-base'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## 🤔 What

- Group all Dependabot npm updates into a single PR instead of one per package
- Ignore ESLint >=9 major bumps (airbnb-base doesn't support flat config)
- Remove `open-pull-requests-limit` (unnecessary with grouping)

## 🤷‍♂️ Why

Dependabot was opening up to 10 separate PRs per month, creating review fatigue. With grouping, all semver-compatible updates land in one PR that can be reviewed and merged in a single pass.

The ESLint ignore rule codifies the constraint documented in our dependency upgrade steering file — `eslint-config-airbnb-base` does not support ESLint v9's flat config yet.

## 🔍 How

Uses Dependabot's native `groups` configuration with a wildcard pattern (`*`) to batch all npm ecosystem updates into one PR.

## 🧪 Testing

No code changes — CI config only. Next monthly Dependabot run will produce a single grouped PR.

## 📸 Previews

N/A
