### PR TITLE
fix(observation): correct row numbers and skip empty measurements

### DIFF
--- a/api/services/ObservationImportService.js
+++ b/api/services/ObservationImportService.js
@@ -105,6 +105,17 @@ const execute = async (file, profile, requestAuthorId) => {
   const { rows, columnIndices } = parsedResult;
 
   // -------------------------------------------------------------------------
+  // Compute the file-line offset so that row numbers in error messages
+  // reference the original file line rather than the parsed-data index.
+  // Offset = (headerRow lines consumed) + (skipFirstRows lines consumed).
+  // The Parser already removed these lines from the data, so any 1-based
+  // row number from downstream stages must be shifted by this amount.
+  // -------------------------------------------------------------------------
+  const fileRowOffset =
+    (profile.headerRow != null ? profile.headerRow : 0) +
+    (profile.skipFirstRows || 0);
+
+  // -------------------------------------------------------------------------
   // Stage 4: TimestampConverter — parse timestamps → UTC Date objects
   // -------------------------------------------------------------------------
   let convertedTimestamps;
@@ -112,7 +123,8 @@ const execute = async (file, profile, requestAuthorId) => {
     convertedTimestamps = TimestampConverter.convert(
       rows,
       profile,
-      columnIndices
+      columnIndices,
+      fileRowOffset
     );
   } catch (err) {
     throw new ImportError('IMPORT_TIMESTAMP_ERROR', err.message, []);
@@ -143,7 +155,8 @@ const execute = async (file, profile, requestAuthorId) => {
       rows,
       sensorConfigMap,
       columnIndices,
-      profile
+      profile,
+      fileRowOffset
     );
   } catch (err) {
     throw new ImportError('IMPORT_CONVERSION_ERROR', err.message, []);

--- a/api/services/ObservationImportService.js
+++ b/api/services/ObservationImportService.js
@@ -60,6 +60,7 @@ class ImportError extends Error {
  *   documentId: number,
  *   timeSeriesMap: Object<string, number>,
  *   measurementCount: number,
+ *   skippedMeasurements: number,
  *   observationDate: Date,
  *   importedAt: Date,
  *   importedBy: number,
@@ -150,14 +151,16 @@ const execute = async (file, profile, requestAuthorId) => {
   });
 
   let convertedMeasurements;
+  let skippedMeasurements;
   try {
-    convertedMeasurements = SIConverter.convertAll(
-      rows,
-      sensorConfigMap,
-      columnIndices,
-      profile,
-      fileRowOffset
-    );
+    ({ measurements: convertedMeasurements, skippedMeasurements } =
+      SIConverter.convertAll(
+        rows,
+        sensorConfigMap,
+        columnIndices,
+        profile,
+        fileRowOffset
+      ));
   } catch (err) {
     throw new ImportError('IMPORT_CONVERSION_ERROR', err.message, []);
   }
@@ -195,6 +198,8 @@ const execute = async (file, profile, requestAuthorId) => {
     }
     throw new ImportError('IMPORT_TRANSACTION_ERROR', err.message, []);
   }
+
+  importResult.skippedMeasurements = skippedMeasurements;
 
   return importResult;
 };

--- a/api/services/observation-import/SIConverter.js
+++ b/api/services/observation-import/SIConverter.js
@@ -85,11 +85,20 @@ const parseLocaleNumber = (rawString, numberLocale) => {
  * @param {number[]} columnIndices - Original column indices in rows
  *   (after excluded-column filtering). Used to map columnIndex → row position.
  * @param {Object} profile - Profile (for numberLocale)
+ * @param {number} [rowOffset=0] - Number of lines consumed before the first data row
+ *   (headerRow + skipFirstRows). Added to 1-based row indices in error messages so
+ *   they reference the original file line number.
  * @returns {Array<{columnIndex: number, value: number, valueSi: number}[]>}
  *   Per-row measurement arrays
  * @throws {Error} if siToDisplayFactor is zero for any quantity kind
  */
-const convertAll = (rows, sensorConfigMap, columnIndices, profile) => {
+const convertAll = (
+  rows,
+  sensorConfigMap,
+  columnIndices,
+  profile,
+  rowOffset = 0
+) => {
   const { numberLocale } = profile || {};
 
   // Pre-compute positions for all measurement columns present in sensorConfigMap
@@ -108,20 +117,23 @@ const convertAll = (rows, sensorConfigMap, columnIndices, profile) => {
   }
 
   return rows.map((row, rowIdx) =>
-    measurementColumns.map(({ colIndex, pos, sensorConfig }) => {
+    measurementColumns.reduce((acc, { colIndex, pos, sensorConfig }) => {
       const rawString = row[pos];
+      // Empty cell → no measurement for this column/row (sensor gap)
+      if (rawString === '') return acc;
+
       let value;
       try {
         value = parseLocaleNumber(rawString, numberLocale);
       } catch (err) {
         throw new Error(
-          `Measurement conversion failed at row ${rowIdx + 1}, column index ${colIndex}: ${err.message}`
+          `Measurement conversion failed at row ${rowIdx + 1 + rowOffset}, column index ${colIndex}: ${err.message}`
         );
       }
       const valueSi = toSI(value, sensorConfig.quantityKind);
-
-      return { columnIndex: colIndex, value, valueSi };
-    })
+      acc.push({ columnIndex: colIndex, value, valueSi });
+      return acc;
+    }, [])
   );
 };
 

--- a/api/services/observation-import/SIConverter.js
+++ b/api/services/observation-import/SIConverter.js
@@ -88,8 +88,8 @@ const parseLocaleNumber = (rawString, numberLocale) => {
  * @param {number} [rowOffset=0] - Number of lines consumed before the first data row
  *   (headerRow + skipFirstRows). Added to 1-based row indices in error messages so
  *   they reference the original file line number.
- * @returns {Array<{columnIndex: number, value: number, valueSi: number}[]>}
- *   Per-row measurement arrays
+ * @returns {{ measurements: Array<{columnIndex: number, value: number, valueSi: number}[]>, skippedMeasurements: number }}
+ *   Per-row measurement arrays and count of skipped empty cells
  * @throws {Error} if siToDisplayFactor is zero for any quantity kind
  */
 const convertAll = (
@@ -116,11 +116,16 @@ const convertAll = (
     measurementColumns.push({ colIndex, pos, sensorConfig });
   }
 
-  return rows.map((row, rowIdx) =>
+  let skippedMeasurements = 0;
+
+  const measurements = rows.map((row, rowIdx) =>
     measurementColumns.reduce((acc, { colIndex, pos, sensorConfig }) => {
       const rawString = row[pos];
-      // Empty cell → no measurement for this column/row (sensor gap)
-      if (rawString === '') return acc;
+      // Empty or whitespace-only cell → no measurement for this column/row (sensor gap)
+      if (rawString.trim() === '') {
+        skippedMeasurements += 1;
+        return acc;
+      }
 
       let value;
       try {
@@ -135,6 +140,8 @@ const convertAll = (
       return acc;
     }, [])
   );
+
+  return { measurements, skippedMeasurements };
 };
 
 module.exports = { toSI, convertAll, parseLocaleNumber };

--- a/api/services/observation-import/TimestampConverter.js
+++ b/api/services/observation-import/TimestampConverter.js
@@ -37,11 +37,14 @@ const COMPONENT_TYPES = [
  *   timeOnlyFormat, and columnMappings
  * @param {number[]} columnIndices - Original column indices present in rows
  *   (after excluded-column filtering). Used to map columnIndex → row position.
+ * @param {number} [rowOffset=0] - Number of lines consumed before the first data row
+ *   (headerRow + skipFirstRows). Added to 1-based row indices in error messages so
+ *   they reference the original file line number.
  * @returns {Date[]} Array of UTC Date objects, one per row
  * @throws {Error} with row number and raw value on parse failure
  * @throws {Error} on dateOnly/timeOnly column pairing issues
  */
-const convert = (rows, profile, columnIndices) => {
+const convert = (rows, profile, columnIndices, rowOffset = 0) => {
   const {
     timezone,
     dateFormat,
@@ -165,6 +168,7 @@ const convert = (rows, profile, columnIndices) => {
   // 3.2–3.5. Parse each row
   // -------------------------------------------------------------------------
   return rows.map((row, rowIndex) => {
+    const fileRow = rowIndex + 1 + rowOffset;
     let m;
 
     if (mode === 'datetime') {
@@ -186,7 +190,7 @@ const convert = (rows, profile, columnIndices) => {
       if (!m || !m.isValid()) {
         // 3.5. Stop at first unparseable row — 1-based row number
         throw new Error(
-          `Failed to parse timestamp at row ${rowIndex + 1}: '${rawValue}' does not match format '${dateFormat}'.`
+          `Failed to parse timestamp at row ${fileRow}: '${rawValue}' does not match format '${dateFormat}'.`
         );
       }
     } else if (mode === 'split') {
@@ -209,7 +213,7 @@ const convert = (rows, profile, columnIndices) => {
 
       if (!m || !m.isValid()) {
         throw new Error(
-          `Failed to parse timestamp at row ${rowIndex + 1}: combined value '${combined}' does not match format '${combinedFormat}'.`
+          `Failed to parse timestamp at row ${fileRow}: combined value '${combined}' does not match format '${combinedFormat}'.`
         );
       }
     } else if (mode === 'epoch') {
@@ -218,13 +222,13 @@ const convert = (rows, profile, columnIndices) => {
       const epochSeconds = Number(raw);
       if (!Number.isInteger(epochSeconds)) {
         throw new Error(
-          `Failed to parse Unix epoch seconds at row ${rowIndex + 1}: '${raw}' is not a valid integer.`
+          `Failed to parse Unix epoch seconds at row ${fileRow}: '${raw}' is not a valid integer.`
         );
       }
       m = dayjs.unix(epochSeconds);
       if (!m.isValid()) {
         throw new Error(
-          `Failed to parse Unix epoch seconds at row ${rowIndex + 1}: '${raw}' produces an invalid date.`
+          `Failed to parse Unix epoch seconds at row ${fileRow}: '${raw}' produces an invalid date.`
         );
       }
       // Reject absurd dates (before 1900 or after 2100) — catches out-of-range
@@ -232,7 +236,7 @@ const convert = (rows, profile, columnIndices) => {
       const epochYear = m.year();
       if (epochYear < 1900 || epochYear > 2100) {
         throw new Error(
-          `Failed to parse Unix epoch seconds at row ${rowIndex + 1}: '${raw}' produces year ${epochYear}, which is outside the accepted range (1900–2100).`
+          `Failed to parse Unix epoch seconds at row ${fileRow}: '${raw}' produces year ${epochYear}, which is outside the accepted range (1900–2100).`
         );
       }
     } else {
@@ -243,7 +247,7 @@ const convert = (rows, profile, columnIndices) => {
         const parsed = parseInt(raw, 10);
         if (Number.isNaN(parsed)) {
           throw new Error(
-            `Failed to parse timestamp component '${type}' at row ${rowIndex + 1}: '${raw}' is not a valid integer.`
+            `Failed to parse timestamp component '${type}' at row ${fileRow}: '${raw}' is not a valid integer.`
           );
         }
         return parsed;
@@ -269,7 +273,7 @@ const convert = (rows, profile, columnIndices) => {
 
       if (!m || !m.isValid()) {
         throw new Error(
-          `Failed to parse timestamp at row ${rowIndex + 1}: components year=${year}, month=${month}, day=${day}, hour=${hour}, minute=${minute}, second=${second} do not form a valid date.`
+          `Failed to parse timestamp at row ${fileRow}: components year=${year}, month=${month}, day=${day}, hour=${hour}, minute=${minute}, second=${second} do not form a valid date.`
         );
       }
     }
@@ -280,7 +284,7 @@ const convert = (rows, profile, columnIndices) => {
       const elapsedSeconds = Number(raw);
       if (!Number.isInteger(elapsedSeconds)) {
         throw new Error(
-          `Failed to parse elapsed_seconds at row ${rowIndex + 1}: '${raw}' is not a valid integer.`
+          `Failed to parse elapsed_seconds at row ${fileRow}: '${raw}' is not a valid integer.`
         );
       }
       if (elapsedSeconds !== 0) {

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -6227,6 +6227,9 @@ paths:
                       type: integer
                   measurementCount:
                     type: integer
+                  skippedMeasurements:
+                    type: integer
+                    description: Number of empty or whitespace-only measurement cells skipped during import (sensor gaps)
                   observationDate:
                     type: string
                     format: date-time

--- a/test/integration/1_services/observation-import/TimestampSIConverter.test.js
+++ b/test/integration/1_services/observation-import/TimestampSIConverter.test.js
@@ -698,7 +698,7 @@ describe('SIConverter', () => {
       const columnIndices = [1];
       const profile = { numberLocale: 'fr' };
 
-      const result = SIConverter.convertAll(
+      const { measurements: result } = SIConverter.convertAll(
         rows,
         sensorConfigMap,
         columnIndices,
@@ -731,7 +731,7 @@ describe('SIConverter', () => {
       const columnIndices = [1];
       const profile = { numberLocale: 'en' };
 
-      const result = SIConverter.convertAll(
+      const { measurements: result } = SIConverter.convertAll(
         rows,
         sensorConfigMap,
         columnIndices,
@@ -773,7 +773,7 @@ describe('SIConverter', () => {
       const columnIndices = [0, 1, 2];
       const profile = { numberLocale: 'en' };
 
-      const result = SIConverter.convertAll(
+      const { measurements: result } = SIConverter.convertAll(
         rows,
         sensorConfigMap,
         columnIndices,
@@ -828,5 +828,263 @@ describe('SIConverter', () => {
         SIConverter.convertAll(rows, sensorConfigMap, columnIndices, profile)
       ).throw(/zero|factor/i);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rowOffset parameter tests
+// ---------------------------------------------------------------------------
+
+describe('TimestampConverter - rowOffset parameter', () => {
+  it('should report the correct file-line number when rowOffset is non-zero', () => {
+    const profile = {
+      timezone: 'UTC',
+      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      columnMappings: [
+        { columnIndex: 0, role: 'timestamp', timestampType: 'datetime' },
+      ],
+    };
+    // Simulate: headerRow=1, skipFirstRows=1 → rowOffset=2
+    // Bad row at data index 0 → file line = 0 + 1 + 2 = row 3
+    const rows = [['INVALID']];
+    const columnIndices = [0];
+    const rowOffset = 2;
+
+    let caughtError;
+    try {
+      TimestampConverter.convert(rows, profile, columnIndices, rowOffset);
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 3/i);
+  });
+
+  it('should report the correct file-line for a later row with rowOffset', () => {
+    const profile = {
+      timezone: 'UTC',
+      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      columnMappings: [
+        { columnIndex: 0, role: 'timestamp', timestampType: 'datetime' },
+      ],
+    };
+    // rowOffset=3, bad row at data index 2 → file line = 2 + 1 + 3 = row 6
+    const rows = [
+      ['2024-01-15 08:00:00'],
+      ['2024-01-15 09:00:00'],
+      ['BAD VALUE'],
+    ];
+    const columnIndices = [0];
+    const rowOffset = 3;
+
+    let caughtError;
+    try {
+      TimestampConverter.convert(rows, profile, columnIndices, rowOffset);
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 6/i);
+  });
+
+  it('should report row 1 when rowOffset is 0 and bad row is at index 0', () => {
+    const profile = {
+      timezone: 'UTC',
+      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      columnMappings: [
+        { columnIndex: 0, role: 'timestamp', timestampType: 'datetime' },
+      ],
+    };
+    const rows = [['BAD']];
+    const columnIndices = [0];
+    const rowOffset = 0;
+
+    let caughtError;
+    try {
+      TimestampConverter.convert(rows, profile, columnIndices, rowOffset);
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 1/i);
+  });
+});
+
+describe('SIConverter - rowOffset parameter', () => {
+  it('should report the correct file-line number when rowOffset is non-zero', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    // rowOffset=2, bad row at data index 0 → file line = 0 + 1 + 2 = row 3
+    const rows = [['not-a-number']];
+    const columnIndices = [1];
+    const profile = { numberLocale: 'en' };
+    const rowOffset = 2;
+
+    let caughtError;
+    try {
+      SIConverter.convertAll(
+        rows,
+        sensorConfigMap,
+        columnIndices,
+        profile,
+        rowOffset
+      );
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 3/i);
+    should(caughtError.message).match(/column index 1/i);
+  });
+
+  it('should report the correct file-line for a later row with rowOffset', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    // rowOffset=3, bad row at data index 1 → file line = 1 + 1 + 3 = row 5
+    const rows = [['10.0'], ['xyz']];
+    const columnIndices = [1];
+    const profile = { numberLocale: 'en' };
+    const rowOffset = 3;
+
+    let caughtError;
+    try {
+      SIConverter.convertAll(
+        rows,
+        sensorConfigMap,
+        columnIndices,
+        profile,
+        rowOffset
+      );
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 5/i);
+  });
+
+  it('should report row 1 when rowOffset is 0 and bad row is at index 0', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    const rows = [['abc']];
+    const columnIndices = [1];
+    const profile = {};
+    const rowOffset = 0;
+
+    let caughtError;
+    try {
+      SIConverter.convertAll(
+        rows,
+        sensorConfigMap,
+        columnIndices,
+        profile,
+        rowOffset
+      );
+    } catch (err) {
+      caughtError = err;
+    }
+    should(caughtError).be.instanceOf(Error);
+    should(caughtError.message).match(/row 1/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty and whitespace cell handling tests
+// ---------------------------------------------------------------------------
+
+describe('SIConverter - empty and whitespace cell handling', () => {
+  it('should skip empty cells and return skippedMeasurements count', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    // 3 rows: first has value, second is empty, third has value
+    const rows = [['10.0'], [''], ['20.0']];
+    const columnIndices = [1];
+    const profile = { numberLocale: 'en' };
+
+    const { measurements, skippedMeasurements } = SIConverter.convertAll(
+      rows,
+      sensorConfigMap,
+      columnIndices,
+      profile
+    );
+
+    should(measurements).have.length(3);
+    should(measurements[0]).have.length(1);
+    should(measurements[0][0].value).equal(10.0);
+    should(measurements[1]).have.length(0); // skipped
+    should(measurements[2]).have.length(1);
+    should(measurements[2][0].value).equal(20.0);
+    should(skippedMeasurements).equal(1);
+  });
+
+  it('should treat whitespace-only cells as empty (sensor gap)', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    const rows = [['  '], ['\t'], [' \t ']];
+    const columnIndices = [1];
+    const profile = { numberLocale: 'en' };
+
+    const { measurements, skippedMeasurements } = SIConverter.convertAll(
+      rows,
+      sensorConfigMap,
+      columnIndices,
+      profile
+    );
+
+    should(measurements[0]).have.length(0);
+    should(measurements[1]).have.length(0);
+    should(measurements[2]).have.length(0);
+    should(skippedMeasurements).equal(3);
+  });
+
+  it('should count skips across multiple measurement columns', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+      [2, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    // Row with col1 present but col2 empty
+    const rows = [
+      ['10.0', ''],
+      ['', '20.0'],
+    ];
+    const columnIndices = [1, 2];
+    const profile = { numberLocale: 'en' };
+
+    const { measurements, skippedMeasurements } = SIConverter.convertAll(
+      rows,
+      sensorConfigMap,
+      columnIndices,
+      profile
+    );
+
+    should(measurements[0]).have.length(1);
+    should(measurements[0][0].columnIndex).equal(1);
+    should(measurements[1]).have.length(1);
+    should(measurements[1][0].columnIndex).equal(2);
+    should(skippedMeasurements).equal(2);
+  });
+
+  it('should return skippedMeasurements=0 when no cells are empty', () => {
+    const sensorConfigMap = new Map([
+      [1, { quantityKind: { siToDisplayFactor: 1, siToDisplayOffset: 0 } }],
+    ]);
+    const rows = [['10.0'], ['20.0']];
+    const columnIndices = [1];
+    const profile = { numberLocale: 'en' };
+
+    const { measurements, skippedMeasurements } = SIConverter.convertAll(
+      rows,
+      sensorConfigMap,
+      columnIndices,
+      profile
+    );
+
+    should(measurements[0]).have.length(1);
+    should(measurements[1]).have.length(1);
+    should(skippedMeasurements).equal(0);
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix row numbers in observation import validation errors to reference the original file line numbers
- Skip empty measurement cells (`""`) silently instead of throwing a parse error

Fixes #1663

## 🤷‍♂️ Why

When the import pipeline reported validation errors (timestamp parse failures, measurement conversion failures), the row numbers referenced the internal parsed-data array index — not the actual line in the user's file. Users had to mentally add the header and skip-first-rows offset to locate the problem, which was confusing.

Additionally, empty measurement cells are normal in scientific time series data (sensor gaps, logger power loss) and should not be treated as errors.

## 🔍 How

**Row number fix** (`ObservationImportService.js`, `TimestampConverter.js`, `SIConverter.js`):
- Compute `fileRowOffset = headerRow + skipFirstRows` once after parsing in the orchestrator
- Pass it as a parameter to `TimestampConverter.convert()` and `SIConverter.convertAll()`
- Each error throw site uses `rowIndex + 1 + rowOffset` directly — plain arithmetic, no post-hoc string manipulation

**Empty cell handling** (`SIConverter.js`):
- Switch from `.map()` to `.reduce()` so that when `rawString === ''`, no entry is added to the row's measurement array
- EntityBuilder already handles missing entries via `.find()` → `undefined` → filtered by `.filter(Boolean)` — no downstream changes needed

## 🧪 Testing

All 2778 existing tests pass. To manually verify:
1. Import a CSV with `headerRow: 1` and `skipFirstRows: 1` containing a bad timestamp on line 5 → error should report "row 5" (not "row 3")
2. Import a CSV with empty measurement cells → import succeeds, those cells produce no `TMeasurement` record
