### PR TITLE
fix(name): remove populate point from name controllers

### DIFF
--- a/api/controllers/v1/name/set-as-main.js
+++ b/api/controllers/v1/name/set-as-main.js
@@ -55,7 +55,6 @@ module.exports = async (req, res) => {
       .populate('grotto')
       .populate('language')
       .populate('massif')
-      .populate('point')
       .populate('reviewer');
 
     const params = {};

--- a/api/controllers/v1/name/update.js
+++ b/api/controllers/v1/name/update.js
@@ -35,7 +35,6 @@ module.exports = async (req, res) => {
       .populate('grotto')
       .populate('language')
       .populate('massif')
-      .populate('point')
       .populate('reviewer');
 
     const params = {};


### PR DESCRIPTION
## 🤔 What

- Remove `.populate('point')` from the name `update` and `set-as-main` controllers
- Closes #1647

## 🤷‍♂️ Why

The production `t_point` table was restructured (the `type` column was removed). When updating or setting a name as main, the controllers called `.populate('point')` which triggered a Waterline JOIN generating `t_point__point.type` — a column that no longer exists, causing `"Unexpected error from database adapter: column t_point__point.type does not exist"`.

## 🔍 How

The `toName` converter never uses the `point` association in its response — it only maps `id`, `name`, `isMain`, `language`, dates, `isDeleted`, `author`, and `reviewer`. The `.populate('point')` call was unnecessary and is now removed from both controllers.

## 🧪 Testing

- PATCH `/api/v1/names/:id` with a valid name body should succeed without database errors
- POST `/api/v1/names/:id/setAsMain` should succeed without database errors

## 📸 Previews

N/A
