### PR TITLE
fix(dbSync): update archiver usage for v8 API

### DIFF
--- a/api/dbSync/dbSync.js
+++ b/api/dbSync/dbSync.js
@@ -173,7 +173,7 @@ async function makeDbSync(isFileExportEnabled = true) {
   let archiveP;
   if (isFileExportEnabled) {
     if (!FileService.isCredentials) {
-      sails.log.warn('[dbSync] DB sync aborded, no azure credentials supplied');
+      sails.log.warn('[dbSync] DB sync aborted, no azure credentials supplied');
       return;
     }
     archive = new ZipArchive();

--- a/api/dbSync/dbSync.js
+++ b/api/dbSync/dbSync.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { pipeline, Duplex, Readable } = require('stream');
-const archiver = require('archiver');
+const { ZipArchive } = require('archiver');
 const CommonService = require('../services/CommonService');
 const FileService = require('../services/FileService');
 const syncUtils = require('./utils');
@@ -176,7 +176,7 @@ async function makeDbSync(isFileExportEnabled = true) {
       sails.log.warn('[dbSync] DB sync aborded, no azure credentials supplied');
       return;
     }
-    archive = archiver('zip');
+    archive = new ZipArchive();
     const { promise } = pipelineAsync(
       archive,
       // fs.createWriteStream(syncUtils.EXPORT_FILE_NAME) // For debug

--- a/test/integration/1_services/DbSync.test.js
+++ b/test/integration/1_services/DbSync.test.js
@@ -13,6 +13,7 @@ describe('DbSync', () => {
     let setMetadataStub;
     let createCollectionStub;
     let switchAliasStub;
+    let importDocumentsStub;
     let isCredentialsOriginal;
 
     before(() => {
@@ -39,7 +40,7 @@ describe('DbSync', () => {
       createCollectionStub = sinon
         .stub(typesense, 'createTimestampedCollection')
         .resolves('test-collection');
-      sinon.stub(typesense, 'importDocuments').resolves();
+      importDocumentsStub = sinon.stub(typesense, 'importDocuments').resolves();
       switchAliasStub = sinon
         .stub(typesense, 'switchCollectionAlias')
         .resolves();
@@ -77,6 +78,45 @@ describe('DbSync', () => {
       // All 7 entities have search config
       should(createCollectionStub.callCount).equal(7);
       should(switchAliasStub.callCount).equal(7);
+      // importDocuments is not called when query returns 0 rows
+      should(importDocumentsStub.called).be.false();
+    });
+  });
+
+  describe('makeDbSync with file export disabled', () => {
+    let queryStub;
+    let uploadStub;
+    let setMetadataStub;
+    let isCredentialsOriginal;
+
+    before(() => {
+      isCredentialsOriginal = FileService.isCredentials;
+    });
+
+    beforeEach(() => {
+      queryStub = sinon.stub(CommonService, 'query').resolves({
+        rowCount: 0,
+        rows: [],
+      });
+
+      FileService.isCredentials = true;
+      uploadStub = sinon
+        .stub(FileService.dbExport, 'upload')
+        .returns(new stream.PassThrough());
+      setMetadataStub = sinon
+        .stub(FileService.dbExport, 'setMetadata')
+        .resolves();
+
+      sinon
+        .stub(typesense, 'createTimestampedCollection')
+        .resolves('test-collection');
+      sinon.stub(typesense, 'importDocuments').resolves();
+      sinon.stub(typesense, 'switchCollectionAlias').resolves();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      FileService.isCredentials = isCredentialsOriginal;
     });
 
     it('should skip file export when isFileExportEnabled is false', async () => {

--- a/test/integration/1_services/DbSync.test.js
+++ b/test/integration/1_services/DbSync.test.js
@@ -1,0 +1,98 @@
+const should = require('should');
+const sinon = require('sinon');
+const stream = require('stream');
+const CommonService = require('../../../api/services/CommonService');
+const FileService = require('../../../api/services/FileService');
+const typesense = require('../../../config/typesense');
+const { makeDbSync } = require('../../../api/dbSync/dbSync');
+
+describe('DbSync', () => {
+  describe('makeDbSync with file export enabled', () => {
+    let queryStub;
+    let uploadStub;
+    let setMetadataStub;
+    let createCollectionStub;
+    let switchAliasStub;
+    let isCredentialsOriginal;
+
+    before(() => {
+      isCredentialsOriginal = FileService.isCredentials;
+    });
+
+    beforeEach(() => {
+      // Stub CommonService.query to return empty results (no rows to process)
+      queryStub = sinon.stub(CommonService, 'query').resolves({
+        rowCount: 0,
+        rows: [],
+      });
+
+      // Stub FileService credentials and upload
+      FileService.isCredentials = true;
+      uploadStub = sinon
+        .stub(FileService.dbExport, 'upload')
+        .returns(new stream.PassThrough());
+      setMetadataStub = sinon
+        .stub(FileService.dbExport, 'setMetadata')
+        .resolves();
+
+      // Stub typesense operations
+      createCollectionStub = sinon
+        .stub(typesense, 'createTimestampedCollection')
+        .resolves('test-collection');
+      sinon.stub(typesense, 'importDocuments').resolves();
+      switchAliasStub = sinon
+        .stub(typesense, 'switchCollectionAlias')
+        .resolves();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      FileService.isCredentials = isCredentialsOriginal;
+    });
+
+    it('should create a zip archive and upload it', async () => {
+      await makeDbSync(true);
+
+      should(uploadStub.calledOnce).be.true();
+      should(uploadStub.firstCall.args[0]).equal('grottocenterDbExport.zip');
+      should(uploadStub.firstCall.args[1]).equal('application/zip');
+      should(setMetadataStub.calledOnce).be.true();
+
+      // setMetadata receives archive size (a number)
+      const archiveSize = setMetadataStub.firstCall.args[0];
+      should(archiveSize).be.a.Number();
+    });
+
+    it('should process all entity collections', async () => {
+      await makeDbSync(true);
+
+      // 7 collections (massif, entrance, cave, document, organization, person, device)
+      // Each gets at least one query call
+      should(queryStub.callCount).be.aboveOrEqual(7);
+    });
+
+    it('should create typesense collections for entities with search config', async () => {
+      await makeDbSync(true);
+
+      // All 7 entities have search config
+      should(createCollectionStub.callCount).equal(7);
+      should(switchAliasStub.callCount).equal(7);
+    });
+
+    it('should skip file export when isFileExportEnabled is false', async () => {
+      await makeDbSync(false);
+
+      should(uploadStub.called).be.false();
+      should(setMetadataStub.called).be.false();
+    });
+
+    it('should abort when no Azure credentials are available', async () => {
+      FileService.isCredentials = false;
+
+      await makeDbSync(true);
+
+      should(uploadStub.called).be.false();
+      should(queryStub.called).be.false();
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Fix `TypeError: archiver is not a function` in automatic weekly dbSync
- Add integration tests for the `makeDbSync` file export path

## 🤷‍♂️ Why

The `archiver` package was upgraded to v8 (`^8.0.0` in package.json), which introduced a breaking API change. v8 no longer exports a factory function — it exports classes (`ZipArchive`, `TarArchive`, etc.).

The automatic dbSync (runs every Monday at 2 AM UTC) calls `makeDbSync(true)` which hits the archiver code path. The manual resync script defaults to `makeDbSync(false)`, skipping file export entirely — that's why manual resyncs still worked.

Last successful automatic run: June 1, 2026.

## 🔍 How

- Replace `const archiver = require('archiver')` with `const { ZipArchive } = require('archiver')`
- Replace `archiver('zip')` with `new ZipArchive()`
- Add `DbSync.test.js` covering the file export path with stubbed dependencies (Azure upload, Typesense) so this class of breakage is caught by CI in the future

## 🧪 Testing

```bash
npm run test -- --grep "DbSync"
```

All 5 new tests pass. Full suite (2882 tests) also passes.

## 📸 Previews

N/A — backend-only fix.
