### PR TITLE
fix(entrance): preserve h_location.id_entrance on permanent delete

### DIFF
--- a/api/controllers/v1/entrance/delete.js
+++ b/api/controllers/v1/entrance/delete.js
@@ -180,57 +180,72 @@ module.exports = async (req, res) => {
       ),
     ]);
 
-    // Clean up FK references to this entrance in history tables.
-    // H-rows are preserved for auditability — only the FK is nulled/reassigned
-    // so the hard delete of t_entrance can proceed.
+    // Clean up FK references to this entrance in T-models (secondary 'exit' FK)
+    // and, when merging, reassign H-model references to the surviving entrance.
+    //
+    // When NOT merging (pure delete), h_ rows intentionally keep their original
+    // id_entrance value. The FK constraints have been dropped (see migration
+    // 1_2026_05_05_drop_history_parent_fk.sql), so orphaned references are safe
+    // and preserve full traceability for audit purposes.
+    //
     // Raw SQL is required because Waterline silently fails on composite-PK models.
     //
     // IMPORTANT: This block must cover every h_ table that has an id_entrance
     // or id_exit column. If a new sub-entity type is added to subEntityDelete
     // above, a matching h_ UPDATE must be added here.
-    await Promise.all([
-      // T-models: secondary 'exit' FK
+    const tModelExitUpdates = [
       TDescription.update({ exit: entranceId }).set({ exit: target }),
       TRigging.update({ exit: entranceId }).set({ exit: target }),
       TComment.update({ exit: entranceId }).set({ exit: target }),
-      // H-models: all entrance/exit references
-      CommonService.query(
-        'UPDATE h_location SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_description SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_description SET id_exit = $1 WHERE id_exit = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_rigging SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_rigging SET id_exit = $1 WHERE id_exit = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_comment SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_comment SET id_exit = $1 WHERE id_exit = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_history SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-      CommonService.query(
-        'UPDATE h_name SET id_entrance = $1 WHERE id_entrance = $2',
-        [target, entranceId]
-      ),
-    ]);
+    ];
+
+    if (shouldMergeInto) {
+      // Reassign h_ references to the merge target
+      await Promise.all([
+        ...tModelExitUpdates,
+        CommonService.query(
+          'UPDATE h_location SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_description SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_description SET id_exit = $1 WHERE id_exit = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_rigging SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_rigging SET id_exit = $1 WHERE id_exit = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_comment SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_comment SET id_exit = $1 WHERE id_exit = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_history SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+        CommonService.query(
+          'UPDATE h_name SET id_entrance = $1 WHERE id_entrance = $2',
+          [target, entranceId]
+        ),
+      ]);
+    } else {
+      // Pure delete: only null the T-model exit FKs (already nullable).
+      // H-rows keep their original id_entrance — the FK constraint is gone,
+      // so orphaned references won't block the hard delete.
+      await Promise.all(tModelExitUpdates);
+    }
 
     if (entrance.documents.length > 0) {
       if (shouldMergeInto) {

--- a/api/controllers/v1/entrance/delete.js
+++ b/api/controllers/v1/entrance/delete.js
@@ -26,7 +26,8 @@ async function hardDestroy(model, criteria) {
 /**
  * Delete sub-entities linked to an entrance.
  * History (h_) rows are intentionally NOT touched — they are preserved
- * for auditability with FK references nulled via raw SQL separately.
+ * for auditability; in merge paths the FK is reassigned via raw SQL,
+ * in delete paths the original value is kept as an orphaned reference.
  *
  * IMPORTANT: When adding a new sub-entity type here, also add a matching
  * h_ UPDATE in the raw SQL block below (search for "h_location" to find it).

--- a/test/integration/4_routes/Entrances/delete-auditability.test.js
+++ b/test/integration/4_routes/Entrances/delete-auditability.test.js
@@ -270,12 +270,42 @@ describe('Entrance features', () => {
       );
       should(hLocation.rows[0].cnt).be.aboveOrEqual(1);
 
-      // Verify h_location FK was preserved (entrance was deleted, not merged)
+      // Verify h_ FKs were preserved (entrance was deleted, not merged)
       const hLocationFk = await CommonService.query(
         'SELECT id_entrance FROM h_location WHERE id = $1',
         [location.id]
       );
       should(hLocationFk.rows[0].id_entrance).equal(entrance.id);
+
+      const hDescriptionFk = await CommonService.query(
+        'SELECT id_entrance FROM h_description WHERE id = $1',
+        [description.id]
+      );
+      should(hDescriptionFk.rows[0].id_entrance).equal(entrance.id);
+
+      const hRiggingFk = await CommonService.query(
+        'SELECT id_entrance FROM h_rigging WHERE id = $1',
+        [rigging.id]
+      );
+      should(hRiggingFk.rows[0].id_entrance).equal(entrance.id);
+
+      const hCommentFk = await CommonService.query(
+        'SELECT id_entrance FROM h_comment WHERE id = $1',
+        [comment.id]
+      );
+      should(hCommentFk.rows[0].id_entrance).equal(entrance.id);
+
+      const hHistoryFk = await CommonService.query(
+        'SELECT id_entrance FROM h_history WHERE id = $1',
+        [history.id]
+      );
+      should(hHistoryFk.rows[0].id_entrance).equal(entrance.id);
+
+      const hNameFk = await CommonService.query(
+        'SELECT id_entrance FROM h_name WHERE id = $1',
+        [name.id]
+      );
+      should(hNameFk.rows[0].id_entrance).equal(entrance.id);
 
       const hDescription = await CommonService.query(
         'SELECT COUNT(*)::integer AS cnt FROM h_description WHERE id = $1',

--- a/test/integration/4_routes/Entrances/delete-auditability.test.js
+++ b/test/integration/4_routes/Entrances/delete-auditability.test.js
@@ -270,12 +270,12 @@ describe('Entrance features', () => {
       );
       should(hLocation.rows[0].cnt).be.aboveOrEqual(1);
 
-      // Verify h_location FK was nulled (entrance was deleted, not merged)
+      // Verify h_location FK was preserved (entrance was deleted, not merged)
       const hLocationFk = await CommonService.query(
         'SELECT id_entrance FROM h_location WHERE id = $1',
         [location.id]
       );
-      should(hLocationFk.rows[0].id_entrance).be.null();
+      should(hLocationFk.rows[0].id_entrance).equal(entrance.id);
 
       const hDescription = await CommonService.query(
         'SELECT COUNT(*)::integer AS cnt FROM h_description WHERE id = $1',


### PR DESCRIPTION
## 🤔 What

- Stop nulling `h_location.id_entrance` (and other h_ table FKs) during permanent entrance deletion without merge
- Retain original entrance references in history rows for auditability
- Closes #1685

## 🤷‍♂️ Why

When permanently deleting an entrance without merging into another, the code was setting `h_location.id_entrance = NULL`. This violated the `NOT NULL` constraint on `h_location.id_entrance`, causing a 500 error (PostgreSQL error 23502).

Nulling the FK also destroys the audit trail — after deletion you can't query which entrance a history record belonged to.

## 🔍 How

The FK constraints from h_ tables to `t_entrance` were already dropped in migration `1_2026_05_05_drop_history_parent_fk.sql`. This means h_ rows can safely point to a non-existent `t_entrance` row without blocking the hard delete.

The fix splits the h_ UPDATE block into two branches:
- **Merge path** (`shouldMergeInto = true`): reassign h_ references to the surviving entrance (existing behavior, unchanged)
- **Pure delete path** (`shouldMergeInto = false`): skip h_ UPDATEs entirely, preserving the original `id_entrance` value as an orphaned-but-valid historical reference

No schema migration needed. The `NOT NULL` constraint stays in place, which is correct — a location history row should always record which entrance it belonged to.

## 🧪 Testing

- `npm run test -- --grep "Delete - Auditability"` validates the fix directly
- Full test suite passes (2882 tests, 0 failures)

## 📸 Previews

N/A
