### PR TITLE
fix(search): guard against non-string sort parameter

### DIFF
--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -16,7 +16,8 @@ module.exports = async (req, res) => {
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
 
   const entity = req.param('entity') ?? '';
-  const sort = req.param('sort');
+  const rawSort = req.param('sort');
+  const sort = typeof rawSort === 'string' ? rawSort : undefined;
 
   // Validate entity-specific sort fields
   if (sort) {

--- a/test/integration/4_routes/Search/advanced-search-sort-type.test.js
+++ b/test/integration/4_routes/Search/advanced-search-sort-type.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+describe('Advanced Search - sort parameter type handling', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should not crash when sort is an empty object', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: {} })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+
+    // sort should be ignored (passed as undefined to service)
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).be.undefined();
+  });
+
+  it('should not crash when sort is a number', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: 123 })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).be.undefined();
+  });
+
+  it('should not crash when sort is an array', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: ['name:asc'] })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).be.undefined();
+  });
+
+  it('should still work correctly with a valid string sort', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: 'name:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).equal('name:asc');
+  });
+
+  it('should ignore sort when it is null', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', name: 'Cave A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'caves' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'caves', sort: null })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).be.undefined();
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Fix `TypeError: sort.split is not a function` in the advanced search endpoint
- Closes #1630

## 🤷‍♂️ Why

The front-end occasionally sends the `sort` parameter as an empty object `{}` instead of a string. The existing guard `if (sort)` passes because `{}` is truthy, then `.split(',')` throws a TypeError since it's a string method.

This was causing intermittent 500 errors in production (4 occurrences over the last 40 hours).

## 🔍 How

- Coerce the raw `sort` parameter to `undefined` if it's not a string, before any validation or downstream use
- This ensures non-string values are silently ignored rather than crashing the endpoint

## 🧪 Testing

- Added 5 integration tests covering: empty object, number, array, null, and valid string sort values
- All 2477 existing tests continue to pass
