### PR TITLE
fix(account): prevent 500 when duplicate nicknames exist in DB

### DIFF
--- a/api/controllers/v1/account/update.js
+++ b/api/controllers/v1/account/update.js
@@ -147,10 +147,11 @@ module.exports = async (req, res) => {
     if (!req.body.nickname) {
       return res.badRequest('You must provide a nickname.');
     }
-    const existingCaver = await TCaver.findOne({
+    const existingCavers = await TCaver.find({
       nickname: req.body.nickname,
-    });
-    if (existingCaver && existingCaver.id !== req.token.id) {
+      id: { '!=': req.token.id },
+    }).limit(1);
+    if (existingCavers.length > 0) {
       return res.conflict('This nickname is already used.');
     }
     updates.nickname = req.body.nickname;

--- a/api/controllers/v1/account/update.js
+++ b/api/controllers/v1/account/update.js
@@ -147,11 +147,14 @@ module.exports = async (req, res) => {
     if (!req.body.nickname) {
       return res.badRequest('You must provide a nickname.');
     }
-    const existingCavers = await TCaver.find({
-      nickname: req.body.nickname,
-      id: { '!=': req.token.id },
-    }).limit(1);
-    if (existingCavers.length > 0) {
+    const nicknameConflict =
+      (
+        await TCaver.find({
+          nickname: req.body.nickname,
+          id: { '!=': req.token.id },
+        }).limit(1)
+      ).length > 0;
+    if (nicknameConflict) {
       return res.conflict('This nickname is already used.');
     }
     updates.nickname = req.body.nickname;

--- a/test/integration/4_routes/Account.test.js
+++ b/test/integration/4_routes/Account.test.js
@@ -245,6 +245,36 @@ describe('Account features', () => {
         .expect(409);
     });
 
+    it('should return 409 even when duplicate nicknames exist in DB', async () => {
+      // Simulate legacy data: create a caver with a nickname that already exists
+      const duplicateNickname = 'DuplicatedNick';
+      const caver1 = await TCaver.create({
+        nickname: duplicateNickname,
+        mail: 'dup1@test.com',
+        password: 'hashed',
+        language: '000',
+      }).fetch();
+      const caver2 = await TCaver.create({
+        nickname: duplicateNickname,
+        mail: 'dup2@test.com',
+        password: 'hashed',
+        language: '000',
+      }).fetch();
+
+      // The authenticated user (id 3) trying to claim this duplicated nickname
+      // should get 409, not 500
+      await supertest(sails.hooks.http.app)
+        .patch('/api/v1/account')
+        .send({ nickname: duplicateNickname })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(409);
+
+      // Cleanup
+      await TCaver.destroy({ id: [caver1.id, caver2.id] });
+    });
+
     it('should return 400 if nickname is empty', async () => {
       await supertest(sails.hooks.http.app)
         .patch('/api/v1/account')

--- a/test/integration/4_routes/Account.test.js
+++ b/test/integration/4_routes/Account.test.js
@@ -261,18 +261,35 @@ describe('Account features', () => {
         language: '000',
       }).fetch();
 
-      // The authenticated user (id 3) trying to claim this duplicated nickname
-      // should get 409, not 500
+      try {
+        // The authenticated user (id 3) trying to claim this duplicated nickname
+        // should get 409, not 500
+        await supertest(sails.hooks.http.app)
+          .patch('/api/v1/account')
+          .send({ nickname: duplicateNickname })
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(409);
+      } finally {
+        await TCaver.destroy({ id: [caver1.id, caver2.id] });
+      }
+    });
+
+    it('should allow submitting own current nickname without conflict', async () => {
+      // The authenticated user (User1, id 3) should be able to submit their
+      // own nickname alongside other fields without triggering a 409
+      const caver = await TCaver.findOne({ id: 3 });
       await supertest(sails.hooks.http.app)
         .patch('/api/v1/account')
-        .send({ nickname: duplicateNickname })
+        .send({ nickname: caver.nickname, name: 'SelfNickTest' })
         .set('Authorization', userToken)
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
-        .expect(409);
-
-      // Cleanup
-      await TCaver.destroy({ id: [caver1.id, caver2.id] });
+        .expect(204);
+      const updated = await TCaver.findOne({ id: 3 });
+      should(updated.name).equal('SelfNickTest');
+      should(updated.nickname).equal(caver.nickname);
     });
 
     it('should return 400 if nickname is empty', async () => {


### PR DESCRIPTION
## 🤔 What

- Fix `PATCH /api/v1/account` crashing with 500 when duplicate nicknames exist in the database
- Closes #1671

## 🤷‍♂️ Why

- `TCaver.findOne({ nickname })` throws when multiple records match (Waterline expects 0 or 1 results from `findOne`)
- Production has legacy duplicate nicknames (e.g., caver IDs 427 and 32181 share the same nickname)
- User 32181 repeatedly fails to update their account because of this crash

## 🔍 How

- Replaced `findOne({ nickname })` + post-hoc ID check with `find({ nickname, id: { '!=': req.token.id } }).limit(1)`
- This excludes the current user upfront and uses `find` which handles multiple matches gracefully
- If any other caver already has the nickname, returns 409 Conflict

## 🧪 Testing

- Added regression test that creates two cavers with the same nickname and verifies the endpoint returns 409 (not 500)
- All existing account tests pass (41 total)
