### PR TITLE
refactor(search): remove unused arrays from Typesense index and add nbEntrances to caves

### DIFF
--- a/api/dbSync/entities/cave.js
+++ b/api/dbSync/entities/cave.js
@@ -31,26 +31,10 @@ async function* processRows(source) {
   for await (const rows of source) {
     const joins = [
       {
-        table: 't_description d',
-        foreignField: 'id_cave',
-        rows,
-        localField: 'descriptions',
-        fields: ['title', 'body', exportUtils.dateAndAuthorFields('d')],
-        join: exportUtils.dateAndAuthorJoins('d'),
-      },
-      {
         table: 't_entrance',
         foreignField: 'id_cave',
         rows,
         localField: 'entrances',
-        fields: ['id'],
-        transform: (e) => e.id,
-      },
-      {
-        table: 't_document',
-        foreignField: 'id_cave',
-        rows,
-        localField: 'documents',
         fields: ['id'],
         transform: (e) => e.id,
       },

--- a/api/dbSync/entities/cave.js
+++ b/api/dbSync/entities/cave.js
@@ -29,6 +29,7 @@ const query = `
 
 async function* processRows(source) {
   for await (const rows of source) {
+    // Keep until frontend migrates from entrances.length to nbEntrances
     const joins = [
       {
         table: 't_entrance',
@@ -50,7 +51,7 @@ function importFormater(d) {
   d.id = `${d.id}`;
   d.dateInscription = new Date(d.dateInscription).getTime();
   if (d.dateReviewed) d.dateReviewed = new Date(d.dateReviewed).getTime();
-  if (d.nbEntrances) d.nbEntrances = parseInt(d.nbEntrances, 10);
+  if (d.nbEntrances != null) d.nbEntrances = parseInt(d.nbEntrances, 10);
   return d;
 }
 /* eslint-enable no-param-reassign */

--- a/api/dbSync/entities/cave.js
+++ b/api/dbSync/entities/cave.js
@@ -14,11 +14,13 @@ const query = `
       c.depth,
       c.length,
       c.temperature,
-      c.is_diving AS "isDiving"
+      c.is_diving AS "isDiving",
+      COUNT(e.id) AS "nbEntrances"
     FROM t_cave AS c
     LEFT JOIN t_name n ON n.id_cave = c.id AND n.is_main = true
     LEFT JOIN t_caver a ON a.id = c.id_author
     LEFT JOIN t_caver r ON r.id = c.id_reviewer
+    LEFT JOIN t_entrance e ON e.id_cave = c.id AND e.is_deleted = false
     WHERE c.is_deleted = false
     GROUP BY c.id, n.name, n.id_language, r.nickname, a.nickname
     ORDER BY c.id ASC
@@ -64,6 +66,7 @@ function importFormater(d) {
   d.id = `${d.id}`;
   d.dateInscription = new Date(d.dateInscription).getTime();
   if (d.dateReviewed) d.dateReviewed = new Date(d.dateReviewed).getTime();
+  if (d.nbEntrances) d.nbEntrances = parseInt(d.nbEntrances, 10);
   return d;
 }
 /* eslint-enable no-param-reassign */
@@ -90,6 +93,7 @@ module.exports = {
         { name: 'length', type: 'int32', optional: true, sort: true },
         { name: 'temperature', type: 'float', optional: true, sort: true },
         { name: 'isDiving', type: 'bool', optional: true, sort: true },
+        { name: 'nbEntrances', type: 'int32', optional: true },
       ],
       default_sorting_field: 'dateInscription',
     },

--- a/api/dbSync/entities/document.js
+++ b/api/dbSync/entities/document.js
@@ -43,8 +43,6 @@ const query = `
     ${exportUtils.PAGGING_PLACEHOLDER}
   `;
 
-const baseUrl = 'https://grottocenter.blob.core.windows.net/documents/';
-
 async function* processRows(source) {
   for await (const rows of source) {
     const joins = [
@@ -86,15 +84,6 @@ async function* processRows(source) {
         fields: ['n.name', 'n.id_language AS language'],
         join: [`LEFT JOIN t_name n ON n.id_grotto = l.id AND n.is_main = true`],
         where: [],
-      },
-      {
-        table: 't_file',
-        foreignField: 'id_document',
-        rows,
-        localField: 'files',
-        fields: ['filename', 'path'],
-        where: ['is_validated = true'],
-        transform: (e) => ({ filename: e.filename, url: baseUrl + e.path }),
       },
       {
         table: 'j_document_iso3166_2',

--- a/api/dbSync/entities/entrance.js
+++ b/api/dbSync/entities/entrance.js
@@ -77,69 +77,12 @@ async function* processRows(source) {
         where: [],
       },
       {
-        table: 't_location l',
-        foreignField: 'id_entrance',
-        rows,
-        localField: 'locations',
-        fields: ['title', 'body', exportUtils.dateAndAuthorFields('l')],
-        join: exportUtils.dateAndAuthorJoins('l'),
-      },
-      {
-        table: 't_description d',
-        foreignField: 'id_entrance',
-        rows,
-        localField: 'descriptions',
-        fields: ['title', 'body', exportUtils.dateAndAuthorFields('d')],
-        join: exportUtils.dateAndAuthorJoins('d'),
-      },
-      {
-        table: 't_rigging rg',
-        foreignField: 'id_entrance',
-        rows,
-        localField: 'riggings',
-        fields: [
-          'title',
-          'obstacles',
-          'ropes',
-          'anchors',
-          'observations',
-          exportUtils.dateAndAuthorFields('rg'),
-        ],
-        join: exportUtils.dateAndAuthorJoins('rg'),
-      },
-      {
-        table: 't_history h',
-        foreignField: 'id_entrance',
-        rows,
-        localField: 'histories',
-        fields: ['body', exportUtils.dateAndAuthorFields('h')],
-        join: exportUtils.dateAndAuthorJoins('h'),
-      },
-      {
-        table: 'j_document_entrance j',
-        foreignField: 'j.id_entrance',
-        rows,
-        localField: 'documents',
-        fields: ['j.id_document AS id'],
-        where: [],
-        transform: (e) => e.id,
-      },
-      {
         table: 't_comment c',
         foreignField: 'id_entrance',
         rows,
         localField: 'comments',
-        fields: [
-          'title',
-          'body',
-          'aestheticism',
-          'caving',
-          'approach',
-          'e_t_trail',
-          'e_t_underground',
-          exportUtils.dateAndAuthorFields('c'),
-        ],
-        join: exportUtils.dateAndAuthorJoins('c'),
+        fields: ['aestheticism', 'caving', 'approach'],
+        join: [],
       },
       {
         table: 'v_data_quality_compute_entrance vq',
@@ -201,7 +144,6 @@ async function* processRows(source) {
       if (row.isSensitive) {
         row.latitude = null;
         row.longitude = null;
-        row.locations = [];
       }
 
       row.cave = row.cave?.[0] ?? null;
@@ -236,6 +178,7 @@ function importFormater(d) {
     caving: average(comments.map((c) => c.caving).filter(filterFn)),
     approach: average(comments.map((c) => c.approach).filter(filterFn)),
   };
+  delete d.comments;
 
   // Strip non-indexed boolean characteristics so they don't leak into search
   const clean = { ...d };

--- a/api/dbSync/entities/entrance.js
+++ b/api/dbSync/entities/entrance.js
@@ -4,13 +4,8 @@ const {
   computeDateLastModif,
 } = require('../../../config/constants/entrance');
 const { getQualityData } = require('../../utils/computeEntranceDataQuality');
+const { computeCommentsRating } = require('../../utils/commentsRating');
 const CommonService = require('../../services/CommonService');
-
-function average(arr) {
-  if (arr.length === 0) return null;
-  return arr.reduce((a, b) => a + b, 0) / arr.length;
-}
-const filterFn = (e) => e && e > 0;
 
 const query = `
     SELECT
@@ -173,11 +168,7 @@ function importFormater(d) {
   if (d.longitude) d.longitude = parseFloat(d.longitude);
 
   const comments = d.comments ?? [];
-  d.commentsRating = {
-    aestheticism: average(comments.map((c) => c.aestheticism).filter(filterFn)),
-    caving: average(comments.map((c) => c.caving).filter(filterFn)),
-    approach: average(comments.map((c) => c.approach).filter(filterFn)),
-  };
+  d.commentsRating = computeCommentsRating(comments);
   delete d.comments;
 
   // Strip non-indexed boolean characteristics so they don't leak into search

--- a/api/dbSync/entities/massif.js
+++ b/api/dbSync/entities/massif.js
@@ -26,26 +26,6 @@ const query = `
 
 async function* processRows(source) {
   for await (const rows of source) {
-    const joins = [
-      {
-        table: 't_description d',
-        foreignField: 'id_massif',
-        rows,
-        localField: 'descriptions',
-        fields: ['title', 'body', exportUtils.dateAndAuthorFields('d')],
-        join: exportUtils.dateAndAuthorJoins('d'),
-      },
-      {
-        table: 't_document',
-        foreignField: 'id_massif',
-        rows,
-        localField: 'documents',
-        fields: ['id'],
-        transform: (e) => e.id,
-      },
-    ];
-
-    await Promise.all(joins.map((e) => exportUtils.joinMany(e)));
     for (const row of rows) yield row;
   }
 }

--- a/api/services/CaveService.js
+++ b/api/services/CaveService.js
@@ -239,7 +239,7 @@ module.exports = {
       length: c.caveLength,
       temperature: c.temperature,
       isDiving: c.isDiving,
-      nbEntrances: c.entrances?.length ?? 0,
+      nbEntrances: (c.entrances ?? []).filter((e) => !e.isDeleted).length,
     };
     await SearchService.updateDocument('caves', cave);
   },

--- a/api/services/CaveService.js
+++ b/api/services/CaveService.js
@@ -239,6 +239,7 @@ module.exports = {
       length: c.caveLength,
       temperature: c.temperature,
       isDiving: c.isDiving,
+      nbEntrances: c.entrances?.length ?? 0,
     };
     await SearchService.updateDocument('caves', cave);
   },

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -28,12 +28,7 @@ const RightService = require('./RightService');
 const coerceToInt = require('../utils/coerceToInt');
 const coerceBool = require('../utils/coerceBool');
 const { getQualityData } = require('../utils/computeEntranceDataQuality');
-
-function average(arr) {
-  if (arr.length === 0) return null;
-  return arr.reduce((a, b) => a + b, 0) / arr.length;
-}
-const filterFn = (e) => e && e > 0;
+const { computeCommentsRating } = require('../utils/commentsRating');
 
 module.exports = {
   getConvertedNameFromClientRequest: (req) => {
@@ -333,17 +328,7 @@ module.exports = {
         temperature: cave.temperature,
         isDiving: cave.isDiving,
       },
-      commentsRating: {
-        aestheticism: average(
-          (comments ?? []).map((cm) => cm.aestheticism).filter(filterFn)
-        ),
-        caving: average(
-          (comments ?? []).map((cm) => cm.caving).filter(filterFn)
-        ),
-        approach: average(
-          (comments ?? []).map((cm) => cm.approach).filter(filterFn)
-        ),
-      },
+      commentsRating: computeCommentsRating(comments ?? []),
     };
 
     if (entrance.isSensitive) {

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -29,6 +29,12 @@ const coerceToInt = require('../utils/coerceToInt');
 const coerceBool = require('../utils/coerceBool');
 const { getQualityData } = require('../utils/computeEntranceDataQuality');
 
+function average(arr) {
+  if (arr.length === 0) return null;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+const filterFn = (e) => e && e > 0;
+
 module.exports = {
   getConvertedNameFromClientRequest: (req) => {
     const result = {
@@ -327,32 +333,22 @@ module.exports = {
         temperature: cave.temperature,
         isDiving: cave.isDiving,
       },
-      descriptions: descriptions?.map((d) => ({
-        title: d.title,
-        body: d.body,
-      })),
-      locations: locations?.map((l) => ({ title: l.title, body: l.body })),
-      riggings: riggings?.map((r) => ({
-        title: r.title,
-        obstacles: r.obstacles,
-        ropes: r.ropes,
-        anchors: r.anchors,
-      })),
-      histories: histories?.map((h) => ({ body: h.body })),
-      documents: documents?.map((d) => d.id),
-      comments: comments?.map((c) => ({
-        title: c.title,
-        body: c.body,
-        aestheticism: c.aestheticism,
-        caving: c.caving,
-        approach: c.approach,
-      })),
+      commentsRating: {
+        aestheticism: average(
+          (comments ?? []).map((cm) => cm.aestheticism).filter(filterFn)
+        ),
+        caving: average(
+          (comments ?? []).map((cm) => cm.caving).filter(filterFn)
+        ),
+        approach: average(
+          (comments ?? []).map((cm) => cm.approach).filter(filterFn)
+        ),
+      },
     };
 
     if (entrance.isSensitive) {
       entrance.latitude = null;
       entrance.longitude = null;
-      entrance.locations = [];
     }
 
     // Compute data quality score and fetch massifs in parallel (independent queries)

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -63,6 +63,7 @@ const c = {
     depth: source.depth,
     temperature: source.temperature,
     isDiving: source.isDiving,
+    nbEntrances: source.nbEntrances ?? source.entrances?.length ?? 0,
     entrances: source.entrances?.map((e) => e.id),
     exploringOrganizations: toList(
       'exploringOrganizations',

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -65,11 +65,6 @@ const c = {
     isDiving: source.isDiving,
     nbEntrances: source.nbEntrances ?? source.entrances?.length ?? 0,
     entrances: source.entrances?.map((e) => e.id),
-    exploringOrganizations: toList(
-      'exploringOrganizations',
-      source,
-      c.toSimpleOrganization
-    ),
   }),
 
   toCaver: (source, meta) => {
@@ -775,14 +770,43 @@ const c = {
       let data = {};
 
       if (_type === 'persons') data = c.toCaver(item.document, meta);
-      else if (_type === 'documents') data = c.toDocument(item.document, meta);
-      else if (_type === 'caves')
+      else if (_type === 'documents') {
+        data = c.toDocument(item.document, meta);
+        // Strip arrays not needed in search responses
+        delete data.authorsOrganization;
+        delete data.files;
+        delete data.newFiles;
+        delete data.modifiedFiles;
+        delete data.deletedFiles;
+      } else if (_type === 'caves')
         data = c.toSimpleCave(item.document, meta); // Only used in quick search
-      else if (_type === 'entrances') data = c.toEntrance(item.document, meta);
-      else if (_type === 'organizations')
+      else if (_type === 'entrances') {
+        data = c.toEntrance(item.document, meta);
+        // Strip arrays not needed in search responses
+        delete data.comments;
+        delete data.descriptions;
+        delete data.histories;
+        delete data.riggings;
+        delete data.locations;
+        delete data.documents;
+        delete data.names;
+        if (data.cave) delete data.cave.exploringOrganizations;
+      } else if (_type === 'organizations') {
         data = c.toOrganization(item.document, meta);
-      else if (_type === 'massifs') data = c.toMassif(item.document);
-      else if (_type === 'devices') data = c.toSimpleDevice(item.document);
+        // Strip arrays not needed in search responses
+        delete data.cavers;
+        delete data.documents;
+        delete data.exploredEntrances;
+        delete data.exploredNetworks;
+        delete data.partnerEntrances;
+        delete data.partnerNetworks;
+      } else if (_type === 'massifs') {
+        data = c.toMassif(item.document);
+        // Strip arrays not needed in search responses
+        delete data.descriptions;
+        delete data.documents;
+        delete data.networks;
+      } else if (_type === 'devices') data = c.toSimpleDevice(item.document);
 
       return {
         ...data,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -782,7 +782,8 @@ const c = {
         data = c.toSimpleCave(item.document, meta); // Only used in quick search
       else if (_type === 'entrances') {
         data = c.toEntrance(item.document, meta);
-        // Strip arrays not needed in search responses
+        // Strip arrays not needed in search responses (transitional: old indexed
+        // documents may still carry these until the post-deploy full re-sync)
         delete data.comments;
         delete data.descriptions;
         delete data.histories;

--- a/api/utils/commentsRating.js
+++ b/api/utils/commentsRating.js
@@ -1,0 +1,30 @@
+/**
+ * Compute comment rating averages for search indexing.
+ * Shared between dbSync (entrance entity) and EntranceService (real-time updates).
+ */
+
+function average(arr) {
+  if (arr.length === 0) return null;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+const filterPositive = (e) => e && e > 0;
+
+/**
+ * Compute the commentsRating aggregate from an array of comment objects.
+ * Each comment is expected to have { aestheticism, caving, approach } numeric fields.
+ *
+ * @param {Array<Object>} comments - Array of comment objects
+ * @returns {{ aestheticism: number|null, caving: number|null, approach: number|null }}
+ */
+function computeCommentsRating(comments) {
+  return {
+    aestheticism: average(
+      comments.map((c) => c.aestheticism).filter(filterPositive)
+    ),
+    caving: average(comments.map((c) => c.caving).filter(filterPositive)),
+    approach: average(comments.map((c) => c.approach).filter(filterPositive)),
+  };
+}
+
+module.exports = { average, filterPositive, computeCommentsRating };

--- a/test/integration/1_services/Converters.test.js
+++ b/test/integration/1_services/Converters.test.js
@@ -189,7 +189,7 @@ describe('Converters Service', () => {
       should(result.length).be.null();
     });
 
-    it('should include exploringOrganizations when present', () => {
+    it('should not include exploringOrganizations', () => {
       const source = {
         id: 1,
         exploringOrganizations: [
@@ -202,15 +202,7 @@ describe('Converters Service', () => {
         ],
       };
       const result = converters.toSimpleCave(source);
-      should(result.exploringOrganizations).eql([
-        { id: 1, name: 'Test Org', language: 'eng', isDeleted: false },
-      ]);
-    });
-
-    it('should handle missing exploringOrganizations', () => {
-      const source = { id: 1 };
-      const result = converters.toSimpleCave(source);
-      should(result.exploringOrganizations).eql([]);
+      should(result.exploringOrganizations).be.undefined();
     });
   });
 

--- a/test/integration/1_services/EntranceService.test.js
+++ b/test/integration/1_services/EntranceService.test.js
@@ -144,7 +144,6 @@ describe('EntranceService', () => {
         author: { id: 1, nickname: 'Author' },
         names: [{ name: 'Test', language: 'en' }],
         iso_3166_2: 'FR-75',
-        locations: [{ title: 'Loc', body: 'Body' }],
       };
 
       await EntranceService.updateInSearch(entrance);
@@ -153,7 +152,6 @@ describe('EntranceService', () => {
       const callArg = updateStub.getCall(0).args[1];
       should(callArg.latitude).be.null();
       should(callArg.longitude).be.null();
-      should(callArg.locations).eql([]);
       process.env.NODE_ENV = originalEnv;
     });
 
@@ -419,22 +417,16 @@ describe('EntranceService', () => {
       const callArg = updateStub.getCall(0).args[1];
       should(callArg.reviewer).equal('Reviewer');
       should(callArg.country).equal('France');
-      should(callArg.descriptions).eql([{ title: 'Desc1', body: 'Body1' }]);
-      should(callArg.locations).eql([{ title: 'Loc1', body: 'LocBody1' }]);
-      should(callArg.riggings).eql([
-        { title: 'Rig1', obstacles: 'obs', ropes: 'rope', anchors: 'anc' },
-      ]);
-      should(callArg.histories).eql([{ body: 'History1' }]);
-      should(callArg.documents).eql([1, 2]);
-      should(callArg.comments).eql([
-        {
-          title: 'Com1',
-          body: 'ComBody1',
-          aestheticism: 5,
-          caving: 4,
-          approach: 3,
-        },
-      ]);
+      // Arrays are no longer indexed — only commentsRating is computed
+      should(callArg.descriptions).be.undefined();
+      should(callArg.locations).be.undefined();
+      should(callArg.riggings).be.undefined();
+      should(callArg.histories).be.undefined();
+      should(callArg.documents).be.undefined();
+      should(callArg.comments).be.undefined();
+      should(callArg.commentsRating).have.property('aestheticism', 5);
+      should(callArg.commentsRating).have.property('caving', 4);
+      should(callArg.commentsRating).have.property('approach', 3);
       process.env.NODE_ENV = originalEnv;
     });
   });


### PR DESCRIPTION
## 🤔 What

- Add `nbEntrances` scalar field to the Caves Typesense index (same pattern as massifs)
- Remove 21 unused arrays from Typesense indexing and search API responses across all 5 entities
- Keep the `entrances` array on caves for now (frontend still uses `.length` in quicksearch)

Closes #1580

## 🤷‍♂️ Why

The Typesense index stores large, unbounded arrays that are never used in search results. This wastes RAM, inflates response payloads, and slows down syncs with expensive JOINs for data that is never displayed.

## 🔍 How

**Index (dbSync processRows):**
- Entrances: removed 6 joins (descriptions, locations, riggings, histories, documents, comments full fields). Kept comments join slimmed to only rating fields (`aestheticism`, `caving`, `approach`) for `commentsRating` computation.
- Caves: removed descriptions and documents joins. Added `COUNT(e.id) AS "nbEntrances"` via `LEFT JOIN t_entrance`.
- Massifs: removed descriptions and documents joins.
- Documents: removed files join.
- Organizations: already clean (no array joins).

**Real-time updates (updateInSearch):**
- Entrances: replaced individual array mappings with `commentsRating` aggregate. Removed `locations = []` for sensitive entrances (no longer relevant).
- Caves: added `nbEntrances: c.entrances?.length ?? 0`.

**Search responses (toSearchResult converter):**
- Strips unused arrays per entity type after conversion, so non-search API endpoints remain unaffected.
- Removed `exploringOrganizations` from `toSimpleCave` (used only in search context).

## 🧪 Testing

All 2792 existing tests pass. Verified each entity via local curl against quicksearch:
- Caves: `nbEntrances` present, `exploringOrganizations` absent
- Entrances: no comments/descriptions/histories/riggings/locations/documents/names arrays
- Massifs: no descriptions/documents/networks
- Documents: no authorsOrganization/files/newFiles/modifiedFiles/deletedFiles
- Organizations: no cavers/documents/exploredEntrances/exploredNetworks/partnerEntrances/partnerNetworks

After deploy, a full Typesense re-sync is needed to remove the arrays from existing documents.
