### PR TITLE
fix(search): use facet search in field-search to fix wrong massif results

### DIFF
--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -178,11 +178,18 @@ async function fieldSearch({
   // documents containing other massif names that share tokens (e.g. "causse"),
   // then group_by would surface those unrelated massif names.
   // Facet search matches against the actual facet values, not document text.
+
+  // Cap max_facet_values at 100 to avoid surfacing raw Typesense validation
+  // errors for out-of-range values (mirrors collectionSearch's per_page cap).
+  const maxFacetValues = size ? Math.min(size, 100) : size;
+
   const params = {
     q: '*',
+    // query_by is required by the Typesense API even for wildcard queries;
+    // it does not participate in matching when q is '*'.
     query_by: field,
     facet_by: field,
-    max_facet_values: size,
+    max_facet_values: maxFacetValues,
     per_page: 0, // We only need facet counts, not document hits
     ...(q !== '*' && { facet_query: `${field}:${q}` }),
     ...(filterBy && { filter_by: filterBy }),
@@ -195,10 +202,19 @@ async function fieldSearch({
   // the controller. The controller reads: found, found_docs, grouped_hits, page.
   const facetInfo = result.facet_counts?.find((f) => f.field_name === field);
   const counts = facetInfo?.counts ?? [];
+
+  // found_docs: sum of document counts for the returned facet values.
+  // Note: on array fields (e.g. massifs.name), a document with multiple
+  // matching values is counted once per value, so this may exceed the true
+  // distinct document count. This is acceptable for the UI's display purpose.
   const totalDocuments = counts.reduce((sum, c) => sum + c.count, 0);
 
+  // Use stats.total_values for the true count of distinct facet values
+  // matching the query, which is not capped by max_facet_values.
+  const totalDistinct = facetInfo?.stats?.total_values ?? counts.length;
+
   return {
-    found: counts.length,
+    found: totalDistinct,
     found_docs: totalDocuments,
     grouped_hits: counts.map((c) => ({
       group_key: [c.value],

--- a/api/services/SearchService.js
+++ b/api/services/SearchService.js
@@ -172,18 +172,40 @@ async function fieldSearch({
     isLogicalCompareAnd
   );
 
+  // Use faceted search to get distinct values for the field.
+  // The previous approach (query_by + group_by) caused wrong results on
+  // array fields like massifs.name: a token-based text search would match
+  // documents containing other massif names that share tokens (e.g. "causse"),
+  // then group_by would surface those unrelated massif names.
+  // Facet search matches against the actual facet values, not document text.
   const params = {
-    q,
+    q: '*',
     query_by: field,
-    group_by: field,
-    group_limit: 1,
-    sort_by: '_group_found:desc',
-    per_page: size,
+    facet_by: field,
+    max_facet_values: size,
+    per_page: 0, // We only need facet counts, not document hits
+    ...(q !== '*' && { facet_query: `${field}:${q}` }),
     ...(filterBy && { filter_by: filterBy }),
     ...(hasPrefixFilter && { max_filter_by_candidates: 100 }),
   };
 
-  return typesense.search(entity, params);
+  const result = await typesense.search(entity, params);
+
+  // Transform facet response to match the grouped_hits format expected by
+  // the controller. The controller reads: found, found_docs, grouped_hits, page.
+  const facetInfo = result.facet_counts?.find((f) => f.field_name === field);
+  const counts = facetInfo?.counts ?? [];
+  const totalDocuments = counts.reduce((sum, c) => sum + c.count, 0);
+
+  return {
+    found: counts.length,
+    found_docs: totalDocuments,
+    grouped_hits: counts.map((c) => ({
+      group_key: [c.value],
+      found: c.count,
+    })),
+    page: result.page,
+  };
 }
 
 module.exports = {

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -334,15 +334,17 @@ describe('SearchService', () => {
   });
 
   describe('fieldSearch()', () => {
-    const facetResponse = (counts = []) => ({
-      facet_counts: [{ field_name: 'name', counts }],
+    const facetResponse = (counts = [], stats = {}) => ({
+      facet_counts: [{ field_name: 'name', counts, stats }],
       page: 1,
     });
 
     it('should search by specific field using facet search', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves(facetResponse([{ value: 'Org A', count: 3 }]));
+        .resolves(
+          facetResponse([{ value: 'Org A', count: 3 }], { total_values: 1 })
+        );
 
       const result = await SearchService.fieldSearch({
         entity: 'organizations',
@@ -462,7 +464,7 @@ describe('SearchService', () => {
       should(call.args[1].filter_by).match(/\|\|/);
     });
 
-    it('should apply size as max_facet_values', async () => {
+    it('should apply size as max_facet_values capped at 100', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
         .resolves(facetResponse());
@@ -471,7 +473,23 @@ describe('SearchService', () => {
         entity: 'organizations',
         field: 'name',
         query: 'test',
-        size: 100,
+        size: 50,
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].max_facet_values).equal(50);
+    });
+
+    it('should cap max_facet_values at 100 for large size values', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves(facetResponse());
+
+      await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'test',
+        size: 500,
       });
 
       const call = typesenseStub.search.getCall(0);
@@ -492,6 +510,48 @@ describe('SearchService', () => {
       should(result.found).equal(0);
       should(result.found_docs).equal(0);
       should(result.grouped_hits).deepEqual([]);
+    });
+
+    it('should use stats.total_values for found when more distinct values exist than returned', async () => {
+      typesenseStub.search = sinon.stub(typesense, 'search').resolves(
+        facetResponse(
+          [
+            { value: 'Org A', count: 3 },
+            { value: 'Org B', count: 2 },
+          ],
+          { total_values: 50 }
+        )
+      );
+
+      const result = await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'org',
+        size: 2,
+      });
+
+      // found reflects the true total, not just the returned count
+      should(result.found).equal(50);
+      should(result.found_docs).equal(5);
+      should(result.grouped_hits.length).equal(2);
+    });
+
+    it('should fall back to counts.length when stats.total_values is not available', async () => {
+      typesenseStub.search = sinon.stub(typesense, 'search').resolves(
+        facetResponse([
+          { value: 'Org A', count: 3 },
+          { value: 'Org B', count: 2 },
+        ])
+      );
+
+      const result = await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'org',
+      });
+
+      should(result.found).equal(2);
+      should(result.found_docs).equal(5);
     });
   });
 

--- a/test/integration/1_services/SearchService.test.js
+++ b/test/integration/1_services/SearchService.test.js
@@ -334,10 +334,15 @@ describe('SearchService', () => {
   });
 
   describe('fieldSearch()', () => {
-    it('should search by specific field', async () => {
+    const facetResponse = (counts = []) => ({
+      facet_counts: [{ field_name: 'name', counts }],
+      page: 1,
+    });
+
+    it('should search by specific field using facet search', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves({ grouped_hits: [] });
+        .resolves(facetResponse([{ value: 'Org A', count: 3 }]));
 
       const result = await SearchService.fieldSearch({
         entity: 'organizations',
@@ -347,6 +352,10 @@ describe('SearchService', () => {
 
       should(typesenseStub.search.calledOnce).be.true();
       should(result).have.property('grouped_hits');
+      should(result.found).equal(1);
+      should(result.found_docs).equal(3);
+      should(result.grouped_hits[0].group_key).deepEqual(['Org A']);
+      should(result.grouped_hits[0].found).equal(3);
     });
 
     it('should handle call with no arguments', async () => {
@@ -354,10 +363,10 @@ describe('SearchService', () => {
       should(result).be.null();
     });
 
-    it('should use wildcard when no query provided', async () => {
+    it('should use wildcard and no facet_query when no query provided', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves({ grouped_hits: [] });
+        .resolves(facetResponse());
 
       await SearchService.fieldSearch({
         entity: 'organizations',
@@ -366,6 +375,38 @@ describe('SearchService', () => {
 
       const call = typesenseStub.search.getCall(0);
       should(call.args[1].q).equal('*');
+      should(call.args[1].facet_query).be.undefined();
+    });
+
+    it('should set facet_query when query is provided', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves(facetResponse());
+
+      await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'test',
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].facet_query).equal('name:test');
+    });
+
+    it('should use facet_by and per_page 0', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves(facetResponse());
+
+      await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'test',
+      });
+
+      const call = typesenseStub.search.getCall(0);
+      should(call.args[1].facet_by).equal('name');
+      should(call.args[1].per_page).equal(0);
     });
 
     it('should return null for invalid entity', async () => {
@@ -390,7 +431,7 @@ describe('SearchService', () => {
     it('should apply filter with AND logic', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves({ grouped_hits: [] });
+        .resolves(facetResponse());
 
       await SearchService.fieldSearch({
         entity: 'organizations',
@@ -407,7 +448,7 @@ describe('SearchService', () => {
     it('should apply filter with OR logic', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves({ grouped_hits: [] });
+        .resolves(facetResponse());
 
       await SearchService.fieldSearch({
         entity: 'organizations',
@@ -421,10 +462,10 @@ describe('SearchService', () => {
       should(call.args[1].filter_by).match(/\|\|/);
     });
 
-    it('should apply size parameter', async () => {
+    it('should apply size as max_facet_values', async () => {
       typesenseStub.search = sinon
         .stub(typesense, 'search')
-        .resolves({ grouped_hits: [] });
+        .resolves(facetResponse());
 
       await SearchService.fieldSearch({
         entity: 'organizations',
@@ -434,7 +475,23 @@ describe('SearchService', () => {
       });
 
       const call = typesenseStub.search.getCall(0);
-      should(call.args[1].per_page).equal(100);
+      should(call.args[1].max_facet_values).equal(100);
+    });
+
+    it('should return empty grouped_hits when no facet counts', async () => {
+      typesenseStub.search = sinon
+        .stub(typesense, 'search')
+        .resolves({ facet_counts: [], page: 1 });
+
+      const result = await SearchService.fieldSearch({
+        entity: 'organizations',
+        field: 'name',
+        query: 'nonexistent',
+      });
+
+      should(result.found).equal(0);
+      should(result.found_docs).equal(0);
+      should(result.grouped_hits).deepEqual([]);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #1646 — Massif pages display entrances from unrelated massifs.

## Why

The `/api/v1/field-search` endpoint returned wrong massif names when searching entrances by `massifs.name`. The old implementation used Typesense's `query_by` + `group_by`, which does token-based text search: a query like "Aumelas (causse d')" was tokenized into ["aumelas", "causse", "d"], matched documents containing *any* massif with those tokens (e.g., "Viols-le-Fort (causse de)"), then grouped by *all* distinct massif names in matched documents — surfacing unrelated massifs.

## What

Switched `fieldSearch` from `query_by` + `group_by` to Typesense's **facet search** (`facet_by` + `facet_query`). Facet search matches tokens within individual facet values rather than across documents, so only massif names whose text actually matches the query are returned. No changes to the HTTP response contract.

## Testing

- All existing tests pass (2492 passing, 1 unrelated flaky failure in rate limiting)
- Updated `SearchService.test.js` with tests covering the new facet-based implementation
- Linter passes

## Checklist

- [x] Tests pass
- [x] Linter passes
- [x] No breaking changes to the API contract
