### PR TITLE
fix(search): validate columns and columnsName in export endpoint

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -94,6 +94,18 @@ module.exports = async (req, res) => {
     res.badRequest('columnsName must be a non-empty array');
     return;
   }
+  if (columns.length !== columnsName.length) {
+    res.badRequest('columns and columnsName must have the same length');
+    return;
+  }
+  if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
+    res.badRequest('each element in columns must be a non-empty string');
+    return;
+  }
+  if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
+    res.badRequest('each element in columnsName must be a non-empty string');
+    return;
+  }
 
   const params = {
     query: req.param('query'),

--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -85,6 +85,16 @@ module.exports = async (req, res) => {
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
   const columns = req.param('columns');
   const columnsName = req.param('columnsName');
+
+  if (!Array.isArray(columns) || columns.length === 0) {
+    res.badRequest('columns must be a non-empty array');
+    return;
+  }
+  if (!Array.isArray(columnsName) || columnsName.length === 0) {
+    res.badRequest('columnsName must be a non-empty array');
+    return;
+  }
+
   const params = {
     query: req.param('query'),
     entity: req.param('entity') ?? '',

--- a/test/integration/4_routes/AdvancedSearchExport.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport.test.js
@@ -75,6 +75,63 @@ describe('Advanced Search Export features', () => {
         });
     });
 
+    it('should return 400 when columns and columnsName have different lengths', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: ['id', 'name'],
+          columnsName: ['ID'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /columns and columnsName must have the same length/
+          );
+          return done();
+        });
+    });
+
+    it('should return 400 when columns contains a non-string element', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: [null, 'name'],
+          columnsName: ['ID', 'Name'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /each element in columns must be a non-empty string/
+          );
+          return done();
+        });
+    });
+
+    it('should return 400 when columnsName contains an empty string', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: ['id'],
+          columnsName: [''],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /each element in columnsName must be a non-empty string/
+          );
+          return done();
+        });
+    });
+
     it('should export search results to CSV', (done) => {
       const SearchService = require('../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({

--- a/test/integration/4_routes/AdvancedSearchExport.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport.test.js
@@ -9,6 +9,72 @@ describe('Advanced Search Export features', () => {
   });
 
   describe('POST /api/v1/advanced-search/export', () => {
+    it('should return 400 when columns is missing', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columnsName: ['ID'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/columns must be a non-empty array/);
+          return done();
+        });
+    });
+
+    it('should return 400 when columnsName is missing', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: ['id'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/columnsName must be a non-empty array/);
+          return done();
+        });
+    });
+
+    it('should return 400 when columns is an empty array', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: [],
+          columnsName: ['ID'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/columns must be a non-empty array/);
+          return done();
+        });
+    });
+
+    it('should return 400 when columnsName is an empty array', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'organizations',
+          columns: ['id'],
+          columnsName: [],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/columnsName must be a non-empty array/);
+          return done();
+        });
+    });
+
     it('should export search results to CSV', (done) => {
       const SearchService = require('../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({


### PR DESCRIPTION
## 🤔 What

- Validate `columns` and `columnsName` request body parameters in `POST /api/v1/advanced-search/export`
- Return 400 when either parameter is missing or is an empty array
- Add 4 integration tests covering the validation scenarios
- Closes #1645

## 🤷‍♂️ Why

Production 500 errors (`TypeError: Cannot read properties of undefined (reading 'map')`) when clients call the export endpoint without providing `columnsName` in the request body. The code called `.map()` on `undefined` without any guard.

## 🔍 How

Added early validation at the top of the controller, checking both `columns` and `columnsName` are non-empty arrays before proceeding. Follows the existing pattern of `res.badRequest(...); return;` used elsewhere in the file.

## 🧪 Testing

```bash
npm run test -- --grep "Advanced Search Export"
```

All 18 tests pass (14 existing + 4 new validation tests).

## 📸 Previews

N/A — backend-only change.
