### PR TITLE
feat(observation): support multiple authors on import

### DIFF
--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -12,7 +12,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Description**: Non-authenticated users
 - **Permissions**:
   - View public cave/entrance/document/organisation/massif/person data
-  - Search through cave/entrance/document/organisation/massif/person data
+  - Search through cave/entrance/document/organisation/massif/person/device data
   - View complete entity history
   - View statistics
   - View all organization details
@@ -23,12 +23,24 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Description**: Default authenticated users role
 - **Permissions**: All Visitor permissions plus:
   - **Content Management**:
-    - Create caves, entrances, documents, Massifs, Organisations, comments, descriptions, locations, riggings, histories
-    - Edit caves, entrances, documents, Massifs, Organisations, descriptions, locations, riggings, histories
+    - Create caves, entrances, documents, massifs, organisations, comments, descriptions, locations, riggings, histories
+    - Edit caves, entrances, documents, massifs, organisations, descriptions, locations, riggings, histories
     - Edit own comments
     - Unlink documents from entities
     - Rollback to a previous version of any content
     - Add/remove own explored entrances
+    - Set main name for entities
+  - **Scientific Data Management**:
+    - Create devices and sensor configurations
+    - Update own devices and sensor configurations
+    - Import observation data (CSV/TSV)
+  - **Messaging**:
+    - Send and receive private messages
+    - View, archive, and unarchive own conversations only
+    - Read messages only in conversations where the user is a participant
+  - **Notifications**:
+    - View own notifications
+    - Mark notifications as read
   - **Personal Management**:
     - Manage personal profile and settings
     - Join/leave organizations (own membership only)
@@ -50,7 +62,9 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Description**: Content reviewers and validators
 - **Permissions**: All User permissions plus:
   - **Content Moderation**:
-    - Delete/restore any caves, entrances, documents, comments, descriptions, locations, riggings, histories, organisations, massifs, documents
+    - Delete/restore any caves, entrances, documents, comments, descriptions, locations, riggings, histories, organisations, massifs
+    - Delete/restore devices and sensor configurations
+    - Update any device or sensor configuration (regardless of ownership)
     - Update any user's comments
     - Validate documents
     - Manage duplicates (documents and entrances)
@@ -67,16 +81,25 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
     - Assign/remove user roles
     - Manage any user accounts
     - Delete user accounts
-    - View user lists (authors, contributors, users)
+    - Ban/unban users (revokes all active tokens)
+    - View user lists (authors, contributors, users, banned, invalid-email)
     - View complete user information
     - Cancel any user's subscriptions
+  - **MFA Management**:
+    - Enroll MFA (generate TOTP secret)
+    - Verify MFA enrollment (activate TOTP)
+    - Reset MFA (requires password re-entry)
   - **System Operations**:
     - Import data from CSV files (documents and entrances)
     - System configuration and maintenance
   - **Sensitive Data Management**:
+    - View coordinates of sensitive entrances
     - Remove sensitive flag from entrances
     - Modify coordinates of sensitive entrances
-    - Access all sensitive entrance data
+    - Mark/unmark massifs as sensitive (cascades to contained entrances)
+    - Preview massif sensitivity impact
+  - **Permanent Deletion**:
+    - Permanently delete any content (caves, entrances, documents, devices, sensor configurations, etc.)
   - **Advanced Organization Management**:
     - Add/remove explored caves for any organization
     - Manage organization memberships for any user
@@ -88,19 +111,22 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | **Public Data Access**                                        |
 | View public cave/entrance/document/organisation/massif/person | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View non-sensitive coordinates                                | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Search content                                                | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Search content (including devices)                            | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View statistics                                               | ✅ | ✅ | ✅ | ✅ | ✅ |
-| View history                                                  | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View history/snapshots                                        | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Content Creation**                                          |
-| Create caves/entrances/document/organisation/massif/person    | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Create caves/entrances/documents/organisations/massifs        | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Create comments/descriptions/locations/riggings/histories     | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Content Modification**                                      |
-| Update caves/entrances/document/organisation/massif/person    | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update caves/entrances/documents/organisations/massifs        | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update descriptions/locations/riggings/histories              | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update own comments                                           | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update any comment                                            | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Soft delete any content                                       | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Set main name for entities                                    | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Move entrance to another cave                                 | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Reorder descriptions/locations/riggings/histories/comments    | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Soft-deleted Content Management**                           |
+| Soft delete any content                                       | ❌ | ❌ | ❌ | ✅ | ✅ |
 | View soft-deleted content                                     | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Restore soft-deleted content                                  | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Permanent delete                                              | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -108,36 +134,65 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | Validate documents                                            | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Manage document duplicates                                    | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Unlink documents from entities                                | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Scientific Domain (Devices, Sensors, Observations)**        |
+| View device/sensor configuration details                      | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Search devices                                                | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Create devices/sensor configurations                          | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update own devices/sensor configurations                      | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update any device/sensor configuration                        | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Soft delete devices/sensor configurations                     | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Restore devices/sensor configurations                         | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Permanently delete devices/sensor configurations              | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Import observation data                                       | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Organization Management**                                   |
 | Join/leave own organizations                                  | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Revoke any user's organization membership                     | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **Explored Cave Management**                                  |
 | Add/remove explored caves (own orgs)                          | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Add/remove explored caves (any org)                           | ❌ | ❌ | ❌ | ✅ | ✅ |
-| **Subscriptions & Notifications**                             |
-| Manage own subscriptions                                      | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **Messaging**                                                 |
+| Send/receive private messages                                 | ❌ | ✅ | ✅ | ✅ | ✅ |
+| View/archive/unarchive own conversations                      | ❌ | ✅ | ✅ | ✅ | ✅ |
+| View another user's conversations                             | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Notifications**                                             |
+| View and manage own notifications                             | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Subscriptions**                                             |
+| Subscribe to country/massif/region                            | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Cancel any user's subscriptions                               | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **Sensitive Data Access**                                     |
 | View sensitive entrance coordinates                           | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Modify sensitive entrance coordinates                         | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Remove sensitive flag                                         | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Remove sensitive flag from entrances                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Mark/unmark massif as sensitive                               | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Preview massif sensitivity impact                             | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **User Management**                                           |
-| View user lists                                               | ❌ | ❌ | ❌ | ❌ | ✅ |
+| View user lists (authors, contributors, users)                | ❌ | ❌ | ❌ | ❌ | ✅ |
+| View banned users list                                        | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Ban/unban users                                               | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Manage user roles                                             | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Delete user accounts                                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Authentication & MFA**                                      |
+| Enroll MFA (generate TOTP secret)                             | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Verify MFA enrollment                                         | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Reset own MFA                                                 | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **System Operations**                                         |
-| Import data from CSV                                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Import data from CSV (documents/entrances)                    | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Download full database export                                 | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 ## Special Permission Cases
 
 ### Sensitive Entrance Data
-- **Coordinates**: Only Moderators and Administrators can view coordinates of sensitive entrances
-- **Locations**: Sensitive entrance location descriptions are hidden from non-privileged users
+- **Coordinates**: Only Administrators can view coordinates of sensitive entrances
+- **Locations**: Sensitive entrance location descriptions are hidden from non-Administrators
 - **Modification**: Only Administrators can remove the sensitive flag or modify coordinates of sensitive entrances
 - **Creation**: Any authenticated user can mark an entrance as sensitive, but coordinates are then hidden from their own
   view
 - **Restriction**: Once marked as sensitive, only Administrators can unmark an entrance (remove the sensitive flag)
+
+### Massif Sensitivity
+- **Mark sensitive**: Only Administrators can mark a massif as sensitive, which cascades to all non-sensitive entrances contained within it
+- **Unmark sensitive**: Only Administrators can unmark a massif (does not cascade removal to individual entrances)
+- **Preview**: Only Administrators can preview how many entrances would be affected by marking a massif as sensitive
 
 ### Organization-Based Permissions
 - **Membership Management**: Users can only manage their own organization memberships
@@ -154,12 +209,42 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Public History**: Available to all users for non-sensitive content
 - **Sensitive History**: Historical data for sensitive entrances requires Administrator privileges
 
+### Scientific Domain Access
+- **Devices**: Any authenticated user can create devices; update requires ownership or Moderator role; soft delete requires Moderator or Administrator; restore requires Moderator; permanent delete requires Administrator
+- **Sensor Configurations**: Same permission model as devices — scoped under a device (nested resource)
+- **Observation Import**: Any authenticated user can import observation data via CSV/TSV
+- **Owner-based update**: The original author of a device or sensor configuration can update it; Moderators can update any device or sensor configuration regardless of ownership
+
+### Ban/Unban
+- Only Administrators can ban or unban users
+- Banning a user revokes all their active JWT tokens immediately
+- A user cannot ban themselves
+
+### MFA (Multi-Factor Authentication)
+- MFA is restricted to Administrators only — both `enroll` and `reset` check for Administrator role
+- Enrollment and verification use a dedicated `mfaEnrollmentAuth` policy with a restricted token (subject `MfaEnrollment`)
+- The `verify` endpoint doesn't have an explicit role check, but it's gated by the MFA enrollment token which is only issued during the admin enrollment flow
+- MFA reset requires a standard `tokenAuth` (full authentication token) plus Administrator role plus password re-entry to prevent stolen-token abuse
+
 ## Security Features
 
 ### JWT Token Authentication
 - All authenticated endpoints require valid JWT tokens
 - Tokens contain user ID and role memberships
 - Tokens are validated by the `tokenAuth` policy
+- Tokens can be revoked via the ban mechanism (iat-based blacklist)
+
+### Token Blacklist
+- Backed by `t_token_blacklist` table with in-memory cache
+- Stores a `revoked_before` timestamp per user
+- Tokens with `iat < revoked_before` are considered revoked
+- Used by the ban system to invalidate all tokens for a user
+
+### MFA Enrollment Tokens
+- Separate token type with subject `MfaEnrollment`
+- Only accepted by MFA-specific endpoints (`enroll`, `verify`)
+- Full authentication tokens are rejected by MFA enrollment endpoints
+- Only Administrators can initiate the enrollment flow
 
 ### Ownership-Based Access
 - Users can modify their own content
@@ -169,11 +254,14 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 ### Sensitive Data Protection
 - Sensitive entrance coordinates are hidden from everyone except Administrators
 - Only Administrators can modify sensitive entrance coordinates
+- Massif-level sensitivity cascades to contained entrances
 
 ### Soft Deletes
 - Content is soft-deleted (marked as deleted, not removed)
-- Only Moderators+ can restore deleted content
-- Administrators can perform permanent deletions
+- Only Moderators and Administrators can soft-delete and restore content
+- Only Administrators can perform permanent deletions
+- Permanent deletion of devices is blocked if they have associated sensor configurations
+- Permanent deletion of sensor configurations is blocked if they have associated time series
 
 ## Architecture
 
@@ -183,6 +271,9 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - `false` - Blocked (default)
 - `true` - Public access (no authentication required)
 - `'tokenAuth'` - Requires valid JWT token
+- `'mfaEnrollmentAuth'` - Requires valid MFA enrollment token
+- `['validateId']` - Public access with ID validation
+- `['validateId', 'tokenAuth']` - Authenticated with ID validation
 
 2. **Controller Level** (`RightService.hasGroup()`)
 - Role-based permission checks
@@ -191,6 +282,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 3. **Business Logic Level**
 - Resource-specific permissions
 - Contextual access control
+- FK guards for permanent deletion
 
 ## Implementation Details
 
@@ -210,6 +302,12 @@ CREATE TABLE j_caver_group (
   id_group int2 NOT NULL,
   PRIMARY KEY (id_caver, id_group)
 );
+
+-- Token blacklist for ban/revocation
+CREATE TABLE t_token_blacklist (
+  id_caver int4 PRIMARY KEY,
+  revoked_before timestamp NOT NULL
+);
 ```
 
 ### Code Examples
@@ -221,6 +319,8 @@ module.exports.policies = {
   '*': false, // Deny all by default
   'v1/entrance/find': true, // Public access
   'v1/entrance/create': 'tokenAuth', // Requires authentication
+  'v1/mfa/enroll': ['mfaEnrollmentAuth'], // Requires MFA enrollment token
+  'v1/device/update': ['validateId', 'tokenAuth'], // ID validation + auth
 };
 ```
 
@@ -280,6 +380,27 @@ result.longitude = !isSensitive || meta?.hasCompleteViewRight === true
 result.locations = !source.isSensitive || meta?.hasCompleteViewRight === true
   ? toList('locations', source, toSimpleLocation)
   : [];
+```
+
+#### Permanent Delete with FK Guard
+```javascript
+// Permanent deletion gated by foreign key check
+if (isPermanent) {
+  if (!hasAdminRight) {
+    return res.forbidden('You are not authorized to permanently delete.');
+  }
+  // Soft-delete first (phase 1)
+  if (!entity.isDeleted) {
+    await TDevice.destroyOne({ id: entityId });
+  }
+  // FK guard: block hard delete if children exist
+  const childCount = await TSensorConfiguration.count({ device: entityId });
+  if (childCount > 0) {
+    return res.conflict('Cannot permanently delete: has associated children.');
+  }
+  // Hard delete (phase 2)
+  await TDevice.destroyOne({ id: entityId });
+}
 ```
 
 ## Adding New Permissions

--- a/api/services/observation-import/EntityBuilder.js
+++ b/api/services/observation-import/EntityBuilder.js
@@ -287,6 +287,9 @@ const build = async ({
 
   // Effective author IDs: use resolved entities if available, else fall back to profile.
   // Deduplicate to prevent duplicate junction rows.
+  // Note: authors.length should always be > 0 here because ProfileValidator
+  // guarantees authorIds is non-empty and ReferenceValidator resolves them.
+  // The fallback to profile.authorIds is a defensive safeguard only.
   const authorIds = [
     ...new Set(
       authors.length > 0 ? authors.map((a) => a.id) : profile.authorIds || []

--- a/api/services/observation-import/EntityBuilder.js
+++ b/api/services/observation-import/EntityBuilder.js
@@ -261,7 +261,7 @@ const processColumn = async ({
  *   { rows: string[][], timestamps: Date[], measurements: Array<{columnIndex, value, valueSi}[]> }
  * @param {Object} params.profile - Full profile JSON
  * @param {Object} params.resolvedEntities
- *   { cave, license, authors: TCaver[], media: Map<id,TMedium>, sensorConfigs: Map<id,TSensorConfiguration> }
+ *   { cave, license, media: Map<id,TMedium>, sensorConfigs: Map<id,TSensorConfiguration> }
  * @param {Object} params.file - Multer file object { buffer, originalname, size, mimetype }
  * @param {number} params.requestAuthorId - Authenticated user ID
  * @returns {Promise<{
@@ -283,18 +283,14 @@ const build = async ({
   requestAuthorId,
 }) => {
   const { timestamps, measurements } = parsedData;
-  const { cave, license, authors } = resolvedEntities;
+  const { cave, license } = resolvedEntities;
 
-  // Effective author IDs: use resolved entities if available, else fall back to profile.
-  // Deduplicate to prevent duplicate junction rows.
-  // Note: authors.length should always be > 0 here because ProfileValidator
-  // guarantees authorIds is non-empty and ReferenceValidator resolves them.
-  // The fallback to profile.authorIds is a defensive safeguard only.
-  const authorIds = [
-    ...new Set(
-      authors.length > 0 ? authors.map((a) => a.id) : profile.authorIds || []
-    ),
-  ];
+  // Use profile.authorIds directly to preserve user-specified ordering.
+  // ProfileValidator guarantees authorIds is a non-empty array of positive
+  // integers, and ReferenceValidator confirms each ID exists in TCaver.
+  // Deduplicate to prevent duplicate junction rows while keeping the first
+  // occurrence (preserves intended primary author at index 0).
+  const authorIds = [...new Set(profile.authorIds)];
 
   // Defensive check: timestamps and measurements must be aligned (same row count)
   if (timestamps.length !== measurements.length) {

--- a/api/services/observation-import/EntityBuilder.js
+++ b/api/services/observation-import/EntityBuilder.js
@@ -261,7 +261,7 @@ const processColumn = async ({
  *   { rows: string[][], timestamps: Date[], measurements: Array<{columnIndex, value, valueSi}[]> }
  * @param {Object} params.profile - Full profile JSON
  * @param {Object} params.resolvedEntities
- *   { cave, license, author, media: Map<id,TMedium>, sensorConfigs: Map<id,TSensorConfiguration> }
+ *   { cave, license, authors: TCaver[], media: Map<id,TMedium>, sensorConfigs: Map<id,TSensorConfiguration> }
  * @param {Object} params.file - Multer file object { buffer, originalname, size, mimetype }
  * @param {number} params.requestAuthorId - Authenticated user ID
  * @returns {Promise<{
@@ -283,7 +283,15 @@ const build = async ({
   requestAuthorId,
 }) => {
   const { timestamps, measurements } = parsedData;
-  const { cave, license, author } = resolvedEntities;
+  const { cave, license, authors } = resolvedEntities;
+
+  // Effective author IDs: use resolved entities if available, else fall back to profile.
+  // Deduplicate to prevent duplicate junction rows.
+  const authorIds = [
+    ...new Set(
+      authors.length > 0 ? authors.map((a) => a.id) : profile.authorIds || []
+    ),
+  ];
 
   // Defensive check: timestamps and measurements must be aligned (same row count)
   if (timestamps.length !== measurements.length) {
@@ -408,7 +416,7 @@ const build = async ({
     const documentData = {
       type: 2, // Dataset
       license: license ? license.id : profile.licenseId,
-      author: author ? author.id : profile.authorId,
+      author: authorIds[0],
       isValidated: false,
       dateInscription: now,
     };
@@ -437,11 +445,15 @@ const build = async ({
       dateInscription: now,
     }).usingConnection(db);
 
-    // Link the author in the junction table
-    await JDocumentCaverAuthor.create({
-      document: document.id,
-      caver: author ? author.id : profile.authorId,
-    }).usingConnection(db);
+    // Link all authors in the junction table (sequential to share the
+    // transaction connection safely — same pattern as time series creation)
+    for (const caverId of authorIds) {
+      // eslint-disable-next-line no-await-in-loop
+      await JDocumentCaverAuthor.create({
+        document: document.id,
+        caver: caverId,
+      }).usingConnection(db);
+    }
 
     // -------------------------------------------------------------------------
     // 4. Upload raw data file to Azure

--- a/api/services/observation-import/ProfileValidator.js
+++ b/api/services/observation-import/ProfileValidator.js
@@ -48,7 +48,7 @@ const validate = (profile) => {
   const requiredFields = [
     'timezone',
     'columnMappings',
-    'authorId',
+    'authorIds',
     'licenseId',
   ];
   requiredFields.forEach((field) => {
@@ -66,7 +66,7 @@ const validate = (profile) => {
   }
 
   // 1c. Referenced ID fields must be positive integers when present
-  const idFields = ['caveId', 'licenseId', 'authorId'];
+  const idFields = ['caveId', 'licenseId'];
   idFields.forEach((field) => {
     const val = profile[field];
     if (val !== undefined && val !== null) {
@@ -77,6 +77,25 @@ const validate = (profile) => {
       }
     }
   });
+
+  // 1d. authorIds must be a non-empty array of positive integers.
+  // Note: isBlank([]) is false (arrays are not blank), so an empty array passes
+  // the required check above but is caught here by the length check.
+  if (!isBlank(profile.authorIds)) {
+    if (!Array.isArray(profile.authorIds)) {
+      errors.push('authorIds must be an array');
+    } else if (profile.authorIds.length === 0) {
+      errors.push('authorIds must not be empty');
+    } else {
+      profile.authorIds.forEach((val, idx) => {
+        if (!isValidId(val)) {
+          errors.push(
+            `authorIds[${idx}] must be a positive integer (got ${JSON.stringify(val)})`
+          );
+        }
+      });
+    }
+  }
 
   // 2. IANA timezone validation
   if (!isBlank(profile.timezone)) {

--- a/api/services/observation-import/ReferenceValidator.js
+++ b/api/services/observation-import/ReferenceValidator.js
@@ -15,7 +15,6 @@ const isBlank = require('../../utils/isBlank');
  * @typedef {Object} ResolvedEntities
  * @property {Object|null}      cave          - Resolved TCave record (or null)
  * @property {Object}           license       - Resolved TLicense record
- * @property {Object[]}         authors       - Resolved TCaver records for all author IDs
  * @property {Map<number,Object>} media       - Map of mediumId → TMedium record
  * @property {Map<number,Object>} sensorConfigs - Map of sensorConfigurationId → TSensorConfiguration (with quantityKind populated)
  */
@@ -32,7 +31,6 @@ const validate = async (profile) => {
   const resolved = {
     cave: null,
     license: null,
-    authors: [],
     media: new Map(),
     sensorConfigs: new Map(),
   };
@@ -112,15 +110,13 @@ const validate = async (profile) => {
     );
   }
 
-  // Author checks: resolve all unique author IDs from authorIds
+  // Author checks: verify all unique author IDs from authorIds exist
   const uniqueAuthorIds = [...new Set(profile.authorIds || [])];
   uniqueAuthorIds.forEach((authorId) => {
     checks.push(
       TCaver.findOne({ id: authorId }).then((author) => {
         if (!author) {
           errors.push(`authorIds: Caver with ID ${authorId} not found`);
-        } else {
-          resolved.authors.push(author);
         }
       })
     );

--- a/api/services/observation-import/ReferenceValidator.js
+++ b/api/services/observation-import/ReferenceValidator.js
@@ -15,7 +15,7 @@ const isBlank = require('../../utils/isBlank');
  * @typedef {Object} ResolvedEntities
  * @property {Object|null}      cave          - Resolved TCave record (or null)
  * @property {Object}           license       - Resolved TLicense record
- * @property {Object}           author        - Resolved TCaver record
+ * @property {Object[]}         authors       - Resolved TCaver records for all author IDs
  * @property {Map<number,Object>} media       - Map of mediumId → TMedium record
  * @property {Map<number,Object>} sensorConfigs - Map of sensorConfigurationId → TSensorConfiguration (with quantityKind populated)
  */
@@ -32,7 +32,7 @@ const validate = async (profile) => {
   const resolved = {
     cave: null,
     license: null,
-    author: null,
+    authors: [],
     media: new Map(),
     sensorConfigs: new Map(),
   };
@@ -112,18 +112,19 @@ const validate = async (profile) => {
     );
   }
 
-  // Author check (required)
-  if (!isBlank(profile.authorId)) {
+  // Author checks: resolve all unique author IDs from authorIds
+  const uniqueAuthorIds = [...new Set(profile.authorIds || [])];
+  uniqueAuthorIds.forEach((authorId) => {
     checks.push(
-      TCaver.findOne({ id: profile.authorId }).then((author) => {
+      TCaver.findOne({ id: authorId }).then((author) => {
         if (!author) {
-          errors.push(`authorId: Caver with ID ${profile.authorId} not found`);
+          errors.push(`authorIds: Caver with ID ${authorId} not found`);
         } else {
-          resolved.author = author;
+          resolved.authors.push(author);
         }
       })
     );
-  }
+  });
 
   // Medium checks (per column mapping, unique IDs)
   uniqueMediumIds.forEach((mediumId) => {

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -7533,7 +7533,7 @@ components:
       required:
         - timezone
         - columnMappings
-        - authorId
+        - authorIds
         - licenseId
       properties:
         encoding:
@@ -7629,11 +7629,13 @@ components:
         longitude:
           type: number
           nullable: true
-        authorId:
-          type: integer
-          minimum: 1
-          maximum: 2147483647
-          description: Caver ID of the data author. Must be a positive integer.
+        authorIds:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          minItems: 1
+          description: Caver IDs of the data authors. Must be a non-empty array of positive integers.
         licenseId:
           type: integer
           minimum: 1

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -6202,9 +6202,14 @@ paths:
                     See the ObservationImportProfile schema for the full structure.
                     Key fields: encoding, headerRow, skipFirstRows, skipLastRows,
                     timezone, dateFormat/dateOnlyFormat/timeOnlyFormat, numberLocale,
-                    columnMappings, caveId, authorId, licenseId,
+                    columnMappings, caveId, authorIds, licenseId,
                     documentTitle, documentLanguage, observationName, dataQuality,
                     samplingIntervalSeconds.
+
+                    Author attribution: `authorIds` is a required array of caver IDs
+                    representing the document authors (people who contributed to the
+                    data collection). All listed authors are linked to the created
+                    document via the j_document_caver_author junction table.
       responses:
         '200':
           description: Import successful

--- a/test/integration/1_services/observation-import/EntityBuilder.property.test.js
+++ b/test/integration/1_services/observation-import/EntityBuilder.property.test.js
@@ -54,7 +54,7 @@ function buildProfile(columnIndices, overrides = {}) {
     timezone: 'Europe/Paris',
     caveId: 1,
     pointLabel: 'Test Point',
-    authorId: 7,
+    authorIds: [7],
     licenseId: 1,
     dataQuality: 'raw',
     columnMappings: [
@@ -95,7 +95,7 @@ function buildResolvedEntities(columnIndices) {
   return {
     cave: { id: 1 },
     license: { id: 1 },
-    author: { id: 7 },
+    authors: [{ id: 7 }],
     media,
     sensorConfigs,
   };
@@ -581,7 +581,7 @@ describe('EntityBuilder - Property 10: Denormalized time series fields match sou
           const resolvedEntities = {
             cave: { id: 1 },
             license: { id: 1 },
-            author: { id: 7 },
+            authors: [{ id: 7 }],
             media,
             sensorConfigs,
           };

--- a/test/integration/1_services/observation-import/EntityBuilder.test.js
+++ b/test/integration/1_services/observation-import/EntityBuilder.test.js
@@ -36,7 +36,7 @@ function buildMinimalParams(overrides = {}) {
       timezone: 'Europe/Paris',
       caveId: 1,
       pointLabel: 'Test Point',
-      authorId: 7,
+      authorIds: [7],
       licenseId: 1,
       dataQuality: 'raw',
       documentTitle: 'My Doc Title',
@@ -54,7 +54,7 @@ function buildMinimalParams(overrides = {}) {
     resolvedEntities: {
       cave: { id: 1 },
       license: { id: 1 },
-      author: { id: 7 },
+      authors: [{ id: 7 }],
       media: new Map([[5, { id: 5, code: 'air' }]]),
       sensorConfigs: new Map([
         [

--- a/test/integration/1_services/observation-import/ProfileValidator.property.test.js
+++ b/test/integration/1_services/observation-import/ProfileValidator.property.test.js
@@ -61,7 +61,7 @@ const idArb = fc.integer({ min: 1, max: 100000 });
 /** A minimal valid profile with all required fields and no violations */
 const minimalValidProfileArb = fc.record({
   timezone: validTimezoneArb,
-  authorId: idArb,
+  authorIds: fc.uniqueArray(idArb, { minLength: 1, maxLength: 3 }),
   licenseId: idArb,
   dateFormat: fc.constant('YYYY-MM-DD HH:mm:ss'),
   columnMappings: fc
@@ -107,8 +107,12 @@ const VIOLATIONS = [
     apply: (p) => ({ ...p, timezone: undefined }),
   },
   {
-    name: 'missing authorId',
-    apply: (p) => ({ ...p, authorId: undefined }),
+    name: 'missing authorIds',
+    apply: (p) => {
+      const q = { ...p };
+      delete q.authorIds;
+      return q;
+    },
   },
   {
     name: 'missing licenseId',
@@ -187,7 +191,7 @@ function countExpectedProfileErrors(profile) {
   if (!profile || typeof profile !== 'object') return 1;
 
   // Required fields
-  ['timezone', 'columnMappings', 'authorId', 'licenseId'].forEach((field) => {
+  ['timezone', 'columnMappings', 'authorIds', 'licenseId'].forEach((field) => {
     if (
       profile[field] === undefined ||
       profile[field] === null ||
@@ -362,7 +366,7 @@ describe('ProfileValidator - Property 1: Profile validation reports all errors',
  */
 const profileWithTimezone = (tz) => ({
   timezone: tz,
-  authorId: 1,
+  authorIds: [1],
   licenseId: 1,
   caveId: 1,
   columnMappings: [

--- a/test/integration/1_services/observation-import/ProfileValidator.test.js
+++ b/test/integration/1_services/observation-import/ProfileValidator.test.js
@@ -15,7 +15,7 @@ const ProfileValidator = require('../../../../api/services/observation-import/Pr
 /** A minimal valid profile — use as a base and override individual fields. */
 const validBase = () => ({
   timezone: 'Europe/Paris',
-  authorId: 1,
+  authorIds: [1],
   licenseId: 1,
   caveId: 42,
   dateFormat: 'YYYY-MM-DD HH:mm:ss',
@@ -68,12 +68,45 @@ describe('ProfileValidator', () => {
     });
   });
 
-  describe('required field: authorId', () => {
-    it('should return an error when authorId is missing', () => {
+  describe('required field: authorIds', () => {
+    it('should return an error when authorIds is missing', () => {
       const profile = validBase();
-      delete profile.authorId;
+      delete profile.authorIds;
       const errors = ProfileValidator.validate(profile);
-      should(errors.some((e) => e.includes('authorId'))).be.true();
+      should(errors.some((e) => e.includes('authorIds'))).be.true();
+    });
+
+    it('should not return an error when authorIds is a valid array', () => {
+      const profile = validBase(); // has authorIds: [1]
+      const errors = ProfileValidator.validate(profile);
+      should(errors.some((e) => e.includes('authorIds'))).be.false();
+    });
+
+    it('should accept multiple author IDs', () => {
+      const profile = { ...validBase(), authorIds: [1, 5, 12] };
+      const errors = ProfileValidator.validate(profile);
+      should(errors.some((e) => e.includes('authorIds'))).be.false();
+    });
+
+    it('should return an error when authorIds is an empty array', () => {
+      const profile = { ...validBase(), authorIds: [] };
+      const errors = ProfileValidator.validate(profile);
+      should(errors.some((e) => e.includes('authorIds'))).be.true();
+    });
+
+    it('should return an error when authorIds contains non-positive integers', () => {
+      const profile = { ...validBase(), authorIds: [1, -3, 'abc'] };
+      const errors = ProfileValidator.validate(profile);
+      should(errors.some((e) => e.includes('authorIds[1]'))).be.true();
+      should(errors.some((e) => e.includes('authorIds[2]'))).be.true();
+    });
+
+    it('should return an error when authorIds is not an array', () => {
+      const profile = { ...validBase(), authorIds: 'not-an-array' };
+      const errors = ProfileValidator.validate(profile);
+      should(
+        errors.some((e) => e.includes('authorIds must be an array'))
+      ).be.true();
     });
   });
 
@@ -444,11 +477,11 @@ describe('ProfileValidator', () => {
   describe('error accumulation', () => {
     it('should return all errors at once when multiple validation rules fail', () => {
       const profile = {
-        // Missing: timezone, authorId, licenseId, columnMappings
+        // Missing: timezone, authorIds, licenseId, columnMappings
         // Also: no caveId/pointLabel
       };
       const errors = ProfileValidator.validate(profile);
-      // Should have at least 4 errors (timezone, authorId, licenseId, columnMappings, caveId/pointLabel)
+      // Should have at least 4 errors (timezone, authorIds, licenseId, columnMappings, caveId/pointLabel)
       should(errors.length).be.aboveOrEqual(4);
     });
 
@@ -472,11 +505,11 @@ describe('ProfileValidator', () => {
     it('should accumulate errors for multiple missing required fields', () => {
       const profile = {
         timezone: 'Europe/Paris',
-        // missing authorId, licenseId, columnMappings
+        // missing authorIds, licenseId, columnMappings
         caveId: 1,
       };
       const errors = ProfileValidator.validate(profile);
-      should(errors.some((e) => e.includes('authorId'))).be.true();
+      should(errors.some((e) => e.includes('authorIds'))).be.true();
       should(errors.some((e) => e.includes('licenseId'))).be.true();
       should(errors.some((e) => e.includes('columnMappings'))).be.true();
     });

--- a/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
+++ b/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
@@ -383,8 +383,6 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     should(result.errors).have.length(0);
     should(result.resolved.cave).be.ok();
     should(result.resolved.license).be.ok();
-    should(result.resolved.authors).be.an.Array();
-    should(result.resolved.authors.length).equal(1);
     should(result.resolved.media.has(5)).be.true();
     should(result.resolved.sensorConfigs.has(10)).be.true();
   });
@@ -509,10 +507,5 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     should(result.errors.length).equal(2);
     should(result.errors.join('\n')).containEql('777');
     should(result.errors.join('\n')).containEql('888');
-
-    // Resolved authors should contain only caver 3
-    should(result.resolved.authors).be.an.Array();
-    should(result.resolved.authors.length).equal(1);
-    should(result.resolved.authors[0].id).equal(3);
   });
 });

--- a/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
+++ b/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
@@ -49,8 +49,8 @@ const profileWithExistenceArb = fc
     licenseId: idArb,
     licenseExists: existsArb,
 
-    authorId: idArb,
-    authorExists: existsArb,
+    // Pool of unique author IDs (1–3) for multi-author scenarios
+    authorIds: fc.uniqueArray(idArb, { minLength: 1, maxLength: 3 }),
 
     // Pools of unique IDs for column-level references
     // Up to 4 unique sensor config IDs and 4 unique medium IDs
@@ -58,24 +58,29 @@ const profileWithExistenceArb = fc
     mediumIds: fc.uniqueArray(idArb, { minLength: 1, maxLength: 4 }),
   })
   .chain((base) => {
-    // Generate existence flags for each unique sensor and medium ID
+    // Generate existence flags for each unique sensor, medium, and author ID
     const sensorExistsArbs = base.sensorIds.map(() => existsArb);
     const mediumExistsArbs = base.mediumIds.map(() => existsArb);
+    const authorExistsArbs = base.authorIds.map(() => existsArb);
 
     return fc
       .tuple(
         fc.tuple(...sensorExistsArbs),
         fc.tuple(...mediumExistsArbs),
+        fc.tuple(...authorExistsArbs),
         // Number of column mappings (1–4)
         fc.integer({ min: 1, max: 4 })
       )
-      .chain(([sensorExistsArr, mediumExistsArr, numCols]) => {
+      .chain(([sensorExistsArr, mediumExistsArr, authorExistsArr, numCols]) => {
         // Build existence maps (id → boolean)
         const sensorExistsMap = new Map(
           base.sensorIds.map((id, i) => [id, sensorExistsArr[i]])
         );
         const mediumExistsMap = new Map(
           base.mediumIds.map((id, i) => [id, mediumExistsArr[i]])
+        );
+        const authorExistsMap = new Map(
+          base.authorIds.map((id, i) => [id, authorExistsArr[i]])
         );
 
         // Generate column mappings that reference IDs from the pools
@@ -104,14 +109,14 @@ const profileWithExistenceArb = fc
           profile: {
             caveId: base.caveId,
             licenseId: base.licenseId,
-            authorIds: [base.authorId],
+            authorIds: base.authorIds,
             columnMappings,
           },
           topLevel: {
             caveExists: base.caveExists,
             licenseExists: base.licenseExists,
-            authorExists: base.authorExists,
           },
+          authorExistsMap,
           sensorExistsMap,
           mediumExistsMap,
         }));
@@ -128,7 +133,13 @@ const profileWithExistenceArb = fc
  * Existence is determined per unique ID (not per column), so the stubs are
  * consistent with the expected error count.
  */
-function installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap) {
+function installStubs(
+  profile,
+  topLevel,
+  authorExistsMap,
+  sensorExistsMap,
+  mediumExistsMap
+) {
   // Build lookup maps for each model
   const caveMap = new Map();
   const licenseMap = new Map();
@@ -145,12 +156,13 @@ function installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap) {
     if (topLevel.licenseExists)
       licenseMap.set(profile.licenseId, { id: profile.licenseId });
   }
+  // Per-author existence
   if (profile.authorIds && profile.authorIds.length > 0) {
-    if (topLevel.authorExists) {
-      profile.authorIds.forEach((id) => {
+    profile.authorIds.forEach((id) => {
+      if (authorExistsMap.get(id)) {
         caverMap.set(id, { id });
-      });
-    }
+      }
+    });
   }
 
   // Per-ID existence for medium and sensor config
@@ -212,6 +224,7 @@ function installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap) {
 function countExpectedErrors(
   profile,
   topLevel,
+  authorExistsMap,
   sensorExistsMap,
   mediumExistsMap
 ) {
@@ -226,8 +239,8 @@ function countExpectedErrors(
   }
   // Author(s): count each unique author ID that doesn't exist
   const uniqueAuthorIds = [...new Set(profile.authorIds || [])];
-  uniqueAuthorIds.forEach(() => {
-    if (!topLevel.authorExists) count += 1;
+  uniqueAuthorIds.forEach((id) => {
+    if (!authorExistsMap.get(id)) count += 1;
   });
 
   // Per-column: collect the unique IDs actually referenced in measurement
@@ -281,9 +294,21 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     await fc.assert(
       fc.asyncProperty(
         profileWithExistenceArb,
-        async ({ profile, topLevel, sensorExistsMap, mediumExistsMap }) => {
+        async ({
+          profile,
+          topLevel,
+          authorExistsMap,
+          sensorExistsMap,
+          mediumExistsMap,
+        }) => {
           // Install stubs before calling validate
-          installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap);
+          installStubs(
+            profile,
+            topLevel,
+            authorExistsMap,
+            sensorExistsMap,
+            mediumExistsMap
+          );
 
           let result;
           try {
@@ -295,6 +320,7 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
           const expectedErrorCount = countExpectedErrors(
             profile,
             topLevel,
+            authorExistsMap,
             sensorExistsMap,
             mediumExistsMap
           );
@@ -334,12 +360,18 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     const topLevel = {
       caveExists: true,
       licenseExists: true,
-      authorExists: true,
     };
+    const authorExistsMap = new Map([[3, true]]);
     const sensorExistsMap = new Map([[10, true]]);
     const mediumExistsMap = new Map([[5, true]]);
 
-    installStubs(allExistProfile, topLevel, sensorExistsMap, mediumExistsMap);
+    installStubs(
+      allExistProfile,
+      topLevel,
+      authorExistsMap,
+      sensorExistsMap,
+      mediumExistsMap
+    );
 
     let result;
     try {
@@ -377,12 +409,18 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     const topLevel = {
       caveExists: false,
       licenseExists: false,
-      authorExists: false,
     };
+    const authorExistsMap = new Map([[777, false]]);
     const sensorExistsMap = new Map([[555, false]]);
     const mediumExistsMap = new Map([[444, false]]);
 
-    installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap);
+    installStubs(
+      profile,
+      topLevel,
+      authorExistsMap,
+      sensorExistsMap,
+      mediumExistsMap
+    );
 
     let result;
     try {

--- a/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
+++ b/test/integration/1_services/observation-import/ReferenceValidator.property.test.js
@@ -4,7 +4,7 @@
  *
  * Property 13: Reference validation completeness
  *
- * For any profile containing M entity references (caveId, licenseId, authorId,
+ * For any profile containing M entity references (caveId, licenseId, authorIds,
  * mediumId per column, sensorConfigurationId per column), if K of
  * those references point to nonexistent entities, the reference validator SHALL
  * report exactly K errors.
@@ -104,7 +104,7 @@ const profileWithExistenceArb = fc
           profile: {
             caveId: base.caveId,
             licenseId: base.licenseId,
-            authorId: base.authorId,
+            authorIds: [base.authorId],
             columnMappings,
           },
           topLevel: {
@@ -145,9 +145,12 @@ function installStubs(profile, topLevel, sensorExistsMap, mediumExistsMap) {
     if (topLevel.licenseExists)
       licenseMap.set(profile.licenseId, { id: profile.licenseId });
   }
-  if (profile.authorId !== undefined && profile.authorId !== null) {
-    if (topLevel.authorExists)
-      caverMap.set(profile.authorId, { id: profile.authorId });
+  if (profile.authorIds && profile.authorIds.length > 0) {
+    if (topLevel.authorExists) {
+      profile.authorIds.forEach((id) => {
+        caverMap.set(id, { id });
+      });
+    }
   }
 
   // Per-ID existence for medium and sensor config
@@ -221,9 +224,11 @@ function countExpectedErrors(
   if (profile.licenseId !== undefined && profile.licenseId !== null) {
     if (!topLevel.licenseExists) count += 1;
   }
-  if (profile.authorId !== undefined && profile.authorId !== null) {
+  // Author(s): count each unique author ID that doesn't exist
+  const uniqueAuthorIds = [...new Set(profile.authorIds || [])];
+  uniqueAuthorIds.forEach(() => {
     if (!topLevel.authorExists) count += 1;
-  }
+  });
 
   // Per-column: collect the unique IDs actually referenced in measurement
   // columns, then check whether they exist. Non-measurement columns are
@@ -314,7 +319,7 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     const allExistProfile = {
       caveId: 1,
       licenseId: 2,
-      authorId: 3,
+      authorIds: [3],
       columnMappings: [
         { columnIndex: 0, role: 'timestamp', timestampType: 'datetime' },
         {
@@ -346,7 +351,8 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     should(result.errors).have.length(0);
     should(result.resolved.cave).be.ok();
     should(result.resolved.license).be.ok();
-    should(result.resolved.author).be.ok();
+    should(result.resolved.authors).be.an.Array();
+    should(result.resolved.authors.length).equal(1);
     should(result.resolved.media.has(5)).be.true();
     should(result.resolved.sensorConfigs.has(10)).be.true();
   });
@@ -357,7 +363,7 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
     const profile = {
       caveId: 999,
       licenseId: 888,
-      authorId: 777,
+      authorIds: [777],
       columnMappings: [
         {
           columnIndex: 1,
@@ -385,20 +391,90 @@ describe('ReferenceValidator - Property 13: Reference validation completeness', 
       sinon.restore();
     }
 
-    // 5 errors: caveId, licenseId, authorId, sensorConfigurationId, mediumId
+    // 5 errors: caveId, licenseId, authorIds, sensorConfigurationId, mediumId
     should(result.errors.length).equal(5);
 
     const errorText = result.errors.join('\n');
     should(errorText).containEql('999'); // caveId
     should(errorText).containEql('888'); // licenseId
-    should(errorText).containEql('777'); // authorId
+    should(errorText).containEql('777'); // authorIds
     should(errorText).containEql('555'); // sensorConfigurationId
     should(errorText).containEql('444'); // mediumId
 
     should(errorText).containEql('caveId');
     should(errorText).containEql('licenseId');
-    should(errorText).containEql('authorId');
+    should(errorText).containEql('authorIds');
     should(errorText).containEql('sensorConfigurationId');
     should(errorText).containEql('mediumId');
+  });
+
+  it('should report errors only for nonexistent authors when authorIds has mixed existence', async function () {
+    this.timeout(10000);
+
+    const profile = {
+      caveId: 1,
+      licenseId: 2,
+      authorIds: [3, 777, 888],
+      columnMappings: [
+        { columnIndex: 0, role: 'timestamp', timestampType: 'datetime' },
+        {
+          columnIndex: 1,
+          role: 'measurement',
+          sensorConfigurationId: 10,
+          mediumId: 5,
+        },
+      ],
+    };
+
+    // Stubs: cave, license, sensor, medium all exist; author 3 exists, 777 and 888 do not
+    const caveMap = new Map([[1, { id: 1 }]]);
+    const licenseMap = new Map([[2, { id: 2 }]]);
+    const caverMap = new Map([[3, { id: 3 }]]);
+    const mediumMap = new Map([[5, { id: 5 }]]);
+    const sensorConfigMap = new Map([
+      [10, { id: 10, quantityKind: { id: 1, code: 'temperature' } }],
+    ]);
+
+    sinon.stub(TCave, 'findOne').callsFake((criteria) => ({
+      then: (resolve) =>
+        Promise.resolve(caveMap.get(criteria.id)).then(resolve),
+    }));
+    sinon.stub(TLicense, 'findOne').callsFake((criteria) => ({
+      then: (resolve) =>
+        Promise.resolve(licenseMap.get(criteria.id)).then(resolve),
+    }));
+    sinon.stub(TCaver, 'findOne').callsFake((criteria) => ({
+      then: (resolve) =>
+        Promise.resolve(caverMap.get(criteria.id)).then(resolve),
+    }));
+    sinon.stub(TMedium, 'findOne').callsFake((criteria) => ({
+      then: (resolve) =>
+        Promise.resolve(mediumMap.get(criteria.id)).then(resolve),
+    }));
+    sinon.stub(TSensorConfiguration, 'findOne').callsFake((criteria) => {
+      const record = sensorConfigMap.get(criteria.id);
+      const populatable = {
+        populate: () => populatable,
+        then: (resolve) => Promise.resolve(record).then(resolve),
+      };
+      return populatable;
+    });
+
+    let result;
+    try {
+      result = await ReferenceValidator.validate(profile);
+    } finally {
+      sinon.restore();
+    }
+
+    // Only 2 errors: author 777 and 888 not found
+    should(result.errors.length).equal(2);
+    should(result.errors.join('\n')).containEql('777');
+    should(result.errors.join('\n')).containEql('888');
+
+    // Resolved authors should contain only caver 3
+    should(result.resolved.authors).be.an.Array();
+    should(result.resolved.authors.length).equal(1);
+    should(result.resolved.authors[0].id).equal(3);
   });
 });

--- a/test/integration/4_routes/Observation/import.test.js
+++ b/test/integration/4_routes/Observation/import.test.js
@@ -19,7 +19,7 @@ const FIXTURE_CSV = path.resolve(
 // Used for cases where we want to test controller behaviour, not pipeline logic.
 const VALID_PROFILE = JSON.stringify({
   timezone: 'Europe/Paris',
-  authorId: 1,
+  authorIds: [1],
   licenseId: 1,
   caveId: 1,
   columnMappings: [
@@ -190,7 +190,7 @@ describe('POST /api/v1/observations/import - E2E pipeline (EntityBuilder stubbed
     // This verifies the pipeline reaches ReferenceValidator with real DB checks.
     const profileWithBadRefs = JSON.stringify({
       timezone: 'Europe/Paris',
-      authorId: 99999,
+      authorIds: [99999],
       licenseId: 99999,
       caveId: 99999,
       columnMappings: [


### PR DESCRIPTION
## 🤔 What

- Replace the single `authorId` field with `authorIds` (array) in the observation import profile
- All listed authors are linked to the created document via `j_document_caver_author`
- Closes #1666

## 🤷‍♂️ Why

Scientific observation campaigns are collaborative — multiple people contribute to data collection. The single-author model forced users to pick one person as "the" author. The `TDocument` model already supports multiple authors via the junction table, so the pipeline just needed to leverage it.

## 🔍 How

- **ProfileValidator**: `authorIds` is now a required field (non-empty array of positive integers). `authorId` is removed.
- **ReferenceValidator**: Resolves each unique ID from `authorIds` against `TCaver`. Returns `resolved.authors` (array).
- **EntityBuilder**: Deduplicates `authorIds`, sets `TDocument.author` FK to the first entry, and creates a `JDocumentCaverAuthor` row for each author sequentially within the transaction.
- `TObservation.author` remains unchanged — always the authenticated user (`requestAuthorId`).
- No schema migration needed.

## 🧪 Testing

All existing tests updated. New test added for mixed author existence (some IDs valid, some not). Run:

```
npm run test -- --grep "EntityBuilder|ProfileValidator|ReferenceValidator|observations/import"
```

## 📸 Previews

N/A — backend-only change.
