### PR TITLE
chore(db): add missing index and drop dead indexes

### DIFF
--- a/sql/9_05_2026_06_15_h_document_id_massif_index.sql
+++ b/sql/9_05_2026_06_15_h_document_id_massif_index.sql
@@ -1,0 +1,6 @@
+\c grottoce;
+
+-- Add index on h_document.id_massif to avoid seq scans during FK constraint checks.
+-- The composite PK (id, date_reviewed) does not help queries filtering only on id_massif.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_h_document_id_massif
+    ON h_document (id_massif);

--- a/sql/9_06_2026_06_15_drop_dead_indexes.sql
+++ b/sql/9_06_2026_06_15_drop_dead_indexes.sql
@@ -1,0 +1,25 @@
+\c grottoce;
+
+-- Drop indexes with 0 scans over 11 months (since 2024-07-21 stats_reset).
+-- They add write overhead on t_entrance without any read benefit.
+DROP INDEX IF EXISTS idx_t_entrance_of_interest;
+DROP INDEX IF EXISTS idx_t_entrance_country_active;
+
+-- Drop unused indexes on other tables (0 scans in 11 months).
+-- idx_h_name_id: h_name has 0 idx_scans total, this index is never used.
+DROP INDEX IF EXISTS idx_h_name_id;
+
+-- idx_time_series_date_range: never used since creation.
+DROP INDEX IF EXISTS idx_time_series_date_range;
+
+-- idx_quantity_kind_code: never used since creation.
+DROP INDEX IF EXISTS idx_quantity_kind_code;
+
+-- idx_t_message_sender: never used, t_message has only 205 rows.
+DROP INDEX IF EXISTS idx_t_message_sender;
+
+-- idx_point_geom: never used, t_point has very few rows.
+DROP INDEX IF EXISTS idx_point_geom;
+
+-- idx_tsql_time_series: never used since creation.
+DROP INDEX IF EXISTS idx_tsql_time_series;

--- a/sql/9_06_2026_06_15_drop_dead_indexes.sql
+++ b/sql/9_06_2026_06_15_drop_dead_indexes.sql
@@ -1,25 +1,27 @@
 \c grottoce;
 
 -- Drop indexes with 0 scans over 11 months (since 2024-07-21 stats_reset).
--- They add write overhead on t_entrance without any read benefit.
-DROP INDEX IF EXISTS idx_t_entrance_of_interest;
-DROP INDEX IF EXISTS idx_t_entrance_country_active;
+-- Using CONCURRENTLY to avoid blocking writes on busy tables.
+-- Note: CONCURRENTLY cannot run inside a transaction block; these statements
+-- are executed by psql which auto-commits each one individually.
+DROP INDEX CONCURRENTLY IF EXISTS idx_t_entrance_of_interest;
+DROP INDEX CONCURRENTLY IF EXISTS idx_t_entrance_country_active;
 
 -- Drop unused indexes on other tables (0 scans in 11 months).
 -- idx_h_name_id: h_name has 0 idx_scans total, this index is never used.
-DROP INDEX IF EXISTS idx_h_name_id;
+DROP INDEX CONCURRENTLY IF EXISTS idx_h_name_id;
 
 -- idx_time_series_date_range: never used since creation.
-DROP INDEX IF EXISTS idx_time_series_date_range;
+DROP INDEX CONCURRENTLY IF EXISTS idx_time_series_date_range;
 
 -- idx_quantity_kind_code: never used since creation.
-DROP INDEX IF EXISTS idx_quantity_kind_code;
+DROP INDEX CONCURRENTLY IF EXISTS idx_quantity_kind_code;
 
 -- idx_t_message_sender: never used, t_message has only 205 rows.
-DROP INDEX IF EXISTS idx_t_message_sender;
+DROP INDEX CONCURRENTLY IF EXISTS idx_t_message_sender;
 
 -- idx_point_geom: never used, t_point has very few rows.
-DROP INDEX IF EXISTS idx_point_geom;
+DROP INDEX CONCURRENTLY IF EXISTS idx_point_geom;
 
 -- idx_tsql_time_series: never used since creation.
-DROP INDEX IF EXISTS idx_tsql_time_series;
+DROP INDEX CONCURRENTLY IF EXISTS idx_tsql_time_series;

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -112,10 +112,7 @@ CREATE INDEX IF NOT EXISTS idx_t_description_cave ON t_description(id_cave) WHER
 CREATE INDEX IF NOT EXISTS idx_t_entrance_geom_public
   ON t_entrance USING gist(point_geom)
   WHERE is_sensitive = false AND is_deleted = false;
-CREATE INDEX IF NOT EXISTS idx_t_entrance_of_interest
-  ON t_entrance(id) WHERE is_of_interest = true AND is_deleted = false;
-CREATE INDEX IF NOT EXISTS idx_t_entrance_country_active
-  ON t_entrance(id_country) WHERE is_deleted = false;
+
 CREATE INDEX IF NOT EXISTS idx_t_entrance_iso3166
   ON t_entrance(iso_3166_2) WHERE iso_3166_2 IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_t_last_change_date
@@ -138,13 +135,11 @@ CREATE INDEX IF NOT EXISTS idx_j_document_caver_author_caver
   ON j_document_caver_author(id_caver);
 CREATE INDEX IF NOT EXISTS idx_j_document_grotto_author_grotto
   ON j_document_grotto_author(id_grotto);
-CREATE INDEX IF NOT EXISTS idx_h_name_id ON h_name(id);
 CREATE INDEX IF NOT EXISTS idx_h_description_document
   ON h_description(id_document) WHERE id_document IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_j_participant_caver ON j_participant(id_caver);
 CREATE INDEX IF NOT EXISTS idx_t_conversation_archive ON t_conversation_archive(id_conversation, id_caver);
 CREATE INDEX IF NOT EXISTS idx_t_message_conversation ON t_message(id_conversation, date_sent DESC);
-CREATE INDEX IF NOT EXISTS idx_t_message_sender ON t_message(id_caver_sender);
 
 -- Materialized view indexes (tables in test DB)
 CREATE INDEX IF NOT EXISTS idx_v_dq_country
@@ -168,8 +163,8 @@ CREATE INDEX IF NOT EXISTS idx_v_biblio_last_update
 CREATE INDEX IF NOT EXISTS idx_v_biblio_sets
   ON v_bibliographic_metadata USING gin(list_sets);
 
--- Scientific observations indexes
-CREATE INDEX IF NOT EXISTS idx_quantity_kind_code ON t_quantity_kind (code);
+-- History table indexes
+CREATE INDEX IF NOT EXISTS idx_h_document_id_massif ON h_document(id_massif);
 `;
 
 // Convert t_measurement from a regular table (created by Waterline migrate:drop)

--- a/test/integration/0_models/IndexOptimization.property.test.js
+++ b/test/integration/0_models/IndexOptimization.property.test.js
@@ -57,6 +57,14 @@ const DEAD_INDEXES = [
   { table: 't_entrance', name: 'idx_t_entrance_of_interest' },
   { table: 't_entrance', name: 'idx_t_entrance_country_active' },
   { table: 'h_name', name: 'idx_h_name_id' },
+  { table: 't_time_series', name: 'idx_time_series_date_range' },
+  { table: 't_quantity_kind', name: 'idx_quantity_kind_code' },
+  { table: 't_message', name: 'idx_t_message_sender' },
+  { table: 't_point', name: 'idx_point_geom' },
+  {
+    table: 't_time_series_quality_log',
+    name: 'idx_tsql_time_series',
+  },
 ];
 
 /**
@@ -83,7 +91,7 @@ describe('IndexOptimization - Property 8: required indexes exist', () => {
 /**
  * Property 9: All dead indexes removed after migration.
  * Encodes: the migration script drops every dead index identified in diagnostics.
- * Covers: all 7 dead indexes with 0 scans over the diagnostic window.
+ * Covers: all 15 dead indexes with 0 scans over the diagnostic window.
  */
 describe('IndexOptimization - Property 9: dead indexes removed', () => {
   DEAD_INDEXES.forEach(({ table, name }) => {

--- a/test/integration/0_models/IndexOptimization.property.test.js
+++ b/test/integration/0_models/IndexOptimization.property.test.js
@@ -8,8 +8,6 @@ const CommonService = require('../../../api/services/CommonService');
 const REQUIRED_INDEXES = [
   // Table indexes
   { table: 't_entrance', name: 'idx_t_entrance_geom_public' },
-  { table: 't_entrance', name: 'idx_t_entrance_of_interest' },
-  { table: 't_entrance', name: 'idx_t_entrance_country_active' },
   { table: 't_entrance', name: 'idx_t_entrance_iso3166' },
   { table: 't_last_change', name: 'idx_t_last_change_date' },
   { table: 't_last_change', name: 'idx_t_last_change_entity' },
@@ -27,8 +25,8 @@ const REQUIRED_INDEXES = [
     table: 'j_document_grotto_author',
     name: 'idx_j_document_grotto_author_grotto',
   },
-  { table: 'h_name', name: 'idx_h_name_id' },
   { table: 'h_description', name: 'idx_h_description_document' },
+  { table: 'h_document', name: 'idx_h_document_id_massif' },
   // Materialized view indexes (tables in test DB)
   { table: 'v_data_quality_compute_entrance', name: 'idx_v_dq_country' },
   { table: 'v_data_quality_compute_entrance', name: 'idx_v_dq_entrance' },
@@ -55,6 +53,10 @@ const DEAD_INDEXES = [
     table: 'j_caver_country_subscription',
     name: 'idx_j_caver_country_subscription_caver',
   },
+  // Dropped in 9_06_2026_06_15: 0 scans over 11 months (stats since 2024-07-21)
+  { table: 't_entrance', name: 'idx_t_entrance_of_interest' },
+  { table: 't_entrance', name: 'idx_t_entrance_country_active' },
+  { table: 'h_name', name: 'idx_h_name_id' },
 ];
 
 /**


### PR DESCRIPTION
## 🤔 What

- Add missing index on `h_document.id_massif` to eliminate sequential scans during FK constraint checks
- Drop 8 dead indexes that have had 0 scans over 11 months (stats window since 2024-07-21)
- Update test infrastructure (`customSQL.js` and `IndexOptimization.property.test.js`)

## 🤷‍♂️ Why

A production database health audit revealed:
- `h_document.id_massif` FK constraint checks were causing 3.3s sequential scans on a 684k-row table because the composite PK `(id, date_reviewed)` doesn't help queries filtering only on `id_massif`
- 8 indexes consuming write overhead on every INSERT/UPDATE/DELETE without ever being read (confirmed by `pg_stat_user_indexes` over 11 months)
- `t_entrance` had accumulated 22,979 dead tuples (16% bloat) degrading scan performance

## 🔍 How

Migration file:
- `sql/9_05_2026_06_15_h_document_id_massif_index.sql` — `CREATE INDEX CONCURRENTLY` (non-blocking)

Dropped indexes:
| Index | Table | Size | Reason |
|-------|-------|------|--------|
| `idx_t_entrance_of_interest` | t_entrance | 16 kB | 0 scans |
| `idx_t_entrance_country_active` | t_entrance | 1.3 MB | 0 scans |
| `idx_h_name_id` | h_name | 2.5 MB | 0 scans |
| `idx_time_series_date_range` | t_time_series | 16 kB | 0 scans |
| `idx_quantity_kind_code` | t_quantity_kind | 16 kB | 0 scans |
| `idx_t_message_sender` | t_message | 16 kB | 0 scans |
| `idx_point_geom` | t_point | 8 kB | 0 scans |
| `idx_tsql_time_series` | t_time_series_quality_log | 8 kB | 0 scans |

## 🧪 Testing

- `npm run test` passes (IndexOptimization property tests updated)
- Production impact: run migrations, then verify with `SELECT idx_scan FROM pg_stat_user_indexes WHERE indexrelname = 'idx_h_document_id_massif'` after a few hours
