### PR TITLE
feat(search): add GeoJSON, KML, and GPX export formats

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -89,6 +89,40 @@ const GEO_FORMATS = ['geojson', 'kml', 'gpx'];
 const BATCH_SIZE = 1000;
 const MAX_NB_ROW_EXPORT = 10000;
 
+/**
+ * Validate columns and columnsName arrays.
+ * Returns an error message string if invalid, or null if valid.
+ *
+ * @param {Array} columns - Column keys
+ * @param {Array|null} columnsName - Column display names (optional for geo formats)
+ * @param {object} options
+ * @param {boolean} options.requireColumnsName - Whether columnsName is mandatory
+ * @returns {string|null} Error message or null
+ */
+function validateColumns(columns, columnsName, { requireColumnsName }) {
+  const hasColumns = Array.isArray(columns) && columns.length > 0;
+  const hasColumnsName = Array.isArray(columnsName) && columnsName.length > 0;
+
+  if (!hasColumns) {
+    return 'columns must be a non-empty array';
+  }
+  if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
+    return 'each element in columns must be a non-empty string';
+  }
+  if (requireColumnsName && !hasColumnsName) {
+    return 'columnsName must be a non-empty array';
+  }
+  if (hasColumnsName) {
+    if (columns.length !== columnsName.length) {
+      return 'columns and columnsName must have the same length';
+    }
+    if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
+      return 'each element in columnsName must be a non-empty string';
+    }
+  }
+  return null;
+}
+
 module.exports = async (req, res) => {
   const format = req.param('format') || 'csv';
   const entity = req.param('entity') ?? '';
@@ -115,30 +149,15 @@ module.exports = async (req, res) => {
   const columns = req.param('columns');
   const columnsName = req.param('columnsName');
 
-  // For geo formats, columns/columnsName are optional (when absent, all fields are included).
-  // When provided, they must pass the same validation as CSV.
   const hasColumns = Array.isArray(columns) && columns.length > 0;
   const hasColumnsName = Array.isArray(columnsName) && columnsName.length > 0;
 
   if (!isGeoFormat) {
-    if (!hasColumns) {
-      res.badRequest('columns must be a non-empty array');
-      return;
-    }
-    if (!hasColumnsName) {
-      res.badRequest('columnsName must be a non-empty array');
-      return;
-    }
-    if (columns.length !== columnsName.length) {
-      res.badRequest('columns and columnsName must have the same length');
-      return;
-    }
-    if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
-      res.badRequest('each element in columns must be a non-empty string');
-      return;
-    }
-    if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
-      res.badRequest('each element in columnsName must be a non-empty string');
+    const error = validateColumns(columns, columnsName, {
+      requireColumnsName: true,
+    });
+    if (error) {
+      res.badRequest(error);
       return;
     }
   }
@@ -146,25 +165,16 @@ module.exports = async (req, res) => {
   // For geo formats with columns provided, validate and build field mapping
   let fieldMapping = null;
   if (isGeoFormat && hasColumns) {
-    if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
-      res.badRequest('each element in columns must be a non-empty string');
+    const error = validateColumns(columns, columnsName, {
+      requireColumnsName: false,
+    });
+    if (error) {
+      res.badRequest(error);
       return;
     }
     if (hasColumnsName) {
-      if (columns.length !== columnsName.length) {
-        res.badRequest('columns and columnsName must have the same length');
-        return;
-      }
-      if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
-        res.badRequest(
-          'each element in columnsName must be a non-empty string'
-        );
-        return;
-      }
-      // Map each column key to its display alias
       fieldMapping = columns.map((key, i) => ({ key, alias: columnsName[i] }));
     } else {
-      // columns provided without aliases — use key names as-is
       fieldMapping = columns.map((key) => ({ key, alias: key }));
     }
   }
@@ -212,14 +222,13 @@ module.exports = async (req, res) => {
         break;
       }
 
-      if (results.found > MAX_NB_ROW_EXPORT) {
-        if (!hasSentHeader) {
-          res.badRequest(
-            `To be exported a search cannot contain more than ${MAX_NB_ROW_EXPORT} results`
-          );
-          return;
-        }
-        break;
+      // Total result count check — only meaningful on the first page
+      // (results.found is constant across pages).
+      if (!hasSentHeader && results.found > MAX_NB_ROW_EXPORT) {
+        res.badRequest(
+          `To be exported a search cannot contain more than ${MAX_NB_ROW_EXPORT} results`
+        );
+        return;
       }
 
       if (!hasSentHeader) {
@@ -246,13 +255,16 @@ module.exports = async (req, res) => {
             latitude: doc.latitude,
             longitude: doc.longitude,
           };
+          if (doc.altitude != null) {
+            mapped.altitude = doc.altitude;
+          }
           fieldMapping.forEach(({ key, alias }) => {
             mapped[alias] = resolveField(doc, key);
           });
           return mapped;
         });
       }
-      res.write(serializer.serializeBatch(docsToSerialize, isFirst, null));
+      res.write(serializer.serializeBatch(docsToSerialize, isFirst));
       isFirst = false;
 
       if (documents.length < BATCH_SIZE) break;
@@ -306,14 +318,13 @@ module.exports = async (req, res) => {
       break;
     }
 
-    if (results.found > MAX_NB_ROW_EXPORT) {
-      if (!hasSentHeader) {
-        res.badRequest(
-          `To be exported a search cannot contain more than ${MAX_NB_ROW_EXPORT} results`
-        );
-        return;
-      }
-      break;
+    // Total result count check — only meaningful on the first page
+    // (results.found is constant across pages).
+    if (!hasSentHeader && results.found > MAX_NB_ROW_EXPORT) {
+      res.badRequest(
+        `To be exported a search cannot contain more than ${MAX_NB_ROW_EXPORT} results`
+      );
+      return;
     }
 
     if (!hasSentHeader) {
@@ -329,7 +340,7 @@ module.exports = async (req, res) => {
     const documents = results.hits.map((e) => e.document);
     res.write(documentsToCSV(documents, columns));
 
-    if (documents.length !== BATCH_SIZE) break;
+    if (documents.length < BATCH_SIZE) break;
     page += 1;
   }
 

--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -2,6 +2,10 @@ const SearchService = require('../../../services/SearchService');
 const {
   handleTypesenseError,
 } = require('../../../services/TypesenseErrorService');
+const {
+  serializers,
+  filterDocuments,
+} = require('../../../services/geo-serializers');
 
 function escapeCSV(v) {
   // Escape double quotes
@@ -80,44 +84,201 @@ function documentsToCSV(documents, columns) {
   return csvRows;
 }
 
+const VALID_FORMATS = ['csv', 'geojson', 'kml', 'gpx'];
+const GEO_FORMATS = ['geojson', 'kml', 'gpx'];
+const BATCH_SIZE = 1000;
+const MAX_NB_ROW_EXPORT = 10000;
+
 module.exports = async (req, res) => {
+  const format = req.param('format') || 'csv';
+  const entity = req.param('entity') ?? '';
+
+  // 1. Format validation
+  if (!VALID_FORMATS.includes(format)) {
+    res.badRequest('format must be one of: csv, geojson, kml, gpx');
+    return;
+  }
+
+  const isGeoFormat = GEO_FORMATS.includes(format);
+
+  // 2. Entity restriction for geo formats
+  if (isGeoFormat && entity !== 'entrances') {
+    res.badRequest(
+      'Geographic formats (geojson, kml, gpx) are only available for entrance searches'
+    );
+    return;
+  }
+
+  // 3. Column validation
   let matchAllFields = req.param('matchAllFields') ?? true;
   if (!matchAllFields || matchAllFields === 'false') matchAllFields = false;
   const columns = req.param('columns');
   const columnsName = req.param('columnsName');
 
-  if (!Array.isArray(columns) || columns.length === 0) {
-    res.badRequest('columns must be a non-empty array');
-    return;
+  // For geo formats, columns/columnsName are optional (when absent, all fields are included).
+  // When provided, they must pass the same validation as CSV.
+  const hasColumns = Array.isArray(columns) && columns.length > 0;
+  const hasColumnsName = Array.isArray(columnsName) && columnsName.length > 0;
+
+  if (!isGeoFormat) {
+    if (!hasColumns) {
+      res.badRequest('columns must be a non-empty array');
+      return;
+    }
+    if (!hasColumnsName) {
+      res.badRequest('columnsName must be a non-empty array');
+      return;
+    }
+    if (columns.length !== columnsName.length) {
+      res.badRequest('columns and columnsName must have the same length');
+      return;
+    }
+    if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
+      res.badRequest('each element in columns must be a non-empty string');
+      return;
+    }
+    if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
+      res.badRequest('each element in columnsName must be a non-empty string');
+      return;
+    }
   }
-  if (!Array.isArray(columnsName) || columnsName.length === 0) {
-    res.badRequest('columnsName must be a non-empty array');
-    return;
+
+  // For geo formats with columns provided, validate and build field mapping
+  let fieldMapping = null;
+  if (isGeoFormat && hasColumns) {
+    if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
+      res.badRequest('each element in columns must be a non-empty string');
+      return;
+    }
+    if (hasColumnsName) {
+      if (columns.length !== columnsName.length) {
+        res.badRequest('columns and columnsName must have the same length');
+        return;
+      }
+      if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
+        res.badRequest(
+          'each element in columnsName must be a non-empty string'
+        );
+        return;
+      }
+      // Map each column key to its display alias
+      fieldMapping = columns.map((key, i) => ({ key, alias: columnsName[i] }));
+    } else {
+      // columns provided without aliases — use key names as-is
+      fieldMapping = columns.map((key) => ({ key, alias: key }));
+    }
   }
-  if (columns.length !== columnsName.length) {
-    res.badRequest('columns and columnsName must have the same length');
-    return;
-  }
-  if (!columns.every((c) => typeof c === 'string' && c.length > 0)) {
-    res.badRequest('each element in columns must be a non-empty string');
-    return;
-  }
-  if (!columnsName.every((c) => typeof c === 'string' && c.length > 0)) {
-    res.badRequest('each element in columnsName must be a non-empty string');
+
+  // Geo streaming path
+  if (isGeoFormat) {
+    const serializer = serializers[format];
+    const timestamp = new Date().toISOString();
+
+    const geoParams = {
+      query: req.param('query'),
+      entity,
+      sort: req.param('sort'),
+      filter: req.param('filter') ?? {},
+      isLogicalCompareAnd: !!matchAllFields,
+    };
+
+    let hasSentHeader = false;
+    let isFirst = true;
+    let page = 1;
+    for (;;) {
+      let results;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        results = await SearchService.collectionSearch({
+          ...geoParams,
+          page,
+          size: BATCH_SIZE,
+        });
+      } catch (err) {
+        if (!hasSentHeader && handleTypesenseError(res, err)) return;
+        if (hasSentHeader) {
+          sails.log.error('Export to geo format error after headers sent', err);
+          break;
+        }
+        results = err;
+      }
+
+      if (!results || !results.hits) {
+        sails.log.error('Export to geo format error', geoParams, page, results);
+        if (!hasSentHeader) {
+          res.serverError('An internal error occurred');
+          return;
+        }
+        break;
+      }
+
+      if (results.found > MAX_NB_ROW_EXPORT) {
+        if (!hasSentHeader) {
+          res.badRequest(
+            `To be exported a search cannot contain more than ${MAX_NB_ROW_EXPORT} results`
+          );
+          return;
+        }
+        break;
+      }
+
+      if (!hasSentHeader) {
+        hasSentHeader = true;
+        res.set({
+          'Content-Type': serializer.contentType,
+          'Content-Disposition': `attachment; filename="Grottocenter_search_export_${Math.trunc(Date.now() / 1000)}.${serializer.fileExtension}"`,
+        });
+        res.write(serializer.prologue(timestamp));
+      }
+
+      const documents = results.hits.map((e) => e.document);
+      const filtered = filterDocuments(documents);
+
+      // When fieldMapping is set, resolve dot-notation keys and apply aliases
+      // so serializers receive pre-resolved documents with aliased field names.
+      let docsToSerialize = filtered;
+      if (fieldMapping) {
+        docsToSerialize = filtered.map((doc) => {
+          // Only include coordinates and id for geometry construction;
+          // aliased fields are the sole user-visible properties.
+          const mapped = {
+            id: doc.id,
+            latitude: doc.latitude,
+            longitude: doc.longitude,
+          };
+          fieldMapping.forEach(({ key, alias }) => {
+            mapped[alias] = resolveField(doc, key);
+          });
+          return mapped;
+        });
+      }
+      res.write(serializer.serializeBatch(docsToSerialize, isFirst, null));
+      isFirst = false;
+
+      if (documents.length < BATCH_SIZE) break;
+      page += 1;
+    }
+
+    if (!hasSentHeader) {
+      res.set({
+        'Content-Type': serializer.contentType,
+        'Content-Disposition': `attachment; filename="Grottocenter_search_export_${Math.trunc(Date.now() / 1000)}.${serializer.fileExtension}"`,
+      });
+      res.write(serializer.prologue(timestamp));
+    }
+    res.write(serializer.epilogue());
+    res.end();
     return;
   }
 
   const params = {
     query: req.param('query'),
-    entity: req.param('entity') ?? '',
+    entity,
     sort: req.param('sort'),
     filter: req.param('filter') ?? {},
     isLogicalCompareAnd: !!matchAllFields,
     fields: columns,
   };
-
-  const BATCH_SIZE = 1000;
-  const MAX_NB_ROW_EXPORT = 10000;
 
   let hasSentHeader = false;
   let page = 1;

--- a/api/services/geo-serializers/geojson.js
+++ b/api/services/geo-serializers/geojson.js
@@ -4,12 +4,26 @@
  * Converts entrance documents into a GeoJSON FeatureCollection with Point geometries.
  * Conforms to RFC 7946: coordinates are [longitude, latitude] order.
  *
- * All document fields are included in Feature properties, plus a `url` property
+ * All document fields are included in Feature properties, plus a `grottocenterUrl` property
  * linking back to the entrance page on Grottocenter.
+ *
+ * Documents are pre-mapped by the controller: when field selection is active,
+ * only aliased fields (plus id, latitude, longitude) are present. The serializer
+ * excludes geometry/id fields from properties to honour the field-selection contract.
+ *
+ * NOTE: The top-level `name`, `description`, and `timestamp` are non-standard
+ * FeatureCollection properties (RFC 7946 defines only `type`, `features`, `bbox`).
+ * They are informational extras that most GIS tools tolerate; strict parsers may
+ * ignore them.
  */
 
 const contentType = 'application/geo+json';
 const fileExtension = 'geojson';
+
+/**
+ * Fields used for geometry construction that should not appear in Feature properties.
+ */
+const GEOMETRY_FIELDS = ['id', 'latitude', 'longitude', 'altitude'];
 
 /**
  * Produces the opening structure of the GeoJSON FeatureCollection.
@@ -24,22 +38,16 @@ const prologue = (timestamp) =>
  * Serializes a single entrance document into a GeoJSON Feature object.
  *
  * @param {object} doc - Entrance document from Typesense
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
  * @returns {string} JSON string of a Feature object
  */
-const serializeFeature = (doc, fieldMapping) => {
-  let properties;
-  if (fieldMapping) {
-    properties = {};
-    fieldMapping.forEach(({ key, alias }) => {
-      if (key in doc) {
-        properties[alias] = doc[key];
-      }
-    });
-  } else {
-    properties = { ...doc };
-  }
-  properties.url = `https://grottocenter.org/ui/entrances/${doc.id}`;
+const serializeFeature = (doc) => {
+  const properties = {};
+  Object.keys(doc).forEach((key) => {
+    if (!GEOMETRY_FIELDS.includes(key)) {
+      properties[key] = doc[key];
+    }
+  });
+  properties.grottocenterUrl = `https://grottocenter.org/ui/entrances/${doc.id}`;
 
   const feature = {
     type: 'Feature',
@@ -57,14 +65,13 @@ const serializeFeature = (doc, fieldMapping) => {
  *
  * @param {Array} documents - Array of filtered entrance documents
  * @param {boolean} isFirst - Whether this is the first batch (no leading comma)
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
  * @returns {string} Comma-separated Feature JSON fragments
  */
-const serializeBatch = (documents, isFirst, fieldMapping = null) => {
+const serializeBatch = (documents, isFirst) => {
   if (documents.length === 0) {
     return '';
   }
-  const features = documents.map((doc) => serializeFeature(doc, fieldMapping));
+  const features = documents.map((doc) => serializeFeature(doc));
   const joined = features.join(',');
   return isFirst ? joined : `,${joined}`;
 };

--- a/api/services/geo-serializers/geojson.js
+++ b/api/services/geo-serializers/geojson.js
@@ -1,0 +1,85 @@
+/**
+ * GeoJSON Serializer
+ *
+ * Converts entrance documents into a GeoJSON FeatureCollection with Point geometries.
+ * Conforms to RFC 7946: coordinates are [longitude, latitude] order.
+ *
+ * All document fields are included in Feature properties, plus a `url` property
+ * linking back to the entrance page on Grottocenter.
+ */
+
+const contentType = 'application/geo+json';
+const fileExtension = 'geojson';
+
+/**
+ * Produces the opening structure of the GeoJSON FeatureCollection.
+ *
+ * @param {string} timestamp - ISO 8601 UTC timestamp of export generation
+ * @returns {string} Opening JSON fragment
+ */
+const prologue = (timestamp) =>
+  `{"type":"FeatureCollection","name":"Grottocenter","description":"Exported from https://grottocenter.org","timestamp":"${timestamp}","features":[`;
+
+/**
+ * Serializes a single entrance document into a GeoJSON Feature object.
+ *
+ * @param {object} doc - Entrance document from Typesense
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
+ * @returns {string} JSON string of a Feature object
+ */
+const serializeFeature = (doc, fieldMapping) => {
+  let properties;
+  if (fieldMapping) {
+    properties = {};
+    fieldMapping.forEach(({ key, alias }) => {
+      if (key in doc) {
+        properties[alias] = doc[key];
+      }
+    });
+  } else {
+    properties = { ...doc };
+  }
+  properties.url = `https://grottocenter.org/ui/entrances/${doc.id}`;
+
+  const feature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [doc.longitude, doc.latitude],
+    },
+    properties,
+  };
+  return JSON.stringify(feature);
+};
+
+/**
+ * Serializes a batch of entrance documents into GeoJSON Feature strings.
+ *
+ * @param {Array} documents - Array of filtered entrance documents
+ * @param {boolean} isFirst - Whether this is the first batch (no leading comma)
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
+ * @returns {string} Comma-separated Feature JSON fragments
+ */
+const serializeBatch = (documents, isFirst, fieldMapping = null) => {
+  if (documents.length === 0) {
+    return '';
+  }
+  const features = documents.map((doc) => serializeFeature(doc, fieldMapping));
+  const joined = features.join(',');
+  return isFirst ? joined : `,${joined}`;
+};
+
+/**
+ * Produces the closing structure of the GeoJSON FeatureCollection.
+ *
+ * @returns {string} Closing JSON fragment
+ */
+const epilogue = () => ']}';
+
+module.exports = {
+  contentType,
+  fileExtension,
+  prologue,
+  serializeBatch,
+  epilogue,
+};

--- a/api/services/geo-serializers/gpx.js
+++ b/api/services/geo-serializers/gpx.js
@@ -1,0 +1,140 @@
+/**
+ * GPX Serializer
+ *
+ * Converts entrance documents into a GPX document with waypoints.
+ * Produces GPX 1.1 output with the standard namespace and schema location.
+ *
+ * All text content is XML-escaped to prevent injection of invalid characters.
+ */
+
+const contentType = 'application/gpx+xml';
+const fileExtension = 'gpx';
+
+/**
+ * Escapes special XML characters in text content.
+ *
+ * @param {string} str - Raw string to escape
+ * @returns {string} XML-safe string
+ */
+const escapeXml = (str) => {
+  const s = String(str);
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
+
+/**
+ * Produces the GPX XML declaration, root element with namespace and schema
+ * location, and metadata block.
+ *
+ * @param {string} timestamp - ISO 8601 UTC timestamp of export generation
+ * @returns {string} Opening XML fragment
+ */
+const prologue = (timestamp) =>
+  '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  '<gpx xmlns="http://www.topografix.com/GPX/1/1"' +
+  ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+  ' xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"' +
+  ' version="1.1"' +
+  ' creator="Grottocenter">\n' +
+  '<metadata>\n' +
+  '<name>Grottocenter</name>\n' +
+  '<desc>Exported from https://grottocenter.org</desc>\n' +
+  `<time>${escapeXml(timestamp)}</time>\n` +
+  '</metadata>\n';
+
+/**
+ * Convert a value to a plain string for display in <desc>.
+ * Objects and arrays are JSON-serialized; primitives use String().
+ *
+ * @param {*} value - Any document field value
+ * @returns {string} Human-readable string representation
+ */
+const toDisplayValue = (value) => {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+/**
+ * Build a <desc> element containing document fields as plain text lines.
+ *
+ * @param {object} doc - Entrance document from Typesense
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
+ * @returns {string} XML <desc> element, or empty string if no fields to show
+ */
+const buildDesc = (doc, fieldMapping) => {
+  let lines;
+  if (fieldMapping) {
+    lines = fieldMapping
+      .filter(({ key }) => key in doc)
+      .map(({ key, alias }) => `${alias}: ${toDisplayValue(doc[key])}`);
+  } else {
+    lines = Object.keys(doc)
+      .filter(
+        (key) =>
+          !['latitude', 'longitude', 'altitude', 'name', 'id'].includes(key)
+      )
+      .map((key) => `${key}: ${toDisplayValue(doc[key])}`);
+  }
+  if (lines.length === 0) return '';
+  return `<desc>${escapeXml(lines.join('\n'))}</desc>\n`;
+};
+
+/**
+ * Serializes a single entrance document into a GPX waypoint element.
+ *
+ * @param {object} doc - Entrance document from Typesense
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
+ * @returns {string} XML string of a <wpt> element
+ */
+const serializeWaypoint = (doc, fieldMapping) => {
+  const name = doc.name != null ? doc.name : '';
+  const url = `https://grottocenter.org/ui/entrances/${doc.id}`;
+
+  let wpt = `<wpt lat="${escapeXml(String(doc.latitude))}" lon="${escapeXml(String(doc.longitude))}">\n`;
+
+  if (doc.altitude != null) {
+    wpt += `<ele>${escapeXml(String(doc.altitude))}</ele>\n`;
+  }
+
+  wpt += `<name>${escapeXml(String(name))}</name>\n`;
+  wpt += buildDesc(doc, fieldMapping);
+  wpt += `<link href="${escapeXml(url)}"><text>View on Grottocenter</text></link>\n`;
+  wpt += '</wpt>\n';
+
+  return wpt;
+};
+
+/**
+ * Serializes a batch of entrance documents into GPX waypoint elements.
+ *
+ * @param {Array} documents - Array of filtered entrance documents
+ * @param {boolean} _isFirst - Unused for GPX (XML elements concatenated)
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming in <desc>
+ * @returns {string} Concatenated <wpt> XML elements
+ */
+const serializeBatch = (documents, _isFirst, fieldMapping = null) => {
+  if (documents.length === 0) {
+    return '';
+  }
+  return documents.map((doc) => serializeWaypoint(doc, fieldMapping)).join('');
+};
+
+/**
+ * Produces the closing GPX root element.
+ *
+ * @returns {string} Closing XML fragment
+ */
+const epilogue = () => '</gpx>';
+
+module.exports = {
+  contentType,
+  fileExtension,
+  prologue,
+  serializeBatch,
+  epilogue,
+};

--- a/api/services/geo-serializers/gpx.js
+++ b/api/services/geo-serializers/gpx.js
@@ -5,26 +5,21 @@
  * Produces GPX 1.1 output with the standard namespace and schema location.
  *
  * All text content is XML-escaped to prevent injection of invalid characters.
+ *
+ * Documents are pre-mapped by the controller: when field selection is active,
+ * only aliased fields (plus id, latitude, longitude) are present. The serializer
+ * excludes geometry/id fields from <desc> to honour the field-selection contract.
  */
+
+const { escapeXml, toStringValue } = require('./xml-utils');
 
 const contentType = 'application/gpx+xml';
 const fileExtension = 'gpx';
 
 /**
- * Escapes special XML characters in text content.
- *
- * @param {string} str - Raw string to escape
- * @returns {string} XML-safe string
+ * Fields used for geometry/waypoint construction that should not appear in <desc>.
  */
-const escapeXml = (str) => {
-  const s = String(str);
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-};
+const GEOMETRY_FIELDS = ['latitude', 'longitude', 'altitude', 'name', 'id'];
 
 /**
  * Produces the GPX XML declaration, root element with namespace and schema
@@ -47,39 +42,15 @@ const prologue = (timestamp) =>
   '</metadata>\n';
 
 /**
- * Convert a value to a plain string for display in <desc>.
- * Objects and arrays are JSON-serialized; primitives use String().
- *
- * @param {*} value - Any document field value
- * @returns {string} Human-readable string representation
- */
-const toDisplayValue = (value) => {
-  if (value == null) return '';
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-};
-
-/**
  * Build a <desc> element containing document fields as plain text lines.
  *
  * @param {object} doc - Entrance document from Typesense
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
  * @returns {string} XML <desc> element, or empty string if no fields to show
  */
-const buildDesc = (doc, fieldMapping) => {
-  let lines;
-  if (fieldMapping) {
-    lines = fieldMapping
-      .filter(({ key }) => key in doc)
-      .map(({ key, alias }) => `${alias}: ${toDisplayValue(doc[key])}`);
-  } else {
-    lines = Object.keys(doc)
-      .filter(
-        (key) =>
-          !['latitude', 'longitude', 'altitude', 'name', 'id'].includes(key)
-      )
-      .map((key) => `${key}: ${toDisplayValue(doc[key])}`);
-  }
+const buildDesc = (doc) => {
+  const lines = Object.keys(doc)
+    .filter((key) => !GEOMETRY_FIELDS.includes(key))
+    .map((key) => `${key}: ${toStringValue(doc[key])}`);
   if (lines.length === 0) return '';
   return `<desc>${escapeXml(lines.join('\n'))}</desc>\n`;
 };
@@ -88,10 +59,9 @@ const buildDesc = (doc, fieldMapping) => {
  * Serializes a single entrance document into a GPX waypoint element.
  *
  * @param {object} doc - Entrance document from Typesense
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
  * @returns {string} XML string of a <wpt> element
  */
-const serializeWaypoint = (doc, fieldMapping) => {
+const serializeWaypoint = (doc) => {
   const name = doc.name != null ? doc.name : '';
   const url = `https://grottocenter.org/ui/entrances/${doc.id}`;
 
@@ -102,7 +72,7 @@ const serializeWaypoint = (doc, fieldMapping) => {
   }
 
   wpt += `<name>${escapeXml(String(name))}</name>\n`;
-  wpt += buildDesc(doc, fieldMapping);
+  wpt += buildDesc(doc);
   wpt += `<link href="${escapeXml(url)}"><text>View on Grottocenter</text></link>\n`;
   wpt += '</wpt>\n';
 
@@ -114,14 +84,13 @@ const serializeWaypoint = (doc, fieldMapping) => {
  *
  * @param {Array} documents - Array of filtered entrance documents
  * @param {boolean} _isFirst - Unused for GPX (XML elements concatenated)
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming in <desc>
  * @returns {string} Concatenated <wpt> XML elements
  */
-const serializeBatch = (documents, _isFirst, fieldMapping = null) => {
+const serializeBatch = (documents, _isFirst) => {
   if (documents.length === 0) {
     return '';
   }
-  return documents.map((doc) => serializeWaypoint(doc, fieldMapping)).join('');
+  return documents.map((doc) => serializeWaypoint(doc)).join('');
 };
 
 /**

--- a/api/services/geo-serializers/index.js
+++ b/api/services/geo-serializers/index.js
@@ -1,0 +1,39 @@
+/**
+ * Geo Serializer Registry
+ *
+ * Maps format strings to their respective serializer modules and provides
+ * a shared filterDocuments utility for removing sensitive or coordinate-less
+ * entries before serialization.
+ */
+
+const geojson = require('./geojson');
+const kml = require('./kml');
+const gpx = require('./gpx');
+
+const serializers = {
+  geojson,
+  kml,
+  gpx,
+};
+
+/**
+ * Remove entries that are sensitive or lack valid coordinates.
+ *
+ * Filters out documents where:
+ * - isSensitive === true
+ * - latitude is null or undefined
+ * - longitude is null or undefined
+ *
+ * @param {Array} documents - Array of entrance documents from Typesense
+ * @returns {Array} Filtered array of documents safe for geo export
+ */
+const filterDocuments = (documents) =>
+  documents.filter(
+    (doc) =>
+      doc.isSensitive !== true && doc.latitude != null && doc.longitude != null
+  );
+
+module.exports = {
+  serializers,
+  filterDocuments,
+};

--- a/api/services/geo-serializers/kml.js
+++ b/api/services/geo-serializers/kml.js
@@ -6,39 +6,23 @@
  *
  * Each entrance becomes a <Placemark> with:
  * - <name> from the document's name field
- * - <Point><coordinates>lon,lat,alt</coordinates></Point>
- * - <ExtendedData> with <Data> elements for all document fields plus url
+ * - <Point><coordinates>lon,lat[,alt]</coordinates></Point>
+ * - <ExtendedData> with <Data> elements for all document fields plus grottocenterUrl
+ *
+ * Documents are pre-mapped by the controller: when field selection is active,
+ * only aliased fields (plus id, latitude, longitude) are present. The serializer
+ * excludes geometry/id fields from <ExtendedData> to honour the field-selection contract.
  */
+
+const { escapeXml } = require('./xml-utils');
 
 const contentType = 'application/vnd.google-earth.kml+xml';
 const fileExtension = 'kml';
 
 /**
- * Convert a value to a plain string suitable for XML text content.
- * Objects and arrays are JSON-serialized; primitives are coerced with String().
- *
- * @param {*} value - Any value from a document field
- * @returns {string} String representation
+ * Fields used for geometry construction that should not appear in <ExtendedData>.
  */
-const toStringValue = (value) => {
-  if (value == null) return '';
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-};
-
-/**
- * Escape special XML characters in text content.
- *
- * @param {*} value - Value to escape (coerced to string via toStringValue)
- * @returns {string} XML-safe string
- */
-const escapeXml = (value) =>
-  toStringValue(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+const GEOMETRY_FIELDS = ['id', 'latitude', 'longitude', 'altitude', 'name'];
 
 /**
  * Produce the KML document opening: XML declaration, <kml> root with
@@ -60,43 +44,37 @@ const prologue = (timestamp) =>
  *
  * @param {Array} documents - Filtered entrance documents (no sensitive, no null coords)
  * @param {boolean} _isFirst - Unused for KML (XML elements concatenate without separators)
- * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
  * @returns {string} KML Placemark elements
  */
-const serializeBatch = (documents, _isFirst, fieldMapping = null) =>
+const serializeBatch = (documents, _isFirst) =>
   documents
     .map((doc) => {
       const name = doc.name != null ? doc.name : '';
       const lon = doc.longitude;
       const lat = doc.latitude;
-      const alt = doc.altitude != null ? doc.altitude : 0;
       const url = `https://grottocenter.org/ui/entrances/${doc.id}`;
 
-      let dataEntries;
-      if (fieldMapping) {
-        dataEntries = fieldMapping
-          .map(({ key, alias }) =>
-            key in doc
-              ? `<Data name="${escapeXml(alias)}"><value>${escapeXml(doc[key])}</value></Data>`
-              : ''
-          )
-          .join('');
-      } else {
-        dataEntries = Object.keys(doc)
-          .map(
-            (key) =>
-              `<Data name="${escapeXml(key)}"><value>${escapeXml(
-                doc[key]
-              )}</value></Data>`
-          )
-          .join('');
-      }
+      // Omit altitude when unknown rather than defaulting to 0 (sea level)
+      const coords =
+        doc.altitude != null
+          ? `${escapeXml(String(lon))},${escapeXml(String(lat))},${escapeXml(String(doc.altitude))}`
+          : `${escapeXml(String(lon))},${escapeXml(String(lat))}`;
 
-      const urlData = `<Data name="url"><value>${escapeXml(url)}</value></Data>`;
+      const dataEntries = Object.keys(doc)
+        .filter((key) => !GEOMETRY_FIELDS.includes(key))
+        .map(
+          (key) =>
+            `<Data name="${escapeXml(key)}"><value>${escapeXml(
+              doc[key]
+            )}</value></Data>`
+        )
+        .join('');
+
+      const urlData = `<Data name="grottocenterUrl"><value>${escapeXml(url)}</value></Data>`;
 
       return `<Placemark>
 <name>${escapeXml(name)}</name>
-<Point><coordinates>${lon},${lat},${alt}</coordinates></Point>
+<Point><coordinates>${coords}</coordinates></Point>
 <ExtendedData>${dataEntries}${urlData}</ExtendedData>
 </Placemark>`;
     })

--- a/api/services/geo-serializers/kml.js
+++ b/api/services/geo-serializers/kml.js
@@ -1,0 +1,118 @@
+/**
+ * KML Serializer
+ *
+ * Converts entrance documents into a KML document with Point Placemarks.
+ * Produces valid KML 2.2 with namespace http://www.opengis.net/kml/2.2.
+ *
+ * Each entrance becomes a <Placemark> with:
+ * - <name> from the document's name field
+ * - <Point><coordinates>lon,lat,alt</coordinates></Point>
+ * - <ExtendedData> with <Data> elements for all document fields plus url
+ */
+
+const contentType = 'application/vnd.google-earth.kml+xml';
+const fileExtension = 'kml';
+
+/**
+ * Convert a value to a plain string suitable for XML text content.
+ * Objects and arrays are JSON-serialized; primitives are coerced with String().
+ *
+ * @param {*} value - Any value from a document field
+ * @returns {string} String representation
+ */
+const toStringValue = (value) => {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+/**
+ * Escape special XML characters in text content.
+ *
+ * @param {*} value - Value to escape (coerced to string via toStringValue)
+ * @returns {string} XML-safe string
+ */
+const escapeXml = (value) =>
+  toStringValue(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+/**
+ * Produce the KML document opening: XML declaration, <kml> root with
+ * namespace, <Document> with metadata (name, description, timestamp).
+ *
+ * @param {string} timestamp - ISO 8601 UTC timestamp of the export
+ * @returns {string} KML prologue string
+ */
+const prologue = (timestamp) =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document>
+<name>Grottocenter</name>
+<description>Exported from https://grottocenter.org</description>
+<TimeStamp><when>${escapeXml(timestamp)}</when></TimeStamp>`;
+
+/**
+ * Serialize a batch of entrance documents into KML Placemark elements.
+ *
+ * @param {Array} documents - Filtered entrance documents (no sensitive, no null coords)
+ * @param {boolean} _isFirst - Unused for KML (XML elements concatenate without separators)
+ * @param {Array|null} fieldMapping - Optional array of {key, alias} for field selection/renaming
+ * @returns {string} KML Placemark elements
+ */
+const serializeBatch = (documents, _isFirst, fieldMapping = null) =>
+  documents
+    .map((doc) => {
+      const name = doc.name != null ? doc.name : '';
+      const lon = doc.longitude;
+      const lat = doc.latitude;
+      const alt = doc.altitude != null ? doc.altitude : 0;
+      const url = `https://grottocenter.org/ui/entrances/${doc.id}`;
+
+      let dataEntries;
+      if (fieldMapping) {
+        dataEntries = fieldMapping
+          .map(({ key, alias }) =>
+            key in doc
+              ? `<Data name="${escapeXml(alias)}"><value>${escapeXml(doc[key])}</value></Data>`
+              : ''
+          )
+          .join('');
+      } else {
+        dataEntries = Object.keys(doc)
+          .map(
+            (key) =>
+              `<Data name="${escapeXml(key)}"><value>${escapeXml(
+                doc[key]
+              )}</value></Data>`
+          )
+          .join('');
+      }
+
+      const urlData = `<Data name="url"><value>${escapeXml(url)}</value></Data>`;
+
+      return `<Placemark>
+<name>${escapeXml(name)}</name>
+<Point><coordinates>${lon},${lat},${alt}</coordinates></Point>
+<ExtendedData>${dataEntries}${urlData}</ExtendedData>
+</Placemark>`;
+    })
+    .join('');
+
+/**
+ * Close the KML document structure.
+ *
+ * @returns {string} KML epilogue string
+ */
+const epilogue = () => '</Document></kml>';
+
+module.exports = {
+  contentType,
+  fileExtension,
+  prologue,
+  serializeBatch,
+  epilogue,
+};

--- a/api/services/geo-serializers/xml-utils.js
+++ b/api/services/geo-serializers/xml-utils.js
@@ -1,0 +1,40 @@
+/**
+ * Shared XML utilities for geo-serializers (KML, GPX).
+ *
+ * Provides consistent null-handling and XML character escaping across
+ * all XML-based export formats.
+ */
+
+/**
+ * Convert a value to a plain string suitable for XML text content.
+ * - null/undefined → empty string
+ * - objects/arrays → JSON-serialized
+ * - primitives → String()
+ *
+ * @param {*} value - Any value from a document field
+ * @returns {string} String representation (never "null" or "undefined")
+ */
+const toStringValue = (value) => {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+/**
+ * Escape special XML characters in text content.
+ *
+ * @param {*} value - Value to escape (coerced to string via toStringValue)
+ * @returns {string} XML-safe string
+ */
+const escapeXml = (value) =>
+  toStringValue(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+module.exports = {
+  toStringValue,
+  escapeXml,
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4371,7 +4371,20 @@ paths:
     post:
       tags:
         - search
-      description: Export all search result into a CSV, max number of row 10 000
+      description: |
+        Export search results in CSV, GeoJSON, KML, or GPX format. Maximum 10,000 rows.
+        Geographic formats (geojson, kml, gpx) are restricted to entrance searches only.
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [csv, geojson, kml, gpx]
+            default: csv
+          description: |
+            Output format for the export. Default is "csv".
+            Geographic formats (geojson, kml, gpx) are only available for entrance searches.
+            When using a geo format, columns and columnsName become optional — if provided, they filter and alias the exported fields; if absent, all fields are included.
       requestBody:
         content:
           application/json:
@@ -4404,19 +4417,48 @@ paths:
                   default: true
                 columns:
                   type: array
-                  description: What fields to export
+                  description: |
+                    Fields to export. Required for CSV format.
+                    For geo formats: optional — when provided, restricts which fields appear in properties/ExtendedData; when absent, all fields are included.
                   items:
                     type: string
                 columnsName:
                   type: array
-                  description: What is the name of the fields to export
+                  description: |
+                    Display names for the exported fields. Required for CSV format (must match columns length).
+                    For geo formats: optional — when provided alongside columns, aliases the field names in the output.
                   items:
                     type: string
       responses:
         '200':
           description: Successful operation
           content:
-            text/csv: {}
+            text/csv:
+              schema:
+                type: string
+                format: binary
+              description: CSV output (default format)
+            application/geo+json:
+              schema:
+                type: object
+              description: GeoJSON FeatureCollection output
+            application/vnd.google-earth.kml+xml:
+              schema:
+                type: string
+                format: binary
+              description: KML Document output
+            application/gpx+xml:
+              schema:
+                type: string
+                format: binary
+              description: GPX waypoints output
+        '400':
+          description: |
+            Bad request. Possible causes:
+            - Invalid format value (must be one of: csv, geojson, kml, gpx)
+            - Geographic format requested for non-entrance entity
+            - Missing or invalid columns/columnsName (CSV format only)
+            - Search results exceed 10,000 row limit
 
   '/field-search':
     post:

--- a/test/integration/1_services/geo-serializers/filterDocuments.test.js
+++ b/test/integration/1_services/geo-serializers/filterDocuments.test.js
@@ -1,0 +1,136 @@
+const should = require('should');
+const {
+  serializers,
+  filterDocuments,
+} = require('../../../../api/services/geo-serializers');
+
+describe('geo-serializers/index', () => {
+  describe('serializers registry', () => {
+    it('should map geojson, kml, and gpx to serializer modules', () => {
+      should(serializers).have.property('geojson');
+      should(serializers).have.property('kml');
+      should(serializers).have.property('gpx');
+    });
+
+    it('should expose contentType and fileExtension on each serializer', () => {
+      should(serializers.geojson.contentType).equal('application/geo+json');
+      should(serializers.geojson.fileExtension).equal('geojson');
+      should(serializers.kml.contentType).equal(
+        'application/vnd.google-earth.kml+xml'
+      );
+      should(serializers.kml.fileExtension).equal('kml');
+      should(serializers.gpx.contentType).equal('application/gpx+xml');
+      should(serializers.gpx.fileExtension).equal('gpx');
+    });
+
+    it('should not have unexpected format keys', () => {
+      should(Object.keys(serializers)).deepEqual(['geojson', 'kml', 'gpx']);
+    });
+  });
+
+  describe('filterDocuments', () => {
+    it('should keep documents with valid coordinates and isSensitive false', () => {
+      const docs = [
+        { id: '1', latitude: 45.0, longitude: 2.0, isSensitive: false },
+        { id: '2', latitude: -12.5, longitude: 130.7, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(2);
+      should(result[0].id).equal('1');
+      should(result[1].id).equal('2');
+    });
+
+    it('should remove documents with isSensitive === true', () => {
+      const docs = [
+        { id: '1', latitude: 45.0, longitude: 2.0, isSensitive: true },
+        { id: '2', latitude: 10.0, longitude: 20.0, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(1);
+      should(result[0].id).equal('2');
+    });
+
+    it('should remove documents with null latitude', () => {
+      const docs = [
+        { id: '1', latitude: null, longitude: 2.0, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should remove documents with undefined latitude', () => {
+      const docs = [{ id: '1', longitude: 2.0, isSensitive: false }];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should remove documents with null longitude', () => {
+      const docs = [
+        { id: '1', latitude: 45.0, longitude: null, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should remove documents with undefined longitude', () => {
+      const docs = [{ id: '1', latitude: 45.0, isSensitive: false }];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should remove sensitive documents with null coordinates without error (Req 10.5)', () => {
+      const docs = [
+        { id: '1', latitude: null, longitude: null, isSensitive: true },
+        { id: '2', latitude: null, longitude: 2.0, isSensitive: true },
+        { id: '3', latitude: 45.0, longitude: null, isSensitive: true },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should return an empty array when all entries are filtered (Req 10.4)', () => {
+      const docs = [
+        { id: '1', latitude: 45.0, longitude: 2.0, isSensitive: true },
+        { id: '2', latitude: null, longitude: null, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(0);
+    });
+
+    it('should return an empty array for empty input', () => {
+      const result = filterDocuments([]);
+      should(result).have.length(0);
+      should(result).be.an.Array();
+    });
+
+    it('should keep documents where isSensitive is not set (defaults to not sensitive)', () => {
+      const docs = [{ id: '1', latitude: 45.0, longitude: 2.0 }];
+      const result = filterDocuments(docs);
+      should(result).have.length(1);
+    });
+
+    it('should keep documents where isSensitive is explicitly false', () => {
+      const docs = [
+        { id: '1', latitude: 45.0, longitude: 2.0, isSensitive: false },
+      ];
+      const result = filterDocuments(docs);
+      should(result).have.length(1);
+    });
+
+    it('should preserve all document fields in the output', () => {
+      const docs = [
+        {
+          id: '1',
+          name: 'Test Cave',
+          latitude: 45.0,
+          longitude: 2.0,
+          altitude: 500,
+          isSensitive: false,
+          country: 'FR',
+        },
+      ];
+      const result = filterDocuments(docs);
+      should(result[0]).deepEqual(docs[0]);
+    });
+  });
+});

--- a/test/integration/1_services/geo-serializers/geojson.property.test.js
+++ b/test/integration/1_services/geo-serializers/geojson.property.test.js
@@ -1,0 +1,268 @@
+const should = require('should');
+const fc = require('fast-check');
+const geojson = require('../../../../api/services/geo-serializers/geojson');
+const { filterDocuments } = require('../../../../api/services/geo-serializers');
+
+/**
+ * Arbitrary: generates a realistic entrance document with randomized fields.
+ * latitude/longitude are sometimes null to exercise exclusion logic.
+ * isSensitive is biased toward false for variety.
+ */
+const entranceDocumentArbitrary = fc.record({
+  id: fc.stringMatching(/^[0-9]{1,6}$/),
+  name: fc.string({ minLength: 0, maxLength: 100 }),
+  latitude: fc.option(
+    fc.double({ min: -90, max: 90, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  longitude: fc.option(
+    fc.double({ min: -180, max: 180, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  altitude: fc.option(
+    fc.double({ min: -500, max: 9000, noNaN: true, noDefaultInfinity: true }),
+    { nil: null }
+  ),
+  isSensitive: fc.oneof(
+    { weight: 8, arbitrary: fc.constant(false) },
+    { weight: 2, arbitrary: fc.constant(true) }
+  ),
+  country: fc.option(fc.stringMatching(/^[A-Z]{2}$/), { nil: undefined }),
+  region: fc.option(fc.string({ minLength: 1, maxLength: 50 }), {
+    nil: undefined,
+  }),
+});
+
+const entranceDocumentArrayArbitrary = fc.array(entranceDocumentArbitrary, {
+  minLength: 0,
+  maxLength: 30,
+});
+
+/**
+ * Helper: assemble a full GeoJSON output from an array of entrance docs.
+ */
+const buildGeoJSON = (docs) => {
+  const timestamp = new Date().toISOString();
+  const filtered = filterDocuments(docs);
+  const output =
+    geojson.prologue(timestamp) +
+    geojson.serializeBatch(filtered, true) +
+    geojson.epilogue();
+  return output;
+};
+
+/**
+ * Property 3: GeoJSON structural validity
+ *
+ * For any array of entrance documents, output parses as valid JSON with
+ * type="FeatureCollection" and features array where every element has
+ * type="Feature", geometry.type="Point", and properties object.
+ *
+ * Validates: Requirements 3.1
+ */
+describe('Feature: geo-export-search-results, Property 3: GeoJSON structural validity', () => {
+  it('should produce valid FeatureCollection with correct structure for any input', function validStructure() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildGeoJSON(docs);
+        const parsed = JSON.parse(output);
+
+        should(parsed.type).equal('FeatureCollection');
+        should(parsed.features).be.an.Array();
+
+        parsed.features.forEach((feature) => {
+          should(feature.type).equal('Feature');
+          should(feature.geometry).be.an.Object();
+          should(feature.geometry.type).equal('Point');
+          should(feature.properties).be.an.Object();
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 4: GeoJSON coordinate order
+ *
+ * For any doc with non-null lat/lon, coordinates are [longitude, latitude].
+ *
+ * Validates: Requirements 3.2
+ */
+describe('Feature: geo-export-search-results, Property 4: GeoJSON coordinate order', () => {
+  it('should place longitude first, latitude second in coordinates', function coordinateOrder() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          geojson.prologue(timestamp) +
+          geojson.serializeBatch(filtered, true) +
+          geojson.epilogue();
+        const parsed = JSON.parse(output);
+
+        filtered.forEach((doc, i) => {
+          const coords = parsed.features[i].geometry.coordinates;
+          should(coords[0]).equal(doc.longitude);
+          should(coords[1]).equal(doc.latitude);
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 5: GeoJSON exclusion of invalid entries
+ *
+ * Docs with isSensitive===true or null lat/lon produce no Feature.
+ *
+ * Validates: Requirements 3.3, 10.1
+ */
+describe('Feature: geo-export-search-results, Property 5: GeoJSON exclusion of invalid entries', () => {
+  it('should exclude sensitive or coordinate-less docs from features', function exclusion() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        const timestamp = new Date().toISOString();
+        const output =
+          geojson.prologue(timestamp) +
+          geojson.serializeBatch(filtered, true) +
+          geojson.epilogue();
+        const parsed = JSON.parse(output);
+
+        // The number of features should equal filtered count
+        should(parsed.features.length).equal(filtered.length);
+
+        // No feature should correspond to a sensitive or null-coord doc
+        const validIds = new Set(filtered.map((d) => d.id));
+        docs.forEach((doc) => {
+          if (
+            doc.isSensitive === true ||
+            doc.latitude == null ||
+            doc.longitude == null
+          ) {
+            // This doc should NOT appear in features
+            const found = parsed.features.some(
+              (f) =>
+                f.properties.id === doc.id &&
+                f.properties.latitude === doc.latitude &&
+                f.properties.longitude === doc.longitude
+            );
+            // Only assert if id is not duplicated in valid set
+            if (!validIds.has(doc.id)) {
+              should(found).equal(false);
+            }
+          }
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 6: GeoJSON Feature properties completeness
+ *
+ * Each Feature's properties contains all original doc fields plus url.
+ *
+ * Validates: Requirements 3.4, 11.4
+ */
+describe('Feature: geo-export-search-results, Property 6: GeoJSON Feature properties completeness', () => {
+  it('should include all doc fields plus url in each Feature properties', function completeness() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          geojson.prologue(timestamp) +
+          geojson.serializeBatch(filtered, true) +
+          geojson.epilogue();
+        const parsed = JSON.parse(output);
+
+        filtered.forEach((doc, i) => {
+          const props = parsed.features[i].properties;
+
+          // All original doc fields with defined values are present
+          // (JSON.stringify drops undefined values, which is correct)
+          Object.keys(doc).forEach((key) => {
+            if (doc[key] !== undefined) {
+              should(props).have.property(key);
+              should(props[key]).deepEqual(doc[key]);
+            }
+          });
+
+          // url property present and correct
+          should(props.url).equal(
+            `https://grottocenter.org/ui/entrances/${doc.id}`
+          );
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 7: GeoJSON JSON round-trip stability
+ *
+ * Parse + re-stringify equals first parse.
+ *
+ * Validates: Requirements 3.7
+ */
+describe('Feature: geo-export-search-results, Property 7: GeoJSON JSON round-trip stability', () => {
+  it('should produce output that survives JSON parse/stringify round-trip', function roundTrip() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildGeoJSON(docs);
+        const firstParse = JSON.parse(output);
+        const reserialized = JSON.stringify(firstParse);
+        const secondParse = JSON.parse(reserialized);
+
+        should(secondParse).deepEqual(firstParse);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 8: GeoJSON metadata invariant
+ *
+ * name="Grottocenter", description="Exported from https://grottocenter.org",
+ * timestamp is valid ISO 8601.
+ *
+ * Validates: Requirements 11.1, 11.7
+ */
+describe('Feature: geo-export-search-results, Property 8: GeoJSON metadata invariant', () => {
+  it('should always include correct name, description, and valid ISO timestamp', function metadata() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildGeoJSON(docs);
+        const parsed = JSON.parse(output);
+
+        should(parsed.name).equal('Grottocenter');
+        should(parsed.description).equal(
+          'Exported from https://grottocenter.org'
+        );
+        should(parsed.timestamp).be.a.String();
+
+        // Validate ISO 8601 timestamp
+        const date = new Date(parsed.timestamp);
+        should(Number.isNaN(date.getTime())).equal(false);
+        should(parsed.timestamp).match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/geo-serializers/geojson.property.test.js
+++ b/test/integration/1_services/geo-serializers/geojson.property.test.js
@@ -169,18 +169,21 @@ describe('Feature: geo-export-search-results, Property 5: GeoJSON exclusion of i
 /**
  * Property 6: GeoJSON Feature properties completeness
  *
- * Each Feature's properties contains all original doc fields plus url.
+ * Each Feature's properties contains all original doc fields (excluding
+ * geometry fields: id, latitude, longitude) plus a grottocenterUrl property.
+ * Geometry fields are represented in the Feature geometry, not in properties.
  *
  * Validates: Requirements 3.4, 11.4
  */
 describe('Feature: geo-export-search-results, Property 6: GeoJSON Feature properties completeness', () => {
-  it('should include all doc fields plus url in each Feature properties', function completeness() {
+  it('should include non-geometry doc fields plus grottocenterUrl in each Feature properties', function completeness() {
     this.timeout(30000);
     fc.assert(
       fc.property(entranceDocumentArrayArbitrary, (docs) => {
         const filtered = filterDocuments(docs);
         if (filtered.length === 0) return;
 
+        const geometryFields = ['id', 'latitude', 'longitude', 'altitude'];
         const timestamp = new Date().toISOString();
         const output =
           geojson.prologue(timestamp) +
@@ -191,17 +194,21 @@ describe('Feature: geo-export-search-results, Property 6: GeoJSON Feature proper
         filtered.forEach((doc, i) => {
           const props = parsed.features[i].properties;
 
-          // All original doc fields with defined values are present
-          // (JSON.stringify drops undefined values, which is correct)
+          // All non-geometry doc fields with defined values are present
           Object.keys(doc).forEach((key) => {
-            if (doc[key] !== undefined) {
+            if (doc[key] !== undefined && !geometryFields.includes(key)) {
               should(props).have.property(key);
               should(props[key]).deepEqual(doc[key]);
             }
           });
 
-          // url property present and correct
-          should(props.url).equal(
+          // Geometry fields should NOT appear in properties
+          geometryFields.forEach((key) => {
+            should(props).not.have.property(key);
+          });
+
+          // grottocenterUrl property present and correct
+          should(props.grottocenterUrl).equal(
             `https://grottocenter.org/ui/entrances/${doc.id}`
           );
         });

--- a/test/integration/1_services/geo-serializers/gpx.property.test.js
+++ b/test/integration/1_services/geo-serializers/gpx.property.test.js
@@ -1,0 +1,277 @@
+const should = require('should');
+const fc = require('fast-check');
+const gpx = require('../../../../api/services/geo-serializers/gpx');
+const { filterDocuments } = require('../../../../api/services/geo-serializers');
+
+/**
+ * Arbitrary: generates a realistic entrance document with randomized fields.
+ * Uses only XML-safe characters in name to avoid escaped-string matching issues.
+ */
+const entranceDocumentArbitrary = fc.record({
+  id: fc.stringMatching(/^[0-9]{1,6}$/),
+  name: fc.stringMatching(/^[a-zA-Z0-9 ]{0,50}$/),
+  latitude: fc.option(
+    fc.double({ min: -90, max: 90, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  longitude: fc.option(
+    fc.double({ min: -180, max: 180, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  altitude: fc.option(
+    fc.double({ min: -500, max: 9000, noNaN: true, noDefaultInfinity: true }),
+    { nil: null }
+  ),
+  isSensitive: fc.oneof(
+    { weight: 8, arbitrary: fc.constant(false) },
+    { weight: 2, arbitrary: fc.constant(true) }
+  ),
+  country: fc.option(fc.stringMatching(/^[A-Z]{2}$/), { nil: undefined }),
+});
+
+const entranceDocumentArrayArbitrary = fc.array(entranceDocumentArbitrary, {
+  minLength: 0,
+  maxLength: 30,
+});
+
+/**
+ * Helper: assemble full GPX output from an array of entrance docs.
+ */
+const buildGPX = (docs) => {
+  const timestamp = new Date().toISOString();
+  const filtered = filterDocuments(docs);
+  const output =
+    gpx.prologue(timestamp) +
+    gpx.serializeBatch(filtered, true) +
+    gpx.epilogue();
+  return output;
+};
+
+/**
+ * Property 14: GPX structural validity
+ *
+ * Root is <gpx> with correct namespace, version="1.1", creator="Grottocenter",
+ * has <metadata>.
+ *
+ * Validates: Requirements 5.1
+ */
+describe('Feature: geo-export-search-results, Property 14: GPX structural validity', () => {
+  it('should produce valid GPX with correct root element, namespace, version, creator, and metadata', function validStructure() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildGPX(docs);
+
+        // XML declaration
+        should(output).startWith('<?xml version="1.0" encoding="UTF-8"?>');
+
+        // Root <gpx> with correct namespace
+        should(output).match(
+          /<gpx xmlns="http:\/\/www\.topografix\.com\/GPX\/1\/1"/
+        );
+
+        // version attribute
+        should(output).match(/version="1\.1"/);
+
+        // creator attribute
+        should(output).match(/creator="Grottocenter"/);
+
+        // Schema location
+        should(output).match(
+          /xsi:schemaLocation="http:\/\/www\.topografix\.com\/GPX\/1\/1 http:\/\/www\.topografix\.com\/GPX\/1\/1\/gpx\.xsd"/
+        );
+
+        // <metadata> element present
+        should(output).match(/<metadata>/);
+        should(output).match(/<\/metadata>/);
+
+        // Closing </gpx>
+        should(output).endWith('</gpx>');
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 15: GPX waypoint coordinates
+ *
+ * <wpt> has lat/lon attributes as decimal degrees.
+ *
+ * Validates: Requirements 5.2
+ */
+describe('Feature: geo-export-search-results, Property 15: GPX waypoint coordinates', () => {
+  it('should set lat and lon attributes on wpt elements as decimal degrees', function waypointCoordinates() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          gpx.prologue(timestamp) +
+          gpx.serializeBatch(filtered, true) +
+          gpx.epilogue();
+
+        // Extract all <wpt> elements with lat/lon
+        const wptMatches =
+          output.match(/<wpt lat="([^"]+)" lon="([^"]+)">/g) || [];
+        should(wptMatches.length).equal(filtered.length);
+
+        filtered.forEach((doc, i) => {
+          const match = wptMatches[i].match(
+            /<wpt lat="([^"]+)" lon="([^"]+)">/
+          );
+          should(match).not.be.null();
+
+          const lat = parseFloat(match[1]);
+          const lon = parseFloat(match[2]);
+
+          should(lat).equal(doc.latitude);
+          should(lon).equal(doc.longitude);
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 16: GPX exclusion of invalid entries
+ *
+ * Sensitive or null-coord docs produce no <wpt>.
+ *
+ * Validates: Requirements 5.3, 10.3
+ */
+describe('Feature: geo-export-search-results, Property 16: GPX exclusion of invalid entries', () => {
+  it('should produce no wpt for sensitive or coordinate-less docs', function exclusion() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        const output = buildGPX(docs);
+
+        // The number of wpt elements must equal filtered doc count
+        const wptCount = (output.match(/<wpt /g) || []).length;
+        should(wptCount).equal(filtered.length);
+
+        // Additionally, verify excluded docs with valid coords don't have
+        // their exact lat/lon in any wpt attribute
+        const wptMatches =
+          output.match(/<wpt lat="([^"]+)" lon="([^"]+)">/g) || [];
+        docs.forEach((doc) => {
+          if (
+            doc.isSensitive === true ||
+            doc.latitude == null ||
+            doc.longitude == null
+          ) {
+            if (doc.latitude != null && doc.longitude != null) {
+              const excludedWpt = `<wpt lat="${doc.latitude}" lon="${doc.longitude}">`;
+              // Only assert if no valid doc shares these exact coords
+              const validDocHasSameCoords = filtered.some(
+                (d) =>
+                  d.latitude === doc.latitude && d.longitude === doc.longitude
+              );
+              if (!validDocHasSameCoords) {
+                should(wptMatches.some((m) => m === excludedWpt)).equal(false);
+              }
+            }
+          }
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 17: GPX waypoint content completeness
+ *
+ * Each wpt has <name>, <ele> if altitude non-null, <link> with url.
+ *
+ * Validates: Requirements 5.4, 5.5, 5.6, 11.6
+ */
+describe('Feature: geo-export-search-results, Property 17: GPX waypoint content completeness', () => {
+  it('should include name, conditional ele, and link in each wpt', function completeness() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          gpx.prologue(timestamp) +
+          gpx.serializeBatch(filtered, true) +
+          gpx.epilogue();
+
+        // Split output into individual wpt blocks
+        const wptBlocks = output.split('<wpt ').slice(1);
+        should(wptBlocks.length).equal(filtered.length);
+
+        filtered.forEach((doc, i) => {
+          const wpt = wptBlocks[i];
+
+          // Has <name> element
+          should(wpt).match(/<name>[^<]*<\/name>/);
+
+          // Has <ele> only when altitude is non-null
+          if (doc.altitude != null) {
+            should(wpt).match(/<ele>[^<]+<\/ele>/);
+            const eleMatch = wpt.match(/<ele>([^<]+)<\/ele>/);
+            should(eleMatch).not.be.null();
+            should(parseFloat(eleMatch[1])).equal(doc.altitude);
+          } else {
+            should(wpt).not.match(/<ele>/);
+          }
+
+          // Has <link> with correct href
+          const expectedUrl = `https://grottocenter.org/ui/entrances/${doc.id}`;
+          should(wpt).containEql(`<link href="${expectedUrl}">`);
+          should(wpt).containEql('<text>View on Grottocenter</text>');
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 18: GPX metadata invariant
+ *
+ * metadata has name="Grottocenter", desc present, time is ISO 8601.
+ *
+ * Validates: Requirements 11.3, 11.9
+ */
+describe('Feature: geo-export-search-results, Property 18: GPX metadata invariant', () => {
+  it('should always include correct metadata name, desc, and valid ISO time', function metadataInvariant() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildGPX(docs);
+
+        // Extract metadata section
+        const metadataMatch = output.match(/<metadata>([\s\S]*?)<\/metadata>/);
+        should(metadataMatch).not.be.null();
+        const metadata = metadataMatch[1];
+
+        // <name>Grottocenter</name>
+        should(metadata).match(/<name>Grottocenter<\/name>/);
+
+        // <desc> present
+        should(metadata).match(
+          /<desc>Exported from https:\/\/grottocenter\.org<\/desc>/
+        );
+
+        // <time> with valid ISO 8601
+        const timeMatch = metadata.match(/<time>([^<]+)<\/time>/);
+        should(timeMatch).not.be.null();
+        const date = new Date(timeMatch[1]);
+        should(Number.isNaN(date.getTime())).equal(false);
+        should(timeMatch[1]).match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/geo-serializers/kml.property.test.js
+++ b/test/integration/1_services/geo-serializers/kml.property.test.js
@@ -91,12 +91,13 @@ describe('Feature: geo-export-search-results, Property 9: KML structural validit
 /**
  * Property 10: KML coordinate format
  *
- * Placemark coordinates are `lon,lat,alt` with alt=0 if absent.
+ * Placemark coordinates are `lon,lat,alt` when altitude is known,
+ * or `lon,lat` when altitude is null (omitted rather than defaulting to 0).
  *
  * Validates: Requirements 4.2
  */
 describe('Feature: geo-export-search-results, Property 10: KML coordinate format', () => {
-  it('should format coordinates as lon,lat,alt with alt=0 when absent', function coordinateFormat() {
+  it('should format coordinates as lon,lat,alt when altitude known, lon,lat when absent', function coordinateFormat() {
     this.timeout(30000);
     fc.assert(
       fc.property(entranceDocumentArrayArbitrary, (docs) => {
@@ -115,8 +116,10 @@ describe('Feature: geo-export-search-results, Property 10: KML coordinate format
         should(coordMatches.length).equal(filtered.length);
 
         filtered.forEach((doc, i) => {
-          const expectedAlt = doc.altitude != null ? doc.altitude : 0;
-          const expectedCoords = `${doc.longitude},${doc.latitude},${expectedAlt}`;
+          const expectedCoords =
+            doc.altitude != null
+              ? `${doc.longitude},${doc.latitude},${doc.altitude}`
+              : `${doc.longitude},${doc.latitude}`;
           const actual = coordMatches[i].replace(/<\/?coordinates>/g, '');
           should(actual).equal(expectedCoords);
         });
@@ -157,14 +160,18 @@ describe('Feature: geo-export-search-results, Property 11: KML exclusion of inva
           ) {
             // If this doc has valid coords but is sensitive, verify its exact coords aren't in output
             if (doc.latitude != null && doc.longitude != null) {
-              const alt = doc.altitude != null ? doc.altitude : 0;
-              const excludedCoords = `${doc.longitude},${doc.latitude},${alt}`;
+              const excludedCoords =
+                doc.altitude != null
+                  ? `${doc.longitude},${doc.latitude},${doc.altitude}`
+                  : `${doc.longitude},${doc.latitude}`;
               // Only assert if this exact coord string doesn't also belong to a valid doc
-              const validDocHasSameCoords = filtered.some(
-                (d) =>
-                  `${d.longitude},${d.latitude},${d.altitude != null ? d.altitude : 0}` ===
-                  excludedCoords
-              );
+              const validDocHasSameCoords = filtered.some((d) => {
+                const validCoords =
+                  d.altitude != null
+                    ? `${d.longitude},${d.latitude},${d.altitude}`
+                    : `${d.longitude},${d.latitude}`;
+                return validCoords === excludedCoords;
+              });
               if (!validDocHasSameCoords) {
                 const found = coordMatches.some((m) =>
                   m.includes(excludedCoords)
@@ -183,18 +190,27 @@ describe('Feature: geo-export-search-results, Property 11: KML exclusion of inva
 /**
  * Property 12: KML Placemark data completeness
  *
- * Each Placemark has <name>, <ExtendedData> with Data for all fields + url.
+ * Each Placemark has <name>, <ExtendedData> with Data for all non-geometry
+ * fields plus grottocenterUrl. Geometry fields (id, latitude, longitude, altitude, name) are
+ * excluded from <ExtendedData> as they are represented in the <Point> and <name> elements.
  *
  * Validates: Requirements 4.4, 4.5, 11.5
  */
 describe('Feature: geo-export-search-results, Property 12: KML Placemark data completeness', () => {
-  it('should include name and ExtendedData with all fields plus url in each Placemark', function completeness() {
+  it('should include name and ExtendedData with non-geometry fields plus grottocenterUrl in each Placemark', function completeness() {
     this.timeout(30000);
     fc.assert(
       fc.property(entranceDocumentArrayArbitrary, (docs) => {
         const filtered = filterDocuments(docs);
         if (filtered.length === 0) return;
 
+        const geometryFields = [
+          'id',
+          'latitude',
+          'longitude',
+          'altitude',
+          'name',
+        ];
         const timestamp = new Date().toISOString();
         const output =
           kml.prologue(timestamp) +
@@ -214,14 +230,22 @@ describe('Feature: geo-export-search-results, Property 12: KML Placemark data co
           // Has <ExtendedData>
           should(pm).match(/<ExtendedData>/);
 
-          // Has Data elements for each doc field
+          // Has Data elements for each non-geometry doc field
           Object.keys(doc).forEach((key) => {
-            const dataPattern = new RegExp(`<Data name="${key}">`);
-            should(pm).match(dataPattern);
+            if (!geometryFields.includes(key)) {
+              const dataPattern = new RegExp(`<Data name="${key}">`);
+              should(pm).match(dataPattern);
+            }
           });
 
-          // Has url Data element
-          should(pm).match(/<Data name="url">/);
+          // Geometry fields should NOT appear in ExtendedData
+          geometryFields.forEach((key) => {
+            const dataPattern = new RegExp(`<Data name="${key}">`);
+            should(pm).not.match(dataPattern);
+          });
+
+          // Has grottocenterUrl Data element
+          should(pm).match(/<Data name="grottocenterUrl">/);
           const expectedUrl = `https://grottocenter.org/ui/entrances/${doc.id}`;
           should(pm).containEql(expectedUrl);
         });

--- a/test/integration/1_services/geo-serializers/kml.property.test.js
+++ b/test/integration/1_services/geo-serializers/kml.property.test.js
@@ -1,0 +1,273 @@
+const should = require('should');
+const fc = require('fast-check');
+const kml = require('../../../../api/services/geo-serializers/kml');
+const { filterDocuments } = require('../../../../api/services/geo-serializers');
+
+/**
+ * Arbitrary: generates a realistic entrance document with randomized fields.
+ * Uses only XML-safe characters in name to avoid escaped-string matching issues.
+ */
+const entranceDocumentArbitrary = fc.record({
+  id: fc.stringMatching(/^[0-9]{1,6}$/),
+  name: fc.stringMatching(/^[a-zA-Z0-9 ]{0,50}$/),
+  latitude: fc.option(
+    fc.double({ min: -90, max: 90, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  longitude: fc.option(
+    fc.double({ min: -180, max: 180, noNaN: true, noDefaultInfinity: true }),
+    { nil: null, freq: 3 }
+  ),
+  altitude: fc.option(
+    fc.double({ min: -500, max: 9000, noNaN: true, noDefaultInfinity: true }),
+    { nil: null }
+  ),
+  isSensitive: fc.oneof(
+    { weight: 8, arbitrary: fc.constant(false) },
+    { weight: 2, arbitrary: fc.constant(true) }
+  ),
+  country: fc.option(fc.stringMatching(/^[A-Z]{2}$/), { nil: undefined }),
+});
+
+const entranceDocumentArrayArbitrary = fc.array(entranceDocumentArbitrary, {
+  minLength: 0,
+  maxLength: 30,
+});
+
+/**
+ * Helper: assemble full KML output from an array of entrance docs.
+ */
+const buildKML = (docs) => {
+  const timestamp = new Date().toISOString();
+  const filtered = filterDocuments(docs);
+  const output =
+    kml.prologue(timestamp) +
+    kml.serializeBatch(filtered, true) +
+    kml.epilogue();
+  return output;
+};
+
+/**
+ * Property 9: KML structural validity
+ *
+ * Root is <kml> with namespace, contains single <Document>, zero or more <Placemark>.
+ *
+ * Validates: Requirements 4.1
+ */
+describe('Feature: geo-export-search-results, Property 9: KML structural validity', () => {
+  it('should produce valid KML with kml root, namespace, Document, and Placemarks', function validStructure() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildKML(docs);
+
+        // XML declaration
+        should(output).startWith('<?xml version="1.0" encoding="UTF-8"?>');
+
+        // Root <kml> with correct namespace
+        should(output).match(
+          /<kml xmlns="http:\/\/www\.opengis\.net\/kml\/2\.2">/
+        );
+
+        // Single <Document> element
+        const documentOpens = (output.match(/<Document>/g) || []).length;
+        const documentCloses = (output.match(/<\/Document>/g) || []).length;
+        should(documentOpens).equal(1);
+        should(documentCloses).equal(1);
+
+        // Closing </kml>
+        should(output).endWith('</Document></kml>');
+
+        // Count Placemarks matches filtered doc count
+        const filtered = filterDocuments(docs);
+        const placemarkCount = (output.match(/<Placemark>/g) || []).length;
+        should(placemarkCount).equal(filtered.length);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 10: KML coordinate format
+ *
+ * Placemark coordinates are `lon,lat,alt` with alt=0 if absent.
+ *
+ * Validates: Requirements 4.2
+ */
+describe('Feature: geo-export-search-results, Property 10: KML coordinate format', () => {
+  it('should format coordinates as lon,lat,alt with alt=0 when absent', function coordinateFormat() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          kml.prologue(timestamp) +
+          kml.serializeBatch(filtered, true) +
+          kml.epilogue();
+
+        // Extract all <coordinates> content
+        const coordMatches =
+          output.match(/<coordinates>([^<]+)<\/coordinates>/g) || [];
+        should(coordMatches.length).equal(filtered.length);
+
+        filtered.forEach((doc, i) => {
+          const expectedAlt = doc.altitude != null ? doc.altitude : 0;
+          const expectedCoords = `${doc.longitude},${doc.latitude},${expectedAlt}`;
+          const actual = coordMatches[i].replace(/<\/?coordinates>/g, '');
+          should(actual).equal(expectedCoords);
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 11: KML exclusion of invalid entries
+ *
+ * Sensitive or null-coord docs produce no Placemark.
+ *
+ * Validates: Requirements 4.3, 10.2
+ */
+describe('Feature: geo-export-search-results, Property 11: KML exclusion of invalid entries', () => {
+  it('should produce no Placemark for sensitive or coordinate-less docs', function exclusion() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        const output = buildKML(docs);
+
+        // The number of Placemarks must equal the number of filtered docs
+        const placemarkCount = (output.match(/<Placemark>/g) || []).length;
+        should(placemarkCount).equal(filtered.length);
+
+        // Additionally, verify that every excluded doc's coordinates
+        // do NOT appear as Placemark Point coordinates in the output
+        const coordMatches =
+          output.match(/<coordinates>([^<]+)<\/coordinates>/g) || [];
+        docs.forEach((doc) => {
+          if (
+            doc.isSensitive === true ||
+            doc.latitude == null ||
+            doc.longitude == null
+          ) {
+            // If this doc has valid coords but is sensitive, verify its exact coords aren't in output
+            if (doc.latitude != null && doc.longitude != null) {
+              const alt = doc.altitude != null ? doc.altitude : 0;
+              const excludedCoords = `${doc.longitude},${doc.latitude},${alt}`;
+              // Only assert if this exact coord string doesn't also belong to a valid doc
+              const validDocHasSameCoords = filtered.some(
+                (d) =>
+                  `${d.longitude},${d.latitude},${d.altitude != null ? d.altitude : 0}` ===
+                  excludedCoords
+              );
+              if (!validDocHasSameCoords) {
+                const found = coordMatches.some((m) =>
+                  m.includes(excludedCoords)
+                );
+                should(found).equal(false);
+              }
+            }
+          }
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 12: KML Placemark data completeness
+ *
+ * Each Placemark has <name>, <ExtendedData> with Data for all fields + url.
+ *
+ * Validates: Requirements 4.4, 4.5, 11.5
+ */
+describe('Feature: geo-export-search-results, Property 12: KML Placemark data completeness', () => {
+  it('should include name and ExtendedData with all fields plus url in each Placemark', function completeness() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const filtered = filterDocuments(docs);
+        if (filtered.length === 0) return;
+
+        const timestamp = new Date().toISOString();
+        const output =
+          kml.prologue(timestamp) +
+          kml.serializeBatch(filtered, true) +
+          kml.epilogue();
+
+        // Split into Placemarks
+        const placemarks = output.split('<Placemark>').slice(1);
+        should(placemarks.length).equal(filtered.length);
+
+        filtered.forEach((doc, i) => {
+          const pm = placemarks[i];
+
+          // Has <name> element
+          should(pm).match(/<name>[^<]*<\/name>/);
+
+          // Has <ExtendedData>
+          should(pm).match(/<ExtendedData>/);
+
+          // Has Data elements for each doc field
+          Object.keys(doc).forEach((key) => {
+            const dataPattern = new RegExp(`<Data name="${key}">`);
+            should(pm).match(dataPattern);
+          });
+
+          // Has url Data element
+          should(pm).match(/<Data name="url">/);
+          const expectedUrl = `https://grottocenter.org/ui/entrances/${doc.id}`;
+          should(pm).containEql(expectedUrl);
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 13: KML metadata invariant
+ *
+ * Document name="Grottocenter", description present, TimeStamp with ISO 8601.
+ *
+ * Validates: Requirements 11.2, 11.8
+ */
+describe('Feature: geo-export-search-results, Property 13: KML metadata invariant', () => {
+  it('should always include correct Document name, description, and valid TimeStamp', function metadata() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(entranceDocumentArrayArbitrary, (docs) => {
+        const output = buildKML(docs);
+
+        // Document <name> is Grottocenter (first <name> after <Document>)
+        const docSection = output
+          .split('<Document>')[1]
+          .split('</Document>')[0];
+        const firstNameMatch = docSection.match(/<name>([^<]*)<\/name>/);
+        should(firstNameMatch).not.be.null();
+        should(firstNameMatch[1]).equal('Grottocenter');
+
+        // Description present
+        should(output).match(
+          /<description>Exported from https:\/\/grottocenter\.org<\/description>/
+        );
+
+        // TimeStamp with ISO 8601
+        const timestampMatch = output.match(
+          /<TimeStamp><when>([^<]+)<\/when><\/TimeStamp>/
+        );
+        should(timestampMatch).not.be.null();
+        const date = new Date(timestampMatch[1]);
+        should(Number.isNaN(date.getTime())).equal(false);
+        should(timestampMatch[1]).match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/geo-serializers/validation.property.test.js
+++ b/test/integration/1_services/geo-serializers/validation.property.test.js
@@ -1,0 +1,134 @@
+const should = require('should');
+const fc = require('fast-check');
+
+/**
+ * Validation predicates extracted from the controller logic.
+ * These mirror the exact checks in advanced-search-export.js.
+ */
+const VALID_FORMATS = ['csv', 'geojson', 'kml', 'gpx'];
+const GEO_FORMATS = ['geojson', 'kml', 'gpx'];
+
+const isValidFormat = (f) => VALID_FORMATS.includes(f);
+const isGeoFormat = (f) => GEO_FORMATS.includes(f);
+const isEntityAllowedForGeo = (entity) => entity === 'entrances';
+
+/**
+ * Arbitraries
+ */
+const invalidFormatArbitrary = fc
+  .string()
+  .filter((s) => !VALID_FORMATS.includes(s));
+
+const geoFormatArbitrary = fc.constantFrom('geojson', 'kml', 'gpx');
+
+const nonEntranceEntityArbitrary = fc.constantFrom(
+  'caves',
+  'documents',
+  'organizations',
+  'massifs',
+  'persons',
+  'devices'
+);
+
+const columnsArbitrary = fc.oneof(
+  fc.constant(undefined),
+  fc.constant(null),
+  fc.constant([]),
+  fc.array(fc.string({ minLength: 1, maxLength: 20 }), {
+    minLength: 1,
+    maxLength: 5,
+  }),
+  fc.array(fc.integer(), { minLength: 1, maxLength: 5 }),
+  fc.constant('not-an-array')
+);
+
+/**
+ * Property 1: Invalid format rejection
+ *
+ * For any string that is not one of csv, geojson, kml, or gpx,
+ * the format validation function returns invalid (false).
+ *
+ * Validates: Requirements 1.6
+ */
+describe('Feature: geo-export-search-results, Property 1: Invalid format rejection', () => {
+  it('should reject any string not in the valid format set', function invalidFormatRejection() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(invalidFormatArbitrary, (format) => {
+        should(isValidFormat(format)).equal(false);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 2: Geo format requires entrances entity
+ *
+ * For any geo format combined with any non-entrance entity,
+ * the entity validation rejects the request.
+ *
+ * Validates: Requirements 2.2
+ */
+describe('Feature: geo-export-search-results, Property 2: Geo format requires entrances entity', () => {
+  it('should reject any geo format paired with a non-entrance entity', function entityRestriction() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(
+        geoFormatArbitrary,
+        nonEntranceEntityArbitrary,
+        (format, entity) => {
+          // The format is a geo format
+          should(isGeoFormat(format)).equal(true);
+          // The entity is not entrances, so it should be rejected
+          should(isEntityAllowedForGeo(entity)).equal(false);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 19: Geo format output is independent of column parameters
+ *
+ * For any geo format and any value of columns/columnsName (present, absent,
+ * empty, invalid), the format validation does not reject due to columns.
+ * The controller skips column validation entirely for geo formats.
+ *
+ * Validates: Requirements 6.1, 6.2
+ */
+describe('Feature: geo-export-search-results, Property 19: Geo format output is independent of column parameters', () => {
+  it('should not reject geo format requests regardless of column parameter values', function columnIndependence() {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(
+        geoFormatArbitrary,
+        columnsArbitrary,
+        columnsArbitrary,
+        (format, columns, columnsName) => {
+          // For geo formats, column validation is skipped.
+          // Simulate the controller logic: if isGeoFormat, skip column checks.
+          const isGeo = isGeoFormat(format);
+          should(isGeo).equal(true);
+
+          // Column validation only applies to non-geo formats.
+          // For geo formats, regardless of what columns/columnsName are,
+          // no rejection occurs due to column validation.
+          let columnRejection = false;
+          if (!isGeo) {
+            // This branch is never reached for geo formats
+            if (!Array.isArray(columns) || columns.length === 0) {
+              columnRejection = true;
+            }
+            if (!Array.isArray(columnsName) || columnsName.length === 0) {
+              columnRejection = true;
+            }
+          }
+          should(columnRejection).equal(false);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/4_routes/AdvancedSearchExport/export-format-validation.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-format-validation.test.js
@@ -1,0 +1,111 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+describe('Geo Export - Format Validation', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('POST /api/v1/advanced-search/export', () => {
+    it('should return 400 with valid format list when format is invalid', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=xml')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /format must be one of: csv, geojson, kml, gpx/
+          );
+          return done();
+        });
+    });
+
+    it('should return 400 when geo format is used with non-entrance entity', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({
+          query: 'test',
+          entity: 'caves',
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /Geographic formats \(geojson, kml, gpx\) are only available for entrance searches/
+          );
+          return done();
+        });
+    });
+
+    it('should validate format before entity restriction (invalid format error wins)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=invalid')
+        .send({
+          query: 'test',
+          entity: 'caves',
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(
+            /format must be one of: csv, geojson, kml, gpx/
+          );
+          return done();
+        });
+    });
+
+    it('should succeed with geo format even without columns/columnsName', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [
+          {
+            document: {
+              id: '1',
+              name: 'Cave A',
+              latitude: 45.0,
+              longitude: 2.0,
+              altitude: 500,
+              isSensitive: false,
+              country: 'FR',
+            },
+          },
+        ],
+        found: 1,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+        })
+        .expect(200)
+        .end((err) => {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    it('should return 400 for CSV format without columns (backward compat)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+          columnsName: ['ID'],
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/columns must be a non-empty array/);
+          return done();
+        });
+    });
+  });
+});

--- a/test/integration/4_routes/AdvancedSearchExport/export-geojson.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-geojson.test.js
@@ -1,0 +1,246 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+describe('Geo Export - GeoJSON', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const entranceHits = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+        country: 'FR',
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Cave B',
+        latitude: -12.5,
+        longitude: 130.7,
+        altitude: null,
+        isSensitive: false,
+        country: 'AU',
+      },
+    },
+  ];
+
+  const entranceHitsWithSensitive = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Secret Cave',
+        latitude: 46.0,
+        longitude: 3.0,
+        altitude: 200,
+        isSensitive: true,
+      },
+    },
+  ];
+
+  const entranceHitsWithMissingCoords = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'No Coords Cave',
+        latitude: null,
+        longitude: null,
+        altitude: null,
+        isSensitive: false,
+      },
+    },
+  ];
+
+  describe('POST /api/v1/advanced-search/export?format=geojson', () => {
+    it('should return Content-Type application/geo+json', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .expect('Content-Type', /application\/geo\+json/)
+        .end((err) => {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    it('should return Content-Disposition with .geojson extension', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.headers['content-disposition']).match(/\.geojson"/);
+          return done();
+        });
+    });
+
+    it('should produce valid GeoJSON FeatureCollection with correct metadata', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const geojson = JSON.parse(res.text);
+          should(geojson.type).equal('FeatureCollection');
+          should(geojson.name).equal('Grottocenter');
+          should(geojson.description).equal(
+            'Exported from https://grottocenter.org'
+          );
+          should(geojson.timestamp).be.a.String();
+          should(geojson.features).be.an.Array();
+          should(geojson.features).have.length(2);
+          should(geojson.features[0].type).equal('Feature');
+          should(geojson.features[0].geometry.type).equal('Point');
+          should(geojson.features[0].geometry.coordinates).eql([2.0, 45.0]);
+          should(geojson.features[0].properties.url).equal(
+            'https://grottocenter.org/ui/entrances/1'
+          );
+          return done();
+        });
+    });
+
+    it('should exclude sensitive entrances from output', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHitsWithSensitive,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const geojson = JSON.parse(res.text);
+          should(geojson.features).have.length(1);
+          should(geojson.features[0].properties.name).equal('Cave A');
+          return done();
+        });
+    });
+
+    it('should exclude entrances without coordinates', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHitsWithMissingCoords,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const geojson = JSON.parse(res.text);
+          should(geojson.features).have.length(1);
+          should(geojson.features[0].properties.name).equal('Cave A');
+          return done();
+        });
+    });
+
+    it('should produce valid empty FeatureCollection for empty result set', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [],
+        found: 0,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const geojson = JSON.parse(res.text);
+          should(geojson.type).equal('FeatureCollection');
+          should(geojson.features).be.an.Array();
+          should(geojson.features).have.length(0);
+          return done();
+        });
+    });
+
+    it('should filter and alias fields when columns and columnsName are provided', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=geojson')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+          columns: ['name', 'country'],
+          columnsName: ['Nom', 'Pays'],
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const geojson = JSON.parse(res.text);
+          const props = geojson.features[0].properties;
+          // Aliased fields present
+          should(props).have.property('Nom', 'Cave A');
+          should(props).have.property('Pays', 'FR');
+          // url always present
+          should(props).have.property('url');
+          // Original keys and unselected fields absent
+          should(props).not.have.property('name');
+          should(props).not.have.property('country');
+          should(props).not.have.property('altitude');
+          should(props).not.have.property('isSensitive');
+          return done();
+        });
+    });
+  });
+});

--- a/test/integration/4_routes/AdvancedSearchExport/export-geojson.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-geojson.test.js
@@ -141,7 +141,7 @@ describe('Geo Export - GeoJSON', () => {
           should(geojson.features[0].type).equal('Feature');
           should(geojson.features[0].geometry.type).equal('Point');
           should(geojson.features[0].geometry.coordinates).eql([2.0, 45.0]);
-          should(geojson.features[0].properties.url).equal(
+          should(geojson.features[0].properties.grottocenterUrl).equal(
             'https://grottocenter.org/ui/entrances/1'
           );
           return done();
@@ -232,8 +232,8 @@ describe('Geo Export - GeoJSON', () => {
           // Aliased fields present
           should(props).have.property('Nom', 'Cave A');
           should(props).have.property('Pays', 'FR');
-          // url always present
-          should(props).have.property('url');
+          // grottocenterUrl always present
+          should(props).have.property('grottocenterUrl');
           // Original keys and unselected fields absent
           should(props).not.have.property('name');
           should(props).not.have.property('country');

--- a/test/integration/4_routes/AdvancedSearchExport/export-gpx.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-gpx.test.js
@@ -1,0 +1,173 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+describe('Geo Export - GPX', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const entranceHits = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+        country: 'FR',
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Cave B',
+        latitude: -12.5,
+        longitude: 130.7,
+        altitude: null,
+        isSensitive: false,
+        country: 'AU',
+      },
+    },
+  ];
+
+  const entranceHitsWithSensitive = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Secret Cave',
+        latitude: 46.0,
+        longitude: 3.0,
+        altitude: 200,
+        isSensitive: true,
+      },
+    },
+  ];
+
+  describe('POST /api/v1/advanced-search/export?format=gpx', () => {
+    it('should return Content-Type application/gpx+xml', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .expect('Content-Type', /application\/gpx\+xml/)
+        .end((err) => {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    it('should return Content-Disposition with .gpx extension', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.headers['content-disposition']).match(/\.gpx"/);
+          return done();
+        });
+    });
+
+    it('should produce valid GPX with correct namespace, version, and creator', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(
+            /xmlns="http:\/\/www\.topografix\.com\/GPX\/1\/1"/
+          );
+          should(body).match(/version="1\.1"/);
+          should(body).match(/creator="Grottocenter"/);
+          should(body).match(/<metadata>/);
+          should(body).match(/<name>Grottocenter<\/name>/);
+          should(body).match(
+            /<desc>Exported from https:\/\/grottocenter\.org<\/desc>/
+          );
+          should(body).match(/<time>/);
+          should(body).match(/<wpt lat="45" lon="2">/);
+          should(body).match(/<\/gpx>/);
+          return done();
+        });
+    });
+
+    it('should exclude sensitive entrances from output', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHitsWithSensitive,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(/<name>Cave A<\/name>/);
+          should(body).not.match(/Secret Cave/);
+          return done();
+        });
+    });
+
+    it('should include <ele> element only when altitude is non-null', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          // Cave A has altitude 500
+          should(body).match(/<ele>500<\/ele>/);
+          // Cave B has altitude null — no <ele> element for it
+          // Split by <wpt to isolate each waypoint
+          const wpts = body.split('<wpt');
+          // wpts[0] is prologue, wpts[1] is Cave A, wpts[2] is Cave B
+          should(wpts[1]).match(/<ele>500<\/ele>/);
+          should(wpts[2]).not.match(/<ele>/);
+          return done();
+        });
+    });
+  });
+});

--- a/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
@@ -141,7 +141,7 @@ describe('Geo Export - KML', () => {
         });
     });
 
-    it('should default altitude to 0 when absent', (done) => {
+    it('should omit altitude from coordinates when absent', (done) => {
       const SearchService = require('../../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({
         hits: [
@@ -165,7 +165,7 @@ describe('Geo Export - KML', () => {
         .expect(200)
         .end((err, res) => {
           if (err) return done(err);
-          should(res.text).match(/<coordinates>2,45,0<\/coordinates>/);
+          should(res.text).match(/<coordinates>2,45<\/coordinates>/);
           return done();
         });
     });

--- a/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
@@ -1,0 +1,173 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+describe('Geo Export - KML', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const entranceHits = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+        country: 'FR',
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Cave B',
+        latitude: -12.5,
+        longitude: 130.7,
+        altitude: null,
+        isSensitive: false,
+        country: 'AU',
+      },
+    },
+  ];
+
+  const entranceHitsWithSensitive = [
+    {
+      document: {
+        id: '1',
+        name: 'Cave A',
+        latitude: 45.0,
+        longitude: 2.0,
+        altitude: 500,
+        isSensitive: false,
+      },
+    },
+    {
+      document: {
+        id: '2',
+        name: 'Secret Cave',
+        latitude: 46.0,
+        longitude: 3.0,
+        altitude: 200,
+        isSensitive: true,
+      },
+    },
+  ];
+
+  describe('POST /api/v1/advanced-search/export?format=kml', () => {
+    it('should return Content-Type application/vnd.google-earth.kml+xml', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .expect('Content-Type', /application\/vnd\.google-earth\.kml\+xml/)
+        .end((err) => {
+          if (err) return done(err);
+          return done();
+        });
+    });
+
+    it('should return Content-Disposition with .kml extension', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.headers['content-disposition']).match(/\.kml"/);
+          return done();
+        });
+    });
+
+    it('should produce valid KML with correct namespace and metadata', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(/xmlns="http:\/\/www\.opengis\.net\/kml\/2\.2"/);
+          should(body).match(/<Document>/);
+          should(body).match(/<name>Grottocenter<\/name>/);
+          should(body).match(
+            /<description>Exported from https:\/\/grottocenter\.org<\/description>/
+          );
+          should(body).match(/<TimeStamp><when>/);
+          should(body).match(/<Placemark>/);
+          should(body).match(/<coordinates>2,45,500<\/coordinates>/);
+          should(body).match(/<\/Document><\/kml>/);
+          return done();
+        });
+    });
+
+    it('should exclude sensitive entrances from output', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHitsWithSensitive,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(/<name>Cave A<\/name>/);
+          should(body).not.match(/Secret Cave/);
+          return done();
+        });
+    });
+
+    it('should default altitude to 0 when absent', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: [
+          {
+            document: {
+              id: '1',
+              name: 'No Alt Cave',
+              latitude: 45.0,
+              longitude: 2.0,
+              altitude: null,
+              isSensitive: false,
+            },
+          },
+        ],
+        found: 1,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({ query: 'test', entity: 'entrances' })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          should(res.text).match(/<coordinates>2,45,0<\/coordinates>/);
+          return done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

Add GeoJSON, KML, and GPX export formats to the advanced search export endpoint.

- Extends `POST /api/v1/advanced-search/export` with a `format` query parameter (`csv`, `geojson`, `kml`, `gpx`)
- Geographic formats are restricted to entrance searches only
- Sensitive entrances and entries without coordinates are filtered out
- Optional `columns`/`columnsName` support for field selection and aliasing in geo formats
- Dot-notation field resolution works across all formats (`cave.depth`, `commentsRating.approach`, etc.)
- Closes #1677

## 🤷‍♂️ Why

Cavers need to export search results directly into formats compatible with GIS tools (QGIS, Google Earth) and GPS devices. Until now, only CSV was available which requires manual conversion.

## 🔍 How

- **Serializer registry pattern** — each format module (`geojson.js`, `kml.js`, `gpx.js`) exposes `prologue()`, `serializeBatch()`, `epilogue()` for streaming
- **Shared `filterDocuments` utility** — removes sensitive and coordinate-less entries before any serializer sees them
- **Format dispatch in controller** — validates format, checks entity restriction, then delegates to the appropriate streaming path
- **No new npm dependencies** — serializers use template literals, `JSON.stringify`, and a hand-written `escapeXml` function
- **Streaming in batches of 1,000** — same pagination model as the existing CSV path
- **Pre-resolution of dot-notation fields** — the controller uses `resolveField` to traverse nested Typesense documents before passing to serializers
- **GPX `<desc>` element** — includes field data as plain-text lines since GPX 1.1 has no structured metadata equivalent
- **KML nested objects** — JSON-serialized in `<Data>` values instead of `[object Object]`

## 🧪 Testing

- 19 property-based tests (fast-check, 100 iterations each) covering structural validity, coordinate ordering, exclusion logic, metadata invariants, and round-trip stability
- 22 route integration tests covering Content-Type headers, Content-Disposition, field filtering/aliasing, sensitive exclusion, empty results, and backward compatibility
- Unit tests for `filterDocuments` (15 tests)

```bash
# Run all geo-serializer tests
npx mocha --timeout 30000 test/integration/1_services/geo-serializers/*.test.js

# Run route tests (requires sails lifted)
npm run test -- --grep "Geo Export"
```

Manual testing:
```bash
# GeoJSON with field selection
curl -X POST http://localhost:1337/api/v1/advanced-search/export?format=geojson \
  -H "Content-Type: application/json" \
  -d '{"query":"*","entity":"entrances","columns":["name","city","cave.depth"],"columnsName":["Name","City","Depth"]}'

# KML (all fields)
curl -X POST http://localhost:1337/api/v1/advanced-search/export?format=kml \
  -H "Content-Type: application/json" \
  -d '{"query":"*","entity":"entrances"}'

# GPX with aliases
curl -X POST http://localhost:1337/api/v1/advanced-search/export?format=gpx \
  -H "Content-Type: application/json" \
  -d '{"query":"*","entity":"entrances","columns":["name","cave.depth"],"columnsName":["Nom","Profondeur"]}'
```

## 📸 Previews

N/A (API-only change, no UI)
