### PR TITLE
feat(observations): add isotope delta quantity kind and per mil unit

### DIFF
--- a/sql/9_05_2026_06_03_scientific_observations_enumerations.sql
+++ b/sql/9_05_2026_06_03_scientific_observations_enumerations.sql
@@ -45,7 +45,8 @@ INSERT INTO t_quantity_kind (id, code, url, symbol_si, display_symbol, si_to_dis
   (22, 'LightIntensity', 'http://qudt.org/vocab/quantitykind/Illuminance', 'lx', 'lx', 1, 0),
   (23, 'AirVelocity', 'http://qudt.org/vocab/quantitykind/Speed', 'm/s', 'm/s', 1, 0),
   (24, 'WaterVelocity', 'http://qudt.org/vocab/quantitykind/Speed', 'm/s', 'm/s', 1, 0),
-  (25, 'RadonConcentration', 'http://qudt.org/vocab/quantitykind/ActivityConcentration', 'Bq/m³', 'Bq/m³', 1, 0)
+  (25, 'RadonConcentration', 'http://qudt.org/vocab/quantitykind/ActivityConcentration', 'Bq/m³', 'Bq/m³', 1, 0),
+  (26, 'IsotopeDelta', 'http://qudt.org/vocab/quantitykind/DimensionlessRatio', '1', '‰', 1000, 0)
 ON CONFLICT (code) DO NOTHING;
 
 -- ============================================================
@@ -79,7 +80,8 @@ INSERT INTO t_unit (id, code, symbol) VALUES
   (25, 'lux', 'lx'),
   (26, 'becquerel_per_cubic_meter', 'Bq/m³'),
   (27, 'meter_per_second', 'm/s'),
-  (28, 'decibel', 'dB')
+  (28, 'decibel', 'dB'),
+  (29, 'per_mil', '‰')
 ON CONFLICT (code) DO NOTHING;
 
 -- ============================================================

--- a/test/fixtures/tquantitykind.json
+++ b/test/fixtures/tquantitykind.json
@@ -16,5 +16,14 @@
     "displaySymbol": "hPa",
     "siToDisplayFactor": "0.01",
     "siToDisplayOffset": "0"
+  },
+  {
+    "id": 3,
+    "code": "IsotopeDelta",
+    "url": "http://qudt.org/vocab/quantitykind/DimensionlessRatio",
+    "symbolSi": "1",
+    "displaySymbol": "‰",
+    "siToDisplayFactor": "1000",
+    "siToDisplayOffset": "0"
   }
 ]

--- a/test/fixtures/tsensorconfiguration.json
+++ b/test/fixtures/tsensorconfiguration.json
@@ -39,5 +39,18 @@
     "author": 2,
     "dateInscription": "2024-05-10T16:00:00.000Z",
     "isDeleted": false
+  },
+  {
+    "id": 4,
+    "device": 1,
+    "quantityKind": 3,
+    "unit": 3,
+    "label": "Channel 3 - δ¹⁸O Isotope Delta",
+    "precisionUpper": 0.1,
+    "precisionLower": -0.1,
+    "resolution": 0.01,
+    "author": 1,
+    "dateInscription": "2024-06-01T10:00:00.000Z",
+    "isDeleted": false
   }
 ]

--- a/test/fixtures/tunit.json
+++ b/test/fixtures/tunit.json
@@ -8,5 +8,10 @@
     "id": 2,
     "code": "HPA",
     "symbol": "hPa"
+  },
+  {
+    "id": 3,
+    "code": "per_mil",
+    "symbol": "‰"
   }
 ]

--- a/test/fixtures/tunit.json
+++ b/test/fixtures/tunit.json
@@ -11,7 +11,7 @@
   },
   {
     "id": 3,
-    "code": "per_mil",
+    "code": "PER_MIL",
     "symbol": "‰"
   }
 ]


### PR DESCRIPTION
## 🤔 What

- Add `IsotopeDelta` quantity kind (per mil relative to a reference standard)
- Add `per_mil` unit (‰)
- Update test fixtures accordingly
- Relates to GrottoCenter/grottocenter-front#1400

## 🤷‍♂️ Why

Isotope delta values (δ¹⁸O, δ²H, δ¹³C) expressed in ‰ relative to VSMOW or VPDB are standard measurements in cave hydrology and paleoclimate research. These cannot currently be represented in sensor configurations because the unit and quantity kind are missing.

## 🔍 How

- New quantity kind `IsotopeDelta` with `symbol_si = '1'` (dimensionless), `display_symbol = '‰'`, `factor = 1000`, `offset = 0` — aligned with how `RelativeHumidity` handles dimensionless quantities (store true ratio in SI, display in ‰).
- New unit `per_mil` with symbol `‰`.
- The reference standard (VSMOW, VPDB) is not encoded here — it will be derivable from the substance/analyte field once GrottoCenter/grottocenter-front#1399 lands.

## 🧪 Testing

Run `npm run dev:clean` to rebuild the local database with the new seed data, then verify:
```sql
docker exec grotto-postgres psql -U root -d grottoce -c "SELECT * FROM t_quantity_kind WHERE code = 'IsotopeDelta';"
docker exec grotto-postgres psql -U root -d grottoce -c "SELECT * FROM t_unit WHERE code = 'per_mil';"
```

## 📸 Previews

N/A — data-only change, no UI impact on the API side.
