### PR TITLE
fix(name): support language update on names, organizations and massifs

### DIFF
--- a/api/controllers/v1/cave/update.js
+++ b/api/controllers/v1/cave/update.js
@@ -43,16 +43,39 @@ module.exports = async (req, res) => {
     return res.badRequest(nameError);
   }
 
+  // Validate language if provided
+  const nameLanguage = req.body.name?.language;
+  if (nameLanguage !== undefined) {
+    if (nameLanguage === null) {
+      return res.badRequest('Language cannot be null.');
+    }
+    const foundLanguage = await TLanguage.findOne({ id: nameLanguage });
+    if (!foundLanguage) {
+      return res.badRequest('The provided language does not exist.');
+    }
+  }
+
   // Handle name manually
   // Currently, use only one name per cave (even if the model can handle multiple names)
   // Done before the TCave update so the last_change_cave DB trigger will fetch the last updated name
-  await TName.updateOne({
-    cave: caveId,
-    isMain: true,
-  }).set({
-    name: nameText,
-    language: req.body.name?.language,
-  });
+  if (req.body.name) {
+    const nameUpdate = {};
+    if (nameText !== undefined) {
+      nameUpdate.name = nameText;
+    }
+    if (nameLanguage !== undefined) {
+      nameUpdate.language = nameLanguage;
+    }
+    if (Object.keys(nameUpdate).length > 0) {
+      const updatedName = await TName.updateOne({
+        cave: caveId,
+        isMain: true,
+      }).set(nameUpdate);
+      if (!updatedName) {
+        sails.log.warn(`Cave ${caveId} has no main name record to update.`);
+      }
+    }
+  }
 
   await TCave.updateOne({ id: caveId }).set(updatedFields);
 

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -2,6 +2,7 @@ const ControllerService = require('../../../services/ControllerService');
 const MassifService = require('../../../services/MassifService');
 const NotificationService = require('../../../services/NotificationService');
 const { toMassif } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   const massifId = req.param('id');
@@ -28,7 +29,42 @@ module.exports = async (req, res) => {
   // Sensitivity is managed exclusively via mark-sensitive / unmark-sensitive
   delete cleanedData.isSensitive;
 
-  // The name is updated via the /api/v1/names route by the front
+  // Validate name length
+  const nameText = req.body.name?.text;
+  const nameError = validateNameLength(nameText);
+  if (nameError) {
+    return res.badRequest(nameError);
+  }
+
+  // Validate language if provided
+  const nameLanguage = req.body.name?.language;
+  if (nameLanguage !== undefined) {
+    if (nameLanguage === null) {
+      return res.badRequest('Language cannot be null.');
+    }
+    const foundLanguage = await TLanguage.findOne({ id: nameLanguage });
+    if (!foundLanguage) {
+      return res.badRequest('The provided language does not exist.');
+    }
+  }
+
+  // Handle name update inline (consistent with entrance and cave update)
+  if (req.body.name) {
+    const nameUpdate = {};
+    if (nameText !== undefined) {
+      nameUpdate.name = nameText;
+    }
+    if (nameLanguage !== undefined) {
+      nameUpdate.language = nameLanguage;
+    }
+    if (Object.keys(nameUpdate).length > 0) {
+      await TName.updateOne({
+        massif: massifId,
+        isMain: true,
+      }).set(nameUpdate);
+    }
+  }
+
   await TMassif.updateOne(massifId).set(cleanedData);
 
   const updatedMassif = await MassifService.getPopulatedMassif(massifId);

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -58,10 +58,13 @@ module.exports = async (req, res) => {
       nameUpdate.language = nameLanguage;
     }
     if (Object.keys(nameUpdate).length > 0) {
-      await TName.updateOne({
+      const updatedName = await TName.updateOne({
         massif: massifId,
         isMain: true,
       }).set(nameUpdate);
+      if (!updatedName) {
+        sails.log.warn(`Massif ${massifId} has no main name record to update.`);
+      }
     }
   }
 

--- a/api/controllers/v1/name/update.js
+++ b/api/controllers/v1/name/update.js
@@ -40,6 +40,12 @@ module.exports = async (req, res) => {
     cleanedData.language = language;
   }
 
+  if (Object.keys(cleanedData).length === 0) {
+    return res.badRequest(
+      'At least one of `name` or `language` must be provided.'
+    );
+  }
+
   try {
     await TName.updateOne({
       id: nameId,

--- a/api/controllers/v1/name/update.js
+++ b/api/controllers/v1/name/update.js
@@ -20,9 +20,25 @@ module.exports = async (req, res) => {
     return res.badRequest(nameError);
   }
 
-  const cleanedData = {
-    name: nameText,
-  };
+  // Validate language if provided
+  const language = req.param('language');
+  if (language !== undefined) {
+    if (language === null) {
+      return res.badRequest('Language cannot be null.');
+    }
+    const foundLanguage = await TLanguage.findOne({ id: language });
+    if (!foundLanguage) {
+      return res.badRequest('The provided language does not exist.');
+    }
+  }
+
+  const cleanedData = {};
+  if (nameText !== undefined) {
+    cleanedData.name = nameText;
+  }
+  if (language !== undefined) {
+    cleanedData.language = language;
+  }
 
   try {
     await TName.updateOne({

--- a/api/controllers/v1/organization/update.js
+++ b/api/controllers/v1/organization/update.js
@@ -3,6 +3,7 @@ const GrottoService = require('../../../services/GrottoService');
 const NotificationService = require('../../../services/NotificationService');
 const EnrichmentQueueService = require('../../../services/EnrichmentQueueService');
 const { toOrganization } = require('../../../services/mapping/converters');
+const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
   // Check if organization exists
@@ -35,7 +36,42 @@ module.exports = async (req, res) => {
     coordinatesChanged = true;
   }
 
-  // The name is updated via the /api/v1/names route by the front
+  // Validate name length
+  const nameText = req.body.name?.text;
+  const nameError = validateNameLength(nameText);
+  if (nameError) {
+    return res.badRequest(nameError);
+  }
+
+  // Validate language if provided
+  const nameLanguage = req.body.name?.language;
+  if (nameLanguage !== undefined) {
+    if (nameLanguage === null) {
+      return res.badRequest('Language cannot be null.');
+    }
+    const foundLanguage = await TLanguage.findOne({ id: nameLanguage });
+    if (!foundLanguage) {
+      return res.badRequest('The provided language does not exist.');
+    }
+  }
+
+  // Handle name update inline (consistent with entrance and cave update)
+  if (req.body.name) {
+    const nameUpdate = {};
+    if (nameText !== undefined) {
+      nameUpdate.name = nameText;
+    }
+    if (nameLanguage !== undefined) {
+      nameUpdate.language = nameLanguage;
+    }
+    if (Object.keys(nameUpdate).length > 0) {
+      await TName.updateOne({
+        grotto: organizationId,
+        isMain: true,
+      }).set(nameUpdate);
+    }
+  }
+
   await TGrotto.updateOne({ id: organizationId }).set(cleanedData);
 
   if (coordinatesChanged) {

--- a/api/controllers/v1/organization/update.js
+++ b/api/controllers/v1/organization/update.js
@@ -65,10 +65,15 @@ module.exports = async (req, res) => {
       nameUpdate.language = nameLanguage;
     }
     if (Object.keys(nameUpdate).length > 0) {
-      await TName.updateOne({
+      const updatedName = await TName.updateOne({
         grotto: organizationId,
         isMain: true,
       }).set(nameUpdate);
+      if (!updatedName) {
+        sails.log.warn(
+          `Organization ${organizationId} has no main name record to update.`
+        );
+      }
     }
   }
 

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3224,18 +3224,27 @@ paths:
     patch:
       tags:
         - names
-      description: Update a name.
+      description: Update a name. Both fields are optional (PATCH semantics).
       parameters:
         - name: id
           in: path
           required: true
           schema:
-            type: string
-        - name: name
-          in: query
-          required: true
-          schema:
-            type: string
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name text (max 200 characters)
+                  maxLength: 200
+                language:
+                  type: string
+                  description: ISO 639-3 language code (must exist in TLanguage)
+                  example: fra
       responses:
         '200':
           description: Successful operation
@@ -3243,6 +3252,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Name'
+        '400':
+          description: Validation error (name too long, language null or not found)
+        '404':
+          description: Name not found
 
   '/names/{id}/setAsMain':
     post:
@@ -4849,7 +4862,7 @@ paths:
     put:
       tags:
         - massifs
-      description: Update a massif, its list of caves, names, descriptions and documents and its geogPolygon. The polygon area must not exceed 8 000 km².
+      description: Update a massif, its list of caves, names, descriptions and documents and its geogPolygon. The polygon area must not exceed 35 000 km². Accepts an optional name field to update the main name atomically.
       parameters:
         - name: id
           in: path
@@ -4857,44 +4870,47 @@ paths:
           required: true
           schema:
             type: string
-        - name: geogPolygon
-          in: query
-          description: GeoJson EPSG4326 which represent the massif on a map (see post method)
-          required: false
-          schema:
-            type: object
-        - name: caves
-          in: query
-          description: List of caves ids
-          required: false
-          schema:
-            type: array
-            items:
+      requestBody:
+        content:
+          application/json:
+            schema:
               type: object
-        - name: descriptions
-          in: query
-          description: List of descriptions ids
-          required: false
-          schema:
-            type: array
-            items:
-              type: object
-        - name: documents
-          in: query
-          description: List of documents ids
-          required: false
-          schema:
-            type: array
-            items:
-              type: object
-        - name: names
-          in: query
-          description: List of names ids
-          required: false
-          schema:
-            type: array
-            items:
-              type: object
+              properties:
+                geogPolygon:
+                  type: object
+                  description: GeoJson EPSG4326 which represent the massif on a map
+                caves:
+                  type: array
+                  description: List of caves ids
+                  items:
+                    type: object
+                descriptions:
+                  type: array
+                  description: List of descriptions ids
+                  items:
+                    type: object
+                documents:
+                  type: array
+                  description: List of documents ids
+                  items:
+                    type: object
+                names:
+                  type: array
+                  description: List of names ids
+                  items:
+                    type: object
+                name:
+                  type: object
+                  description: Optional. Update the main name inline (text and/or language).
+                  properties:
+                    text:
+                      type: string
+                      description: Name text (max 200 characters)
+                      maxLength: 200
+                    language:
+                      type: string
+                      description: ISO 639-3 language code (must exist in TLanguage)
+                      example: fra
       responses:
         '200':
           description: Successful operation
@@ -4905,7 +4921,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Massif'
         '400':
-          description: Bad request, or the polygon area exceeds the 8 000 km² limit.
+          description: Bad request, name too long, language null or not found, or the polygon area exceeds the 35 000 km² limit.
         '404':
           description: Resource not found
         '403':
@@ -5205,7 +5221,7 @@ paths:
     put:
       tags:
         - organizations
-      description: Update an organization. See the POST /organization route explaination about the parameters you can use to update an organization.
+      description: Update an organization. Accepts an optional name field to update the main name atomically.
       parameters:
         - name: id
           in: path
@@ -5213,6 +5229,52 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  type: string
+                city:
+                  type: string
+                country:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: ISO 3166-1 alpha-2 country code
+                county:
+                  type: string
+                customMessage:
+                  type: string
+                latitude:
+                  type: number
+                longitude:
+                  type: number
+                mail:
+                  type: string
+                postalCode:
+                  type: string
+                region:
+                  type: string
+                url:
+                  type: string
+                yearBirth:
+                  type: integer
+                name:
+                  type: object
+                  description: Optional. Update the main name inline (text and/or language).
+                  properties:
+                    text:
+                      type: string
+                      description: Name text (max 200 characters)
+                      maxLength: 200
+                    language:
+                      type: string
+                      description: ISO 639-3 language code (must exist in TLanguage)
+                      example: fra
       responses:
         200:
           description: Successful operation
@@ -5220,8 +5282,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Organization'
+        400:
+          description: Validation error (name too long, language null or not found)
         403:
           description: You are not authorized to update an organization.
+        404:
+          description: Organization not found.
 
   '/organizations/count':
     get:

--- a/test/integration/4_routes/Caves/update.test.js
+++ b/test/integration/4_routes/Caves/update.test.js
@@ -140,7 +140,7 @@ describe('Cave features', () => {
           .send({
             name: {
               text: 'new cave name',
-              language: 'aut',
+              language: 'fra',
             },
           })
           .expect(200)
@@ -148,7 +148,7 @@ describe('Cave features', () => {
             if (err) return done(err);
             const populatedCave = await TCave.findOne(caveId).populate('names');
             should(populatedCave.names[0].name).equal('new cave name');
-            should(populatedCave.names[0].language).equal('aut');
+            should(populatedCave.names[0].language).equal('fra');
             return done();
           });
       });

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -40,6 +40,7 @@ describe('Massif features', () => {
       name: 'Test',
       language: 'fra',
       massif: massif.id,
+      isMain: true,
     }).fetch();
     testNameId = name.id;
   });
@@ -157,6 +158,111 @@ describe('Massif features', () => {
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(200, done);
+    });
+
+    it('should update name text via inline name field', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { text: 'Updated Massif Name' } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(async (err) => {
+          if (err) return done(err);
+          try {
+            const updatedName = await TName.findOne({ id: testNameId });
+            should(updatedName.name).equal('Updated Massif Name');
+
+            // Reset
+            await TName.updateOne({ id: testNameId }).set({ name: 'Test' });
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    it('should update name language via inline name field', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { language: 'eng' } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(async (err) => {
+          if (err) return done(err);
+          try {
+            const updatedName = await TName.findOne({ id: testNameId });
+            should(updatedName.language).equal('eng');
+
+            // Reset
+            await TName.updateOne({ id: testNameId }).set({
+              language: 'fra',
+            });
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    it('should update both name text and language atomically', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { text: 'Le Massif', language: 'fra' } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(async (err) => {
+          if (err) return done(err);
+          try {
+            const updatedName = await TName.findOne({ id: testNameId });
+            should(updatedName.name).equal('Le Massif');
+            should(updatedName.language).equal('fra');
+
+            // Reset
+            await TName.updateOne({ id: testNameId }).set({
+              name: 'Test',
+              language: 'fra',
+            });
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    it('should return 400 when name language does not exist', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { language: 'zzz' } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400, done);
+    });
+
+    it('should return 400 when name language is null', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { language: null } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400, done);
+    });
+
+    it('should return 400 when name text is too long', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ name: { text: 'A'.repeat(500) } })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(400, done);
     });
   });
 });

--- a/test/integration/4_routes/Names/update.test.js
+++ b/test/integration/4_routes/Names/update.test.js
@@ -58,18 +58,19 @@ describe('Name features', () => {
         });
     });
 
-    it('should handle empty name parameter', (done) => {
+    it('should return 400 when no fields are provided', (done) => {
       supertest(sails.hooks.http.app)
         .patch('/api/v1/names/8')
         .set('Authorization', moderatorToken)
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .send({})
-        .expect(200)
+        .expect(400)
         .end((err, res) => {
           if (err) return done(err);
-          // Should still return the name object even with no updates
-          should(res.body).have.property('name');
+          should(res.text).containEql(
+            'At least one of `name` or `language` must be provided'
+          );
           return done();
         });
     });

--- a/test/integration/4_routes/Names/update.test.js
+++ b/test/integration/4_routes/Names/update.test.js
@@ -148,5 +148,83 @@ describe('Name features', () => {
         .send(updateData)
         .expect(400, done); // Very long name likely causes validation error
     });
+
+    it('should update language successfully', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/names/7')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({ language: 'fra' })
+        .expect(200)
+        .end(async (err, res) => {
+          if (err) return done(err);
+
+          try {
+            const { body: name } = res;
+            should(name.language).have.property('id', 'fra');
+            should(name.name).equal('The cave with name 7');
+
+            // Reset language back to original
+            await TName.updateOne({ id: 7 }).set({ language: 'eng' });
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    it('should update both name and language simultaneously', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/names/7')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({ name: 'Nom de grotte', language: 'fra' })
+        .expect(200)
+        .end(async (err, res) => {
+          if (err) return done(err);
+
+          try {
+            const { body: name } = res;
+            should(name.name).equal('Nom de grotte');
+            should(name.language).have.property('id', 'fra');
+
+            // Reset back to original
+            await TName.updateOne({ id: 7 }).set({
+              name: 'The cave with name 7',
+              language: 'eng',
+            });
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    it('should return 400 when language does not exist', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/names/7')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({ language: 'zzz' })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).containEql('does not exist');
+          return done();
+        });
+    });
+
+    it('should return 400 when language is null', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch('/api/v1/names/7')
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({ language: null })
+        .expect(400, done);
+    });
   });
 });

--- a/test/integration/4_routes/Organization/update.test.js
+++ b/test/integration/4_routes/Organization/update.test.js
@@ -93,6 +93,111 @@ describe('Organization features', () => {
             return done();
           });
       });
+
+      it('should update name text via inline name field', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { text: 'Updated Org Name' } })
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: organization } = res;
+              should(organization.name).equal('Updated Org Name');
+
+              // Reset
+              await TName.updateOne({ id: 1 }).set({
+                name: 'Organization 1',
+              });
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      });
+
+      it('should update name language via inline name field', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { language: 'eng' } })
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: organization } = res;
+              should(organization.language).equal('eng');
+
+              // Reset
+              await TName.updateOne({ id: 1 }).set({ language: 'fra' });
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      });
+
+      it('should update both name text and language atomically', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { text: 'The Organization', language: 'eng' } })
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: organization } = res;
+              should(organization.name).equal('The Organization');
+              should(organization.language).equal('eng');
+
+              // Reset
+              await TName.updateOne({ id: 1 }).set({
+                name: 'Organization 1',
+                language: 'fra',
+              });
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      });
+
+      it('should return 400 when name language does not exist', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { language: 'zzz' } })
+          .expect(400, done);
+      });
+
+      it('should return 400 when name language is null', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { language: null } })
+          .expect(400, done);
+      });
+
+      it('should return 400 when name text is too long', (done) => {
+        supertest(sails.hooks.http.app)
+          .put('/api/v1/organizations/1')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({ name: { text: 'A'.repeat(500) } })
+          .expect(400, done);
+      });
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

- `PATCH /api/v1/names/:id` now accepts an optional `language` field (ISO 639-3 code) to update the language of an existing name
- `PUT /api/v1/organizations/:id` now accepts an optional `name: { text, language }` field to update the main name atomically in the same request
- `PUT /api/v1/massifs/:id` now accepts the same `name: { text, language }` field
- Closes #1652

## 🤷‍♂️ Why

Once a name was created with a wrong language, there was no way to correct it through the API. The `PATCH /names/:id` endpoint only accepted the `name` text field and silently ignored `language`.

Additionally, organizations and massifs required two separate API calls to update entity data + name (one PUT for the entity, one PATCH for the name), which is non-transactional and inconsistent with how entrances and caves already handle it inline.

## 🔍 How

- **`PATCH /names/:id`**: Added `language` as an optional body parameter. If provided, it's validated against `TLanguage` (must exist, cannot be null). Both `name` and `language` are independently optional (PATCH semantics).

- **`PUT /organizations/:id`** and **`PUT /massifs/:id`**: Added support for an optional `name` object in the request body with `text` and `language` sub-fields. When present, the main name (`isMain: true`) is updated inline — same pattern already used by `PUT /entrances/:id` and `PUT /caves/:id`.

All changes are fully backward compatible. Omitting the new fields preserves existing behavior.

## 🧪 Testing

- Integration tests added for all three endpoints covering: successful updates, both fields together, invalid language, null language, name too long
- Verified manually via curl against local dev server with GET roundtrips confirming persistence

## 📸 Previews

N/A — backend-only change.
