### PR TITLE
feat(sso): add product-agnostic SSO token endpoint and Superset security manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ config/local.js
 node_modules
 bower_components
 
+# Python
+__pycache__/
+*.pyc
+
 
 
 

--- a/api/controllers/v1/sso/auth-token.js
+++ b/api/controllers/v1/sso/auth-token.js
@@ -1,0 +1,29 @@
+const SsoService = require('../../../services/SsoService');
+
+module.exports = async (req, res) => {
+  const { product } = req.body || {};
+
+  // req.token only has { id, groups, nickname } — fetch full caver for name/surname
+  const caver = await TCaver.findOne({ id: req.token.id });
+  if (!caver) {
+    return res.forbidden('Access denied.');
+  }
+
+  const result = SsoService.issueToken(caver, product);
+
+  if (result.error) {
+    if (result.status === 500) {
+      return res.serverError(result.error);
+    }
+    return res.badRequest(result.error);
+  }
+
+  const params = { controllerMethod: 'SsoController.authToken' };
+  return ControllerService.treat(
+    req,
+    null,
+    { token: result.token },
+    params,
+    res
+  );
+};

--- a/api/services/SsoService.js
+++ b/api/services/SsoService.js
@@ -1,0 +1,113 @@
+/**
+ * SsoService.js
+ *
+ * @description :: Product-agnostic SSO token issuance for cross-origin
+ *                 Just-In-Time authentication with external products.
+ *                 Each registered product has its own signing secret
+ *                 resolved from a dedicated environment variable.
+ */
+
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+
+/**
+ * Product registry mapping product identifiers to their
+ * corresponding environment variable names for signing secrets.
+ * To onboard a new product: add an entry here and set the env var.
+ */
+const PRODUCT_REGISTRY = {
+  superset: 'SSO_SALT_SUPERSET',
+};
+
+const SSO_TOKEN_TTL = 30; // seconds
+
+// Local dev fallback (matches SUPERSET_SSO_SECRET default in superset_config.py).
+// Only used when NODE_ENV=development and the env var is not set.
+const DEV_FALLBACK_SALT = 'aR4nd0mSs0DevSalt_change_in_prod';
+
+/**
+ * Resolve the signing salt for a given product.
+ * @param {string} product - Product identifier from request body
+ * @returns {{ salt: string } | { error: string, status: number }}
+ */
+function resolveSalt(product) {
+  if (!product || typeof product !== 'string') {
+    return {
+      error: "The 'product' field is required and must be a string.",
+      status: 400,
+    };
+  }
+
+  const envVarName = PRODUCT_REGISTRY[product];
+  if (!envVarName) {
+    return {
+      error: `Product '${product}' is not supported.`,
+      status: 400,
+    };
+  }
+
+  const salt = process.env[envVarName];
+  if (!salt || !salt.trim()) {
+    // In development, fall back to a shared dev secret (must match Superset side)
+    if (process.env.NODE_ENV === 'development') {
+      return { salt: DEV_FALLBACK_SALT };
+    }
+    sails.log.error(
+      `SsoService: signing secret not configured for product '${product}' (env var: ${envVarName})`
+    );
+    return {
+      error: 'Server configuration error.',
+      status: 500,
+    };
+  }
+
+  return { salt };
+}
+
+/**
+ * Build the SSO token payload for a caver and product.
+ * Uses synthetic email ({id}@grottocenter.org) to avoid PII exposure.
+ *
+ * @param {Object} caver - Caver record (must have id; may have name, surname)
+ * @param {string} product - Product identifier (used as `aud` claim)
+ * @returns {Object} JWT payload
+ */
+function buildPayload(caver, product) {
+  return {
+    sub: caver.id,
+    aud: product,
+    email: `${caver.id}@grottocenter.org`,
+    firstName: caver.name || '',
+    lastName: caver.surname || '',
+    jti: crypto.randomUUID(),
+  };
+}
+
+/**
+ * Issue an SSO token for the given caver and product.
+ * @param {Object} caver - Caver record (id, name, surname)
+ * @param {string} product - Product identifier
+ * @returns {{ token: string } | { error: string, status: number }}
+ */
+function issueToken(caver, product) {
+  const saltResult = resolveSalt(product);
+  if (saltResult.error) {
+    return saltResult;
+  }
+
+  const payload = buildPayload(caver, product);
+  const token = jwt.sign(payload, saltResult.salt, {
+    algorithm: 'HS256',
+    expiresIn: SSO_TOKEN_TTL,
+  });
+
+  return { token };
+}
+
+module.exports = {
+  PRODUCT_REGISTRY,
+  SSO_TOKEN_TTL,
+  resolveSalt,
+  buildPayload,
+  issueToken,
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -64,6 +64,8 @@ tags:
     description: Scientific observation data import
   - name: Substances
     description: Substance reference table for chemical species and isotopes
+  - name: SSO
+    description: Single Sign-On token issuance for external product integration
 
 paths:
   '/health':
@@ -6443,6 +6445,52 @@ paths:
           description: Validation error (missing name or name exceeds 200 characters).
         '401':
           description: Authentication required.
+
+  '/sso/auth-token':
+    post:
+      tags:
+        - SSO
+      summary: Issue SSO authentication token
+      description: >-
+        Issues a short-lived JWT (30-second TTL) for cross-origin authentication with
+        an external product. The token is signed with a product-specific secret and
+        includes a synthetic email (no real PII). The front-end submits this token to
+        the target product's SSO login endpoint via a hidden POST form.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - product
+              properties:
+                product:
+                  type: string
+                  enum:
+                    - superset
+                  description: Target product identifier. Determines which signing secret is used.
+      responses:
+        '200':
+          description: SSO token issued successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: Signed JWT (30s TTL) for the target product.
+        '400':
+          description: The product field is missing, empty, or not a supported product.
+        '401':
+          description: Bearer token is missing, invalid, expired, or has been revoked.
+        '403':
+          description: Access denied (user account not found).
+        '500':
+          description: The signing secret is not configured for the requested product (server misconfiguration).
 
 components:
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -304,6 +304,9 @@ module.exports.policies = {
   'v1/substance/find': true,
   'v1/substance/create': 'tokenAuth',
 
+  // SSO
+  'v1/sso/auth-token': 'tokenAuth',
+
   // Miscellaneous
   'v1/convert/convert': true,
   'v1/file-format/find-all': true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -461,6 +461,9 @@ module.exports.routes = {
   'GET /api/v1/substances': 'v1/substance/find',
   'POST /api/v1/substances': 'v1/substance/create',
 
+  // SSO
+  'POST /api/v1/sso/auth-token': 'v1/sso/auth-token',
+
   //  ╦ ╦╔═╗╔╗ ╦ ╦╔═╗╔═╗╦╔═╔═╗
   //  ║║║║╣ ╠╩╗╠═╣║ ║║ ║╠╩╗╚═╗
   //  ╚╩╝╚═╝╚═╝╩ ╩╚═╝╚═╝╩ ╩╚═╝

--- a/docker/docker-compose.superset.yml
+++ b/docker/docker-compose.superset.yml
@@ -19,6 +19,7 @@ services:
     entrypoint: ["/app/docker-entrypoint.sh"]
     environment:
       - SUPERSET_SECRET_KEY=grottocenter_local_dev_secret_key_change_in_prod
+      - SUPERSET_SSO_SECRET=aR4nd0mSs0DevSalt_change_in_prod
       - SQLALCHEMY_DATABASE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@dbserver:5432/${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -33,8 +34,14 @@ services:
     networks:
       - default
       - grottocenter_default
+    # Volume mounts override Dockerfile COPY for hot-reloading during development.
+    # In production, files are baked into the image via COPY in the Dockerfile.
     volumes:
       - ../docker/superset/superset_config.py:/app/pythonpath/superset_config.py
+      - ../docker/superset/gc_security_manager.py:/app/pythonpath/gc_security_manager.py
+      - ../docker/superset/jti_store.py:/app/pythonpath/jti_store.py
+      - ../docker/superset/gc_creator_permissions.py:/app/pythonpath/gc_creator_permissions.py
+      - ../docker/superset/templates:/app/pythonpath/templates
       - ../docker/superset/docker-entrypoint.sh:/app/docker-entrypoint.sh
       - ../docker/superset/export:/app/superset-export
 

--- a/docker/superset/Dockerfile
+++ b/docker/superset/Dockerfile
@@ -1,7 +1,7 @@
 FROM apache/superset:6.1.0
 
 USER root
-RUN uv pip install psycopg2-binary==2.9.12 flask-cors==6.0.2
+RUN uv pip install psycopg2-binary==2.9.12 flask-cors==6.0.2 pyjwt==2.9.0
 
 # Copy startup script
 COPY startup.sh /usr/bin/startup.sh
@@ -9,6 +9,12 @@ RUN chmod +x /usr/bin/startup.sh
 
 # Copy Superset configuration
 COPY superset_config.py /app/pythonpath/superset_config.py
+
+# Copy SSO security manager and JTI store
+COPY gc_security_manager.py /app/pythonpath/gc_security_manager.py
+COPY jti_store.py /app/pythonpath/jti_store.py
+COPY gc_creator_permissions.py /app/pythonpath/gc_creator_permissions.py
+COPY templates/ /app/pythonpath/templates/
 
 # Copy Grottocenter branding assets
 COPY branding/ /app/superset/static/assets/images/grottocenter/

--- a/docker/superset/docker-entrypoint.sh
+++ b/docker/superset/docker-entrypoint.sh
@@ -25,6 +25,10 @@ superset fab create-admin \
 echo "==> Initializing Superset..."
 superset init
 
+# Used by local dev (docker-compose.superset.yml overrides CMD with this entrypoint)
+echo "==> Ensuring GC_Creator role exists with correct permissions..."
+python /app/pythonpath/gc_creator_permissions.py
+
 # Import dashboard if export directory exists and DB is fresh
 if [ -d "$EXPORT_DIR/dashboards" ]; then
   # Work on a copy so we don't mutate the volume-mounted source

--- a/docker/superset/gc_creator_permissions.py
+++ b/docker/superset/gc_creator_permissions.py
@@ -1,0 +1,139 @@
+"""
+GC_Creator role permissions (whitelist).
+
+Defines the exact set of permissions for JIT-provisioned Superset users.
+Run during startup to ensure the role exists with the correct permissions.
+New Superset upgrades won't accidentally grant extra permissions — only
+what's listed here is allowed.
+
+Usage:
+    python gc_creator_permissions.py
+"""
+
+# (permission_name, view_menu_name)
+GC_CREATOR_PERMISSIONS = [
+    # --- Dashboard & Chart CRUD ---
+    ("can_read", "Dashboard"),
+    ("can_write", "Dashboard"),
+    ("can_read", "Chart"),
+    ("can_write", "Chart"),
+    ("can_export", "Chart"),
+    ("can_export", "Dashboard"),
+    ("can_dashboard", "Superset"),
+    ("can_dashboard_permalink", "Superset"),
+    ("can_drill", "Dashboard"),
+    ("can_view_chart_as_table", "Dashboard"),
+    ("can_view_query", "Dashboard"),
+    ("can_put_chart_customizations", "Dashboard"),
+    ("can_get_embedded", "Dashboard"),
+
+    # --- Explore & Data interaction ---
+    ("can_explore", "Superset"),
+    ("can_explore_json", "Superset"),
+    ("can_csv", "Superset"),
+    ("can_slice", "Superset"),
+    ("can_fetch_datasource_metadata", "Superset"),
+    ("can_file_handler", "Superset"),
+    ("can_language_pack", "Superset"),
+    ("can_log", "Superset"),
+
+    # --- Datasource access (read-only) ---
+    ("can_read", "Dataset"),
+    ("can_read", "Database"),
+    ("can_get", "Datasource"),
+    ("can_get_column_values", "Datasource"),
+    ("can_get_drill_info", "Dataset"),
+    ("can_external_metadata", "Datasource"),
+    ("can_external_metadata_by_name", "Datasource"),
+    ("can_samples", "Datasource"),
+    ("can_validate_expression", "Datasource"),
+    ("all_datasource_access", "all_datasource_access"),
+
+    # --- Read-only supporting views ---
+    ("can_read", "EmbeddedDashboard"),
+    ("can_read", "Explore"),
+    ("can_read", "ExploreFormDataRestApi"),
+    ("can_read", "ExplorePermalinkRestApi"),
+    ("can_read", "DashboardFilterStateRestApi"),
+    ("can_read", "DashboardPermalinkRestApi"),
+    ("can_read", "Annotation"),
+    ("can_read", "AvailableDomains"),
+    ("can_read", "CssTemplate"),
+    ("can_read", "CurrentUserRestApi"),
+    ("can_read", "Tag"),
+    ("can_read", "Task"),
+    ("can_read", "Theme"),
+    ("can_read", "AdvancedDataType"),
+
+    # --- Write permissions for filter/explore state persistence ---
+    ("can_write", "DashboardFilterStateRestApi"),
+    ("can_write", "DashboardPermalinkRestApi"),
+    ("can_write", "ExploreFormDataRestApi"),
+    ("can_write", "ExplorePermalinkRestApi"),
+    ("can_write", "CurrentUserRestApi"),
+
+    # --- API & menu access ---
+    ("can_get", "MenuApi"),
+    ("can_get", "OpenApi"),
+    ("can_query", "Api"),
+    ("can_query_form_data", "Api"),
+    ("can_time_range", "Api"),
+    ("can_list", "AsyncEventsRestApi"),
+    ("can_list", "DynamicPlugin"),
+    ("can_list", "SavedQuery"),
+    ("can_list", "Tags"),
+    ("can_show", "DynamicPlugin"),
+    ("can_show", "SwaggerView"),
+    ("can_recent_activity", "Log"),
+
+    # --- Menu items ---
+    ("menu_access", "Home"),
+    ("menu_access", "Dashboards"),
+    ("menu_access", "Charts"),
+    ("menu_access", "Data"),
+    ("menu_access", "Databases"),
+    ("menu_access", "Datasets"),
+]
+
+ROLE_NAME = "GC_Creator"
+
+
+def ensure_role_with_permissions():
+    """Create or update the GC_Creator role with exactly the whitelisted permissions."""
+    from superset.app import create_app
+
+    app = create_app()
+    with app.app_context():
+        from superset import security_manager
+        from superset.extensions import db
+
+        # Ensure role exists
+        role = security_manager.find_role(ROLE_NAME)
+        if not role:
+            role = security_manager.add_role(ROLE_NAME)
+            print(f"Created role '{ROLE_NAME}'")
+
+        # Clear existing permissions (whitelist = start fresh)
+        role.permissions = []
+
+        # Add each whitelisted permission
+        added = 0
+        skipped = 0
+        for perm_name, view_name in GC_CREATOR_PERMISSIONS:
+            pv = security_manager.find_permission_view_menu(perm_name, view_name)
+            if pv:
+                role.permissions.append(pv)
+                added += 1
+            else:
+                # Permission/view might not exist in this Superset version
+                skipped += 1
+
+        db.session.commit()
+        print(
+            f"Role '{ROLE_NAME}': {added} permissions set, "
+            f"{skipped} skipped (not found in this Superset version)"
+        )
+
+
+if __name__ == "__main__":
+    ensure_role_with_permissions()

--- a/docker/superset/gc_security_manager.py
+++ b/docker/superset/gc_security_manager.py
@@ -46,9 +46,9 @@ TOKEN_MAX_AGE_SECONDS = 30
 GC_CREATOR_ROLE_NAME = "GC_Creator"
 
 
-def _render_error(reason: str) -> tuple[str, int]:
+def _render_error(reason: str, status_code: int = 400) -> tuple[str, int]:
     """Render the SSO error page with the given reason."""
-    return render_template_string(_ERROR_TEMPLATE, reason=reason), 400
+    return render_template_string(_ERROR_TEMPLATE, reason=reason), status_code
 
 
 class GrottocenterSecurityManager(SupersetSecurityManager):
@@ -91,7 +91,7 @@ class GrottocenterSecurityManager(SupersetSecurityManager):
         sso_secret = current_app.config.get("SUPERSET_SSO_SECRET", "").strip()
         if not sso_secret:
             logger.error("SUPERSET_SSO_SECRET is not configured")
-            return _render_error("An unexpected error occurred.")
+            return _render_error("An unexpected error occurred.", status_code=500)
 
         # 3. Verify JWT signature and audience
         try:
@@ -161,6 +161,8 @@ class GrottocenterSecurityManager(SupersetSecurityManager):
                 )
                 return None
 
+            # "Caver" fallback: buildPayload coerces null/empty caver.name to '',
+            # so empty first_name means the caver has no name set in GC.
             user = self.add_user(
                 username=email,
                 first_name=first_name or "Caver",
@@ -176,15 +178,15 @@ class GrottocenterSecurityManager(SupersetSecurityManager):
             # Update name if changed (never modify roles)
             changed = False
             if user.first_name != first_name:
+                # "Caver" fallback: buildPayload coerces null/empty caver.name to '',
+                # so empty first_name means the caver has no name set in GC.
                 user.first_name = first_name or "Caver"
                 changed = True
             if user.last_name != last_name:
                 user.last_name = last_name or ""
                 changed = True
             if changed:
-                from superset.extensions import db
-
-                db.session.commit()
+                self.update_user(user)
                 logger.info(f"SSO: Updated name for Superset user '{email}'")
 
         return user

--- a/docker/superset/gc_security_manager.py
+++ b/docker/superset/gc_security_manager.py
@@ -34,7 +34,11 @@ except FileNotFoundError:
         "</body></html>"
     )
 
-# Module-level JTI store (shared across requests within the same process)
+# Module-level JTI store (shared across requests within the same process).
+# LIMITATION: In multi-worker deployments (Gunicorn with >1 worker), each worker
+# has its own JTI store. A token consumed by worker A can be replayed on worker B.
+# For the current traffic volume and 30s TTL, this is an acceptable risk.
+# If replay protection needs to be absolute, replace with Redis SET NX EX.
 _jti_store = JtiStore(ttl_seconds=30)
 
 EXPECTED_AUDIENCE = "superset"
@@ -89,39 +93,39 @@ class GrottocenterSecurityManager(SupersetSecurityManager):
             logger.error("SUPERSET_SSO_SECRET is not configured")
             return _render_error("An unexpected error occurred.")
 
-        # 3. Verify JWT signature
+        # 3. Verify JWT signature and audience
         try:
             payload = jwt.decode(
                 token_str,
                 sso_secret,
                 algorithms=["HS256"],
-                options={"verify_exp": True, "verify_aud": False, "verify_sub": False},
+                audience=EXPECTED_AUDIENCE,
+                options={"verify_exp": True, "verify_sub": False},
             )
         except jwt.ExpiredSignatureError:
             return _render_error("The authentication token has expired.")
+        except jwt.InvalidAudienceError:
+            return _render_error("This token is not intended for this service.")
         except jwt.InvalidTokenError:
             return _render_error("The authentication token is invalid.")
 
-        # 4. Verify audience
-        if payload.get("aud") != EXPECTED_AUDIENCE:
-            return _render_error("This token is not intended for this service.")
-
-        # 5. Verify iat freshness (within 30s)
+        # 4. Verify iat freshness (within 30s).
+        # Defense-in-depth: PyJWT's verify_exp already rejects tokens past their
+        # exp (which is iat + 30), but this manual check guards against tokens
+        # where exp was manipulated independently of iat.
         iat = payload.get("iat")
         if iat is None or (time.time() - iat) > TOKEN_MAX_AGE_SECONDS:
             return _render_error("The authentication token has expired.")
 
-        # 6. Check JTI for replay
+        # 5. Check JTI for replay (atomic check-and-add to avoid TOCTOU race)
         jti = payload.get("jti")
         if not jti:
             return _render_error("The authentication token is invalid.")
 
-        if _jti_store.contains(jti):
+        if not _jti_store.add_if_new(jti):
             return _render_error("This token has already been used.")
 
-        _jti_store.add(jti)
-
-        # 7. JIT provision or update user
+        # 6. JIT provision or update user
         email = payload.get("email", "")
         first_name = payload.get("firstName", "")
         last_name = payload.get("lastName", "")
@@ -133,10 +137,10 @@ class GrottocenterSecurityManager(SupersetSecurityManager):
         if user is None:
             return _render_error("Service configuration error. Please contact support.")
 
-        # 8. Establish session
+        # 7. Establish session
         login_user(user)
 
-        # 9. Redirect to landing page
+        # 8. Redirect to landing page
         return redirect("/superset/welcome/")
 
     def _jit_provision_user(self, email: str, first_name: str, last_name: str):

--- a/docker/superset/gc_security_manager.py
+++ b/docker/superset/gc_security_manager.py
@@ -1,0 +1,186 @@
+"""
+Grottocenter custom security manager for Apache Superset.
+
+Adds a /login/sso endpoint that accepts a short-lived JWT issued by
+the GC API, verifies it, provisions (or updates) a local Superset user,
+and establishes a Flask session.
+"""
+
+import logging
+import os
+import time
+
+import jwt
+from flask import current_app, redirect, render_template_string, request
+from flask_login import login_user
+from superset.security import SupersetSecurityManager
+
+from jti_store import JtiStore
+
+logger = logging.getLogger(__name__)
+
+# Load the error template once at module level
+_TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+_ERROR_TEMPLATE_PATH = os.path.join(_TEMPLATE_DIR, "sso_error.html")
+
+try:
+    with open(_ERROR_TEMPLATE_PATH, "r", encoding="utf-8") as _f:
+        _ERROR_TEMPLATE = _f.read()
+except FileNotFoundError:
+    _ERROR_TEMPLATE = (
+        "<html><body><h1>Login Failed</h1>"
+        "<p>{{ reason }}</p>"
+        "<p>Please close this tab and try again from Grottocenter.</p>"
+        "</body></html>"
+    )
+
+# Module-level JTI store (shared across requests within the same process)
+_jti_store = JtiStore(ttl_seconds=30)
+
+EXPECTED_AUDIENCE = "superset"
+TOKEN_MAX_AGE_SECONDS = 30
+GC_CREATOR_ROLE_NAME = "GC_Creator"
+
+
+def _render_error(reason: str) -> tuple[str, int]:
+    """Render the SSO error page with the given reason."""
+    return render_template_string(_ERROR_TEMPLATE, reason=reason), 400
+
+
+class GrottocenterSecurityManager(SupersetSecurityManager):
+    """Custom security manager with GC SSO support."""
+
+    def register_views(self) -> None:
+        """Register parent views then add SSO route.
+
+        We register the SSO endpoint directly on the Flask app (not via FAB)
+        to ensure it is publicly accessible without Flask-Login authentication.
+        The route is also exempted from CSRF since the token itself serves as
+        the authentication proof (it's a cross-origin POST from grottocenter.org).
+        """
+        super().register_views()
+
+        security_manager = self
+
+        @self.appbuilder.app.route("/login/sso", methods=["POST"])
+        def login_sso():
+            """Handle SSO login via JWT from GC API (public endpoint)."""
+            try:
+                return security_manager._handle_sso_login()
+            except Exception:
+                logger.exception("Unexpected error during SSO login")
+                return _render_error("An unexpected error occurred.")
+
+        # Exempt from CSRF — the JWT itself is the proof of authenticity
+        csrf = self.appbuilder.app.extensions.get("csrf")
+        if csrf:
+            csrf.exempt(login_sso)
+
+    def _handle_sso_login(self):
+        """Core SSO login logic — verify JWT, provision user, establish session."""
+        # 1. Extract token
+        token_str = request.form.get("token", "").strip()
+        if not token_str:
+            return _render_error("No authentication token was provided.")
+
+        # 2. Get the SSO secret
+        sso_secret = current_app.config.get("SUPERSET_SSO_SECRET", "").strip()
+        if not sso_secret:
+            logger.error("SUPERSET_SSO_SECRET is not configured")
+            return _render_error("An unexpected error occurred.")
+
+        # 3. Verify JWT signature
+        try:
+            payload = jwt.decode(
+                token_str,
+                sso_secret,
+                algorithms=["HS256"],
+                options={"verify_exp": True, "verify_aud": False, "verify_sub": False},
+            )
+        except jwt.ExpiredSignatureError:
+            return _render_error("The authentication token has expired.")
+        except jwt.InvalidTokenError:
+            return _render_error("The authentication token is invalid.")
+
+        # 4. Verify audience
+        if payload.get("aud") != EXPECTED_AUDIENCE:
+            return _render_error("This token is not intended for this service.")
+
+        # 5. Verify iat freshness (within 30s)
+        iat = payload.get("iat")
+        if iat is None or (time.time() - iat) > TOKEN_MAX_AGE_SECONDS:
+            return _render_error("The authentication token has expired.")
+
+        # 6. Check JTI for replay
+        jti = payload.get("jti")
+        if not jti:
+            return _render_error("The authentication token is invalid.")
+
+        if _jti_store.contains(jti):
+            return _render_error("This token has already been used.")
+
+        _jti_store.add(jti)
+
+        # 7. JIT provision or update user
+        email = payload.get("email", "")
+        first_name = payload.get("firstName", "")
+        last_name = payload.get("lastName", "")
+
+        if not email:
+            return _render_error("The authentication token is invalid.")
+
+        user = self._jit_provision_user(email, first_name, last_name)
+        if user is None:
+            return _render_error("Service configuration error. Please contact support.")
+
+        # 8. Establish session
+        login_user(user)
+
+        # 9. Redirect to landing page
+        return redirect("/superset/welcome/")
+
+    def _jit_provision_user(self, email: str, first_name: str, last_name: str):
+        """Create or update a Superset user from SSO claims.
+
+        Returns the user object, or None if the GC_Creator role is missing.
+        """
+        # Look up existing user by email (used as username)
+        user = self.find_user(username=email)
+
+        if user is None:
+            # Create new user — need the GC_Creator role
+            gc_role = self.find_role(GC_CREATOR_ROLE_NAME)
+            if gc_role is None:
+                logger.error(
+                    f"Role '{GC_CREATOR_ROLE_NAME}' not found in Superset. "
+                    "Cannot provision SSO user."
+                )
+                return None
+
+            user = self.add_user(
+                username=email,
+                first_name=first_name or "Caver",
+                last_name=last_name or "",
+                email=email,
+                role=gc_role,
+            )
+            if not user:
+                logger.error(f"SSO: Failed to create Superset user '{email}'")
+                return None
+            logger.info(f"SSO: Created new Superset user '{email}'")
+        else:
+            # Update name if changed (never modify roles)
+            changed = False
+            if user.first_name != first_name:
+                user.first_name = first_name or "Caver"
+                changed = True
+            if user.last_name != last_name:
+                user.last_name = last_name or ""
+                changed = True
+            if changed:
+                from superset.extensions import db
+
+                db.session.commit()
+                logger.info(f"SSO: Updated name for Superset user '{email}'")
+
+        return user

--- a/docker/superset/jti_store.py
+++ b/docker/superset/jti_store.py
@@ -1,0 +1,38 @@
+"""
+In-memory JTI (JWT ID) tracking with automatic time-based eviction.
+
+Prevents token replay by tracking consumed jti values for a configurable
+TTL (default 30 seconds). After the TTL expires, entries are automatically
+evicted to keep memory bounded.
+"""
+
+import time
+import threading
+
+
+class JtiStore:
+    """Thread-safe in-memory JTI store with automatic eviction."""
+
+    def __init__(self, ttl_seconds: int = 30):
+        self._store: dict[str, float] = {}  # jti → insertion_time
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+
+    def contains(self, jti: str) -> bool:
+        """Check if a jti has been consumed (evicts stale entries first)."""
+        with self._lock:
+            self._evict_stale()
+            return jti in self._store
+
+    def add(self, jti: str) -> None:
+        """Record a jti as consumed."""
+        with self._lock:
+            self._store[jti] = time.time()
+
+    def _evict_stale(self) -> None:
+        """Remove entries older than the TTL."""
+        now = time.time()
+        cutoff = now - self._ttl
+        self._store = {
+            jti: ts for jti, ts in self._store.items() if ts > cutoff
+        }

--- a/docker/superset/jti_store.py
+++ b/docker/superset/jti_store.py
@@ -29,6 +29,18 @@ class JtiStore:
         with self._lock:
             self._store[jti] = time.time()
 
+    def add_if_new(self, jti: str) -> bool:
+        """Atomically check and add a jti. Returns True if added, False if already present.
+
+        This avoids the TOCTOU race between separate contains() + add() calls.
+        """
+        with self._lock:
+            self._evict_stale()
+            if jti in self._store:
+                return False
+            self._store[jti] = time.time()
+            return True
+
     def _evict_stale(self) -> None:
         """Remove entries older than the TTL."""
         now = time.time()

--- a/docker/superset/startup.sh
+++ b/docker/superset/startup.sh
@@ -15,5 +15,9 @@ superset fab create-admin \
 echo "==> Initializing Superset..."
 superset init
 
+# Used by production (Dockerfile CMD runs startup.sh)
+echo "==> Ensuring GC_Creator role exists with correct permissions..."
+python /app/pythonpath/gc_creator_permissions.py
+
 echo "==> Starting server..."
 exec /usr/bin/run-server.sh

--- a/docker/superset/superset_config.py
+++ b/docker/superset/superset_config.py
@@ -2,9 +2,26 @@
 Superset configuration for Grottocenter local development.
 """
 import os
+from datetime import timedelta
 
 # Security
 SECRET_KEY = os.environ.get('SUPERSET_SECRET_KEY', 'grottocenter_local_dev_secret_key_change_in_prod')
+
+# ============================================================
+# Custom Security Manager (SSO via GC API)
+# ============================================================
+try:
+    from gc_security_manager import GrottocenterSecurityManager
+    CUSTOM_SECURITY_MANAGER = GrottocenterSecurityManager
+except ImportError:
+    pass  # SSO module not available (e.g., local dev without image rebuild)
+
+# SSO secret for verifying tokens from GC API (must match SSO_SALT_SUPERSET on API side).
+# Set via env var in docker-compose (local dev) or Azure App Settings (production).
+SUPERSET_SSO_SECRET = os.environ.get('SUPERSET_SSO_SECRET', '')
+
+# Session lifetime: 1 hour (for SSO-provisioned users)
+PERMANENT_SESSION_LIFETIME = timedelta(hours=1)
 
 # ============================================================
 # Branding

--- a/docker/superset/superset_config.py
+++ b/docker/superset/superset_config.py
@@ -18,6 +18,8 @@ except ImportError:
 
 # SSO secret for verifying tokens from GC API (must match SSO_SALT_SUPERSET on API side).
 # Set via env var in docker-compose (local dev) or Azure App Settings (production).
+# Empty string is intentional fallback — gc_security_manager rejects all tokens if unset,
+# which is fail-safe. For local dev, docker-compose.superset.yml passes this env var.
 SUPERSET_SSO_SECRET = os.environ.get('SUPERSET_SSO_SECRET', '')
 
 # Session lifetime: 1 hour (for SSO-provisioned users)

--- a/docker/superset/templates/sso_error.html
+++ b/docker/superset/templates/sso_error.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grottocenter – SSO Login Error</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+      color: #333;
+    }
+    .container {
+      text-align: center;
+      max-width: 420px;
+      padding: 2rem;
+    }
+    h1 {
+      font-size: 1.5rem;
+      color: #5D4037;
+      margin-bottom: 1rem;
+    }
+    p {
+      font-size: 1rem;
+      line-height: 1.5;
+      margin-bottom: 1.5rem;
+    }
+    .hint {
+      font-size: 0.875rem;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Login Failed</h1>
+    <p>{{ reason }}</p>
+    <p class="hint">Please close this tab and try again from Grottocenter.</p>
+  </div>
+</body>
+</html>

--- a/docker/superset/tests/test_gc_security_manager.py
+++ b/docker/superset/tests/test_gc_security_manager.py
@@ -42,7 +42,7 @@ class TestJwtVerification:
 
     def test_valid_token_decodes_successfully(self):
         token = _make_token()
-        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], audience="superset", options={"verify_sub": False})
         assert decoded["sub"] == 42
         assert decoded["aud"] == "superset"
         assert decoded["email"] == "42@grottocenter.org"
@@ -50,26 +50,26 @@ class TestJwtVerification:
     def test_invalid_signature_raises(self):
         token = _make_token(secret="wrong-secret")
         with pytest.raises(jwt.InvalidSignatureError):
-            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], audience="superset", options={"verify_sub": False})
 
     def test_expired_token_raises(self):
         token = _make_token(exp_offset=-10)
         with pytest.raises(jwt.ExpiredSignatureError):
-            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], audience="superset", options={"verify_sub": False})
 
     def test_wrong_audience_detected(self):
         payload = dict(VALID_PAYLOAD)
         payload["aud"] = "not-superset"
         token = _make_token(payload=payload)
-        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
-        assert decoded["aud"] != "superset"
+        with pytest.raises(jwt.InvalidAudienceError):
+            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], audience="superset", options={"verify_sub": False})
 
     def test_iat_freshness_check(self):
         """Token with iat older than 30s should be considered expired."""
         payload = dict(VALID_PAYLOAD)
         payload["iat"] = int(time.time()) - 60  # 60s ago
         token = _make_token(payload=payload, exp_offset=120)
-        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_exp": False, "verify_sub": False})
+        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], audience="superset", options={"verify_exp": False, "verify_sub": False})
         assert (time.time() - decoded["iat"]) > 30
 
 

--- a/docker/superset/tests/test_gc_security_manager.py
+++ b/docker/superset/tests/test_gc_security_manager.py
@@ -1,0 +1,119 @@
+"""Unit tests for the GC security manager SSO logic.
+
+These tests validate the JWT verification, JTI tracking, and error page
+rendering without requiring a full Superset application context.
+"""
+
+import os
+import sys
+import time
+
+import jwt
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from jti_store import JtiStore
+
+# Test constants
+TEST_SECRET = "test-sso-secret-for-unit-tests"
+VALID_PAYLOAD = {
+    "sub": 42,
+    "aud": "superset",
+    "email": "42@grottocenter.org",
+    "firstName": "Jean",
+    "lastName": "Dupont",
+    "jti": "test-unique-jti-001",
+    "iat": int(time.time()),
+}
+
+
+def _make_token(payload=None, secret=None, exp_offset=30):
+    """Helper to create a signed JWT."""
+    p = dict(payload or VALID_PAYLOAD)
+    if "iat" not in (payload or {}):
+        p["iat"] = int(time.time())
+    p["exp"] = p["iat"] + exp_offset
+    return jwt.encode(p, secret or TEST_SECRET, algorithm="HS256")
+
+
+class TestJwtVerification:
+    """Test JWT signature, audience, and freshness verification."""
+
+    def test_valid_token_decodes_successfully(self):
+        token = _make_token()
+        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+        assert decoded["sub"] == 42
+        assert decoded["aud"] == "superset"
+        assert decoded["email"] == "42@grottocenter.org"
+
+    def test_invalid_signature_raises(self):
+        token = _make_token(secret="wrong-secret")
+        with pytest.raises(jwt.InvalidSignatureError):
+            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+
+    def test_expired_token_raises(self):
+        token = _make_token(exp_offset=-10)
+        with pytest.raises(jwt.ExpiredSignatureError):
+            jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+
+    def test_wrong_audience_detected(self):
+        payload = dict(VALID_PAYLOAD)
+        payload["aud"] = "not-superset"
+        token = _make_token(payload=payload)
+        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_sub": False})
+        assert decoded["aud"] != "superset"
+
+    def test_iat_freshness_check(self):
+        """Token with iat older than 30s should be considered expired."""
+        payload = dict(VALID_PAYLOAD)
+        payload["iat"] = int(time.time()) - 60  # 60s ago
+        token = _make_token(payload=payload, exp_offset=120)
+        decoded = jwt.decode(token, TEST_SECRET, algorithms=["HS256"], options={"verify_aud": False, "verify_exp": False, "verify_sub": False})
+        assert (time.time() - decoded["iat"]) > 30
+
+
+class TestJtiReplayProtection:
+    """Test that consumed JTIs are rejected on reuse."""
+
+    def test_first_use_passes(self):
+        store = JtiStore(ttl_seconds=30)
+        assert store.contains("fresh-jti") is False
+
+    def test_second_use_rejected(self):
+        store = JtiStore(ttl_seconds=30)
+        store.add("used-jti")
+        assert store.contains("used-jti") is True
+
+    def test_eviction_clears_old_entries(self):
+        store = JtiStore(ttl_seconds=0)
+        store.add("old-jti")
+        time.sleep(0.01)
+        assert store.contains("old-jti") is False
+
+
+class TestErrorPageRendering:
+    """Test that error pages don't expose sensitive information."""
+
+    def test_error_template_contains_reason_placeholder(self):
+        template_path = os.path.join(
+            os.path.dirname(__file__), "..", "templates", "sso_error.html"
+        )
+        with open(template_path, "r") as f:
+            content = f.read()
+
+        assert "{{ reason }}" in content
+        assert "close this tab and try again from Grottocenter" in content
+
+    def test_error_template_does_not_contain_secrets(self):
+        template_path = os.path.join(
+            os.path.dirname(__file__), "..", "templates", "sso_error.html"
+        )
+        with open(template_path, "r") as f:
+            content = f.read()
+
+        # Should not contain any env var references, stack trace patterns, or paths
+        assert "SUPERSET_SSO_SECRET" not in content
+        assert "SSO_SALT" not in content
+        assert "traceback" not in content.lower()
+        assert "/app/pythonpath" not in content

--- a/docker/superset/tests/test_gc_security_manager_properties.py
+++ b/docker/superset/tests/test_gc_security_manager_properties.py
@@ -1,0 +1,132 @@
+"""Property-based tests for the GC security manager SSO logic.
+
+Uses Hypothesis to validate correctness properties from the design document.
+"""
+
+import os
+import sys
+import time
+
+import jwt
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from jti_store import JtiStore
+
+TEST_SECRET = "property-test-secret"
+
+
+# --- Strategies ---
+
+valid_payload_st = st.fixed_dictionaries({
+    "sub": st.integers(min_value=1, max_value=999999),
+    "aud": st.just("superset"),
+    "email": st.from_regex(r"[0-9]+@grottocenter\.org", fullmatch=True),
+    "firstName": st.text(min_size=0, max_size=50),
+    "lastName": st.text(min_size=0, max_size=50),
+    "jti": st.uuids().map(str),
+})
+
+non_superset_aud_st = st.text(min_size=1, max_size=20).filter(
+    lambda s: s != "superset"
+)
+
+secret_st = st.text(min_size=1, max_size=64).filter(lambda s: len(s.strip()) > 0)
+
+
+def _sign(payload, secret=TEST_SECRET, exp_offset=30):
+    """Sign a payload as JWT."""
+    p = dict(payload)
+    p["iat"] = int(time.time())
+    p["exp"] = p["iat"] + exp_offset
+    return jwt.encode(p, secret, algorithm="HS256")
+
+
+class TestProperty6JwtVerificationGate:
+    """Property 6: Token accepted iff signature + aud + iat all pass."""
+
+    @settings(max_examples=100)
+    @given(payload=valid_payload_st, secret=secret_st)
+    def test_valid_token_accepted(self, payload, secret):
+        """Valid tokens pass all checks."""
+        token = _sign(payload, secret=secret)
+        decoded = jwt.decode(
+            token, secret, algorithms=["HS256"],
+            options={"verify_aud": False, "verify_sub": False}
+        )
+        assert decoded["aud"] == "superset"
+        assert (time.time() - decoded["iat"]) <= 30
+
+    @settings(max_examples=100)
+    @given(payload=valid_payload_st, sign_secret=secret_st, verify_secret=secret_st)
+    def test_wrong_secret_rejected(self, payload, sign_secret, verify_secret):
+        """Tokens signed with a different secret are rejected."""
+        assume(sign_secret != verify_secret)
+        token = _sign(payload, secret=sign_secret)
+        with pytest.raises(jwt.InvalidSignatureError):
+            jwt.decode(
+                token, verify_secret, algorithms=["HS256"],
+                options={"verify_aud": False, "verify_sub": False}
+            )
+
+    @settings(max_examples=100)
+    @given(payload=valid_payload_st, wrong_aud=non_superset_aud_st)
+    def test_wrong_audience_rejected(self, payload, wrong_aud):
+        """Tokens with non-superset audience are rejected at application level."""
+        payload_copy = dict(payload)
+        payload_copy["aud"] = wrong_aud
+        token = _sign(payload_copy)
+        decoded = jwt.decode(
+            token, TEST_SECRET, algorithms=["HS256"],
+            options={"verify_aud": False, "verify_sub": False}
+        )
+        assert decoded["aud"] != "superset"
+
+
+class TestProperty7ReplaySingleUse:
+    """Property 7: After consumption, same JTI is rejected."""
+
+    @settings(max_examples=100)
+    @given(jti=st.uuids().map(str))
+    def test_consumed_jti_is_rejected(self, jti):
+        """Once added, a JTI is detected as already consumed."""
+        store = JtiStore(ttl_seconds=30)
+        assert store.contains(jti) is False
+        store.add(jti)
+        assert store.contains(jti) is True
+
+
+class TestProperty10ErrorPagesSafe:
+    """Property 10: Error pages are safe and informative."""
+
+    FORBIDDEN_PATTERNS = [
+        "SUPERSET_SSO_SECRET",
+        "SSO_SALT_SUPERSET",
+        "traceback",
+        "Traceback",
+        "/app/pythonpath",
+        "File \"",
+    ]
+
+    def test_template_contains_required_elements(self):
+        template_path = os.path.join(
+            os.path.dirname(__file__), "..", "templates", "sso_error.html"
+        )
+        with open(template_path, "r") as f:
+            content = f.read()
+
+        assert "{{ reason }}" in content
+        assert "close this tab and try again" in content
+
+    def test_template_excludes_sensitive_content(self):
+        template_path = os.path.join(
+            os.path.dirname(__file__), "..", "templates", "sso_error.html"
+        )
+        with open(template_path, "r") as f:
+            content = f.read()
+
+        for pattern in self.FORBIDDEN_PATTERNS:
+            assert pattern not in content, f"Template should not contain: {pattern}"

--- a/docker/superset/tests/test_gc_security_manager_properties.py
+++ b/docker/superset/tests/test_gc_security_manager_properties.py
@@ -55,7 +55,7 @@ class TestProperty6JwtVerificationGate:
         token = _sign(payload, secret=secret)
         decoded = jwt.decode(
             token, secret, algorithms=["HS256"],
-            options={"verify_aud": False, "verify_sub": False}
+            audience="superset", options={"verify_sub": False}
         )
         assert decoded["aud"] == "superset"
         assert (time.time() - decoded["iat"]) <= 30
@@ -69,21 +69,21 @@ class TestProperty6JwtVerificationGate:
         with pytest.raises(jwt.InvalidSignatureError):
             jwt.decode(
                 token, verify_secret, algorithms=["HS256"],
-                options={"verify_aud": False, "verify_sub": False}
+                audience="superset", options={"verify_sub": False}
             )
 
     @settings(max_examples=100)
     @given(payload=valid_payload_st, wrong_aud=non_superset_aud_st)
     def test_wrong_audience_rejected(self, payload, wrong_aud):
-        """Tokens with non-superset audience are rejected at application level."""
+        """Tokens with non-superset audience are rejected by PyJWT."""
         payload_copy = dict(payload)
         payload_copy["aud"] = wrong_aud
         token = _sign(payload_copy)
-        decoded = jwt.decode(
-            token, TEST_SECRET, algorithms=["HS256"],
-            options={"verify_aud": False, "verify_sub": False}
-        )
-        assert decoded["aud"] != "superset"
+        with pytest.raises(jwt.InvalidAudienceError):
+            jwt.decode(
+                token, TEST_SECRET, algorithms=["HS256"],
+                audience="superset", options={"verify_sub": False}
+            )
 
 
 class TestProperty7ReplaySingleUse:

--- a/docker/superset/tests/test_jti_store.py
+++ b/docker/superset/tests/test_jti_store.py
@@ -40,3 +40,18 @@ class TestJtiStore:
         store.add("dup-jti")
         store.add("dup-jti")
         assert store.contains("dup-jti") is True
+
+    def test_add_if_new_returns_true_for_new_jti(self):
+        store = JtiStore(ttl_seconds=30)
+        assert store.add_if_new("fresh-jti") is True
+
+    def test_add_if_new_returns_false_for_existing_jti(self):
+        store = JtiStore(ttl_seconds=30)
+        store.add_if_new("used-jti")
+        assert store.add_if_new("used-jti") is False
+
+    def test_add_if_new_is_atomic(self):
+        """Two sequential add_if_new calls — only first succeeds."""
+        store = JtiStore(ttl_seconds=30)
+        assert store.add_if_new("race-jti") is True
+        assert store.add_if_new("race-jti") is False

--- a/docker/superset/tests/test_jti_store.py
+++ b/docker/superset/tests/test_jti_store.py
@@ -1,0 +1,42 @@
+"""Unit tests for the JTI store."""
+
+import time
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from jti_store import JtiStore
+
+
+class TestJtiStore:
+    """Test JTI store add/contains/eviction."""
+
+    def test_contains_returns_false_for_unknown_jti(self):
+        store = JtiStore(ttl_seconds=30)
+        assert store.contains("unknown-jti") is False
+
+    def test_contains_returns_true_after_add(self):
+        store = JtiStore(ttl_seconds=30)
+        store.add("test-jti-1")
+        assert store.contains("test-jti-1") is True
+
+    def test_eviction_after_ttl(self):
+        store = JtiStore(ttl_seconds=0)  # immediate eviction
+        store.add("expired-jti")
+        time.sleep(0.01)
+        assert store.contains("expired-jti") is False
+
+    def test_multiple_jtis_tracked_independently(self):
+        store = JtiStore(ttl_seconds=30)
+        store.add("jti-a")
+        store.add("jti-b")
+        assert store.contains("jti-a") is True
+        assert store.contains("jti-b") is True
+        assert store.contains("jti-c") is False
+
+    def test_add_same_jti_twice_still_detected(self):
+        store = JtiStore(ttl_seconds=30)
+        store.add("dup-jti")
+        store.add("dup-jti")
+        assert store.contains("dup-jti") is True

--- a/test/integration/1_services/SsoService.property.test.js
+++ b/test/integration/1_services/SsoService.property.test.js
@@ -1,0 +1,138 @@
+const should = require('should');
+const fc = require('fast-check');
+const jwt = require('jsonwebtoken');
+const SsoService = require('../../../api/services/SsoService');
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// Arbitrary for caver-like objects
+const caverArb = fc.record({
+  id: fc.integer({ min: 1, max: 999999 }),
+  name: fc.oneof(fc.string({ minLength: 0, maxLength: 50 }), fc.constant(null)),
+  surname: fc.oneof(
+    fc.string({ minLength: 0, maxLength: 50 }),
+    fc.constant(null)
+  ),
+});
+
+// Arbitrary for invalid product values
+const invalidProductArb = fc.oneof(
+  fc.constant(undefined),
+  fc.constant(null),
+  fc.constant(''),
+  fc.integer(),
+  fc.boolean(),
+  fc
+    .string({ minLength: 1, maxLength: 20 })
+    .filter((s) => !Object.keys(SsoService.PRODUCT_REGISTRY).includes(s))
+);
+
+describe('SsoService - Property-Based Tests', () => {
+  afterEach(() => {
+    delete process.env.SSO_SALT_SUPERSET;
+  });
+
+  describe('Property 1: Payload construction correctness', () => {
+    it('should produce correct payload fields for any caver and valid product', function payloadCorrectness() {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(caverArb, (caver) => {
+          const payload = SsoService.buildPayload(caver, 'superset');
+
+          should(payload.sub).equal(caver.id);
+          should(payload.aud).equal('superset');
+          should(payload.email).equal(`${caver.id}@grottocenter.org`);
+          should(payload.firstName).equal(caver.name || '');
+          should(payload.lastName).equal(caver.surname || '');
+          should(payload.jti).match(UUID_V4_REGEX);
+          should(typeof payload.jti).equal('string');
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 2: Token signing round-trip', () => {
+    it('should produce a verifiable token with exp - iat === 30', () => {
+      const saltArb = fc
+        .string({ minLength: 1, maxLength: 64 })
+        .filter((s) => s.trim().length > 0);
+
+      fc.assert(
+        fc.property(caverArb, saltArb, (caver, salt) => {
+          process.env.SSO_SALT_SUPERSET = salt;
+          const result = SsoService.issueToken(caver, 'superset');
+
+          should(result.token).be.a.String();
+
+          const decoded = jwt.verify(result.token, salt);
+          should(decoded.sub).equal(caver.id);
+          should(decoded.aud).equal('superset');
+          should(decoded.email).equal(`${caver.id}@grottocenter.org`);
+          should(decoded.exp - decoded.iat).equal(30);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 3: JTI uniqueness', () => {
+    it('should generate distinct jti values across multiple calls', () => {
+      fc.assert(
+        fc.property(
+          caverArb,
+          fc.integer({ min: 2, max: 20 }),
+          (caver, count) => {
+            const jtis = new Set();
+            for (let i = 0; i < count; i += 1) {
+              const payload = SsoService.buildPayload(caver, 'superset');
+              should(payload.jti).match(UUID_V4_REGEX);
+              jtis.add(payload.jti);
+            }
+            should(jtis.size).equal(count);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 4: Invalid product rejection', () => {
+    it('should return error with status 400 for any invalid product', () => {
+      fc.assert(
+        fc.property(invalidProductArb, (product) => {
+          const result = SsoService.resolveSalt(product);
+          should(result.error).be.a.String();
+          should(result.status).equal(400);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Property 5: Missing salt returns server error', () => {
+    // NOTE: This test relies on NODE_ENV !== 'development' (test runner uses NODE_ENV=test).
+    // In development mode, the DEV_FALLBACK_SALT would activate and mask the 500.
+    it('should return error with status 500 for any whitespace-only or empty salt', () => {
+      const whitespaceSaltArb = fc.oneof(
+        fc.constant(''),
+        fc.constant('   '),
+        fc.constant('\t'),
+        fc.constant('\n'),
+        fc.constant('  \t  '),
+        fc.constant('\n\t ')
+      );
+
+      fc.assert(
+        fc.property(whitespaceSaltArb, (salt) => {
+          process.env.SSO_SALT_SUPERSET = salt;
+          const result = SsoService.resolveSalt('superset');
+          should(result.error).be.a.String();
+          should(result.status).equal(500);
+        }),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/test/integration/1_services/SsoService.test.js
+++ b/test/integration/1_services/SsoService.test.js
@@ -145,6 +145,8 @@ describe('SsoService', () => {
     });
 
     it('should return error when salt is not configured', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
       delete process.env.SSO_SALT_SUPERSET;
       const caver = { id: 1, name: 'Test', surname: 'User' };
       const result = SsoService.issueToken(caver, 'superset');
@@ -152,6 +154,7 @@ describe('SsoService', () => {
       should(result.error).be.a.String();
       should(result.status).equal(500);
       should(result.token).be.undefined();
+      process.env.NODE_ENV = originalEnv;
     });
   });
 });

--- a/test/integration/1_services/SsoService.test.js
+++ b/test/integration/1_services/SsoService.test.js
@@ -1,0 +1,148 @@
+const should = require('should');
+const SsoService = require('../../../api/services/SsoService');
+
+describe('SsoService', () => {
+  describe('resolveSalt()', () => {
+    afterEach(() => {
+      delete process.env.SSO_SALT_SUPERSET;
+    });
+
+    it('should return error 400 when product is missing', () => {
+      const result = SsoService.resolveSalt(undefined);
+      should(result.error).be.a.String();
+      should(result.status).equal(400);
+    });
+
+    it('should return error 400 when product is empty string', () => {
+      const result = SsoService.resolveSalt('');
+      should(result.error).be.a.String();
+      should(result.status).equal(400);
+    });
+
+    it('should return error 400 when product is not a string', () => {
+      const result = SsoService.resolveSalt(123);
+      should(result.error).be.a.String();
+      should(result.status).equal(400);
+    });
+
+    it('should return error 400 for unknown product', () => {
+      const result = SsoService.resolveSalt('unknown_product');
+      should(result.error).be.a.String();
+      should(result.status).equal(400);
+      should(result.error).containEql('not supported');
+    });
+
+    it('should return error 500 when env var is not set', () => {
+      delete process.env.SSO_SALT_SUPERSET;
+      const result = SsoService.resolveSalt('superset');
+      should(result.error).be.a.String();
+      should(result.status).equal(500);
+    });
+
+    it('should return error 500 when env var is empty', () => {
+      process.env.SSO_SALT_SUPERSET = '';
+      const result = SsoService.resolveSalt('superset');
+      should(result.error).be.a.String();
+      should(result.status).equal(500);
+    });
+
+    it('should return error 500 when env var is whitespace only', () => {
+      process.env.SSO_SALT_SUPERSET = '   ';
+      const result = SsoService.resolveSalt('superset');
+      should(result.error).be.a.String();
+      should(result.status).equal(500);
+    });
+
+    it('should return salt for valid product with configured env var', () => {
+      process.env.SSO_SALT_SUPERSET = 'test-secret-123';
+      const result = SsoService.resolveSalt('superset');
+      should(result.salt).equal('test-secret-123');
+      should(result.error).be.undefined();
+    });
+  });
+
+  describe('buildPayload()', () => {
+    it('should build correct payload with all caver fields', () => {
+      const caver = { id: 42, name: 'Jean', surname: 'Dupont' };
+      const payload = SsoService.buildPayload(caver, 'superset');
+
+      should(payload.sub).equal(42);
+      should(payload.aud).equal('superset');
+      should(payload.email).equal('42@grottocenter.org');
+      should(payload.firstName).equal('Jean');
+      should(payload.lastName).equal('Dupont');
+      should(payload.jti).match(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('should use empty string for null name', () => {
+      const caver = { id: 1, name: null, surname: 'Smith' };
+      const payload = SsoService.buildPayload(caver, 'superset');
+
+      should(payload.firstName).equal('');
+      should(payload.lastName).equal('Smith');
+    });
+
+    it('should use empty string for undefined surname', () => {
+      const caver = { id: 1, name: 'Test' };
+      const payload = SsoService.buildPayload(caver, 'superset');
+
+      should(payload.firstName).equal('Test');
+      should(payload.lastName).equal('');
+    });
+
+    it('should use empty string for empty name and surname', () => {
+      const caver = { id: 5, name: '', surname: '' };
+      const payload = SsoService.buildPayload(caver, 'superset');
+
+      should(payload.firstName).equal('');
+      should(payload.lastName).equal('');
+    });
+  });
+
+  describe('issueToken()', () => {
+    afterEach(() => {
+      delete process.env.SSO_SALT_SUPERSET;
+    });
+
+    it('should return a signed JWT for valid inputs', () => {
+      process.env.SSO_SALT_SUPERSET = 'my-test-salt';
+      const caver = { id: 10, name: 'Alice', surname: 'Doe' };
+      const result = SsoService.issueToken(caver, 'superset');
+
+      should(result.token).be.a.String();
+      should(result.error).be.undefined();
+
+      // Verify the token can be decoded
+      // eslint-disable-next-line global-require
+      const jsonwebtoken = require('jsonwebtoken');
+      const decoded = jsonwebtoken.verify(result.token, 'my-test-salt');
+      should(decoded.sub).equal(10);
+      should(decoded.aud).equal('superset');
+      should(decoded.email).equal('10@grottocenter.org');
+      should(decoded.firstName).equal('Alice');
+      should(decoded.lastName).equal('Doe');
+      should(decoded.exp - decoded.iat).equal(30);
+    });
+
+    it('should return error for invalid product', () => {
+      const caver = { id: 1, name: 'Test', surname: 'User' };
+      const result = SsoService.issueToken(caver, 'invalid');
+
+      should(result.error).be.a.String();
+      should(result.status).equal(400);
+      should(result.token).be.undefined();
+    });
+
+    it('should return error when salt is not configured', () => {
+      delete process.env.SSO_SALT_SUPERSET;
+      const caver = { id: 1, name: 'Test', surname: 'User' };
+      const result = SsoService.issueToken(caver, 'superset');
+
+      should(result.error).be.a.String();
+      should(result.status).equal(500);
+      should(result.token).be.undefined();
+    });
+  });
+});

--- a/test/integration/1_services/SsoService.test.js
+++ b/test/integration/1_services/SsoService.test.js
@@ -33,24 +33,33 @@ describe('SsoService', () => {
     });
 
     it('should return error 500 when env var is not set', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
       delete process.env.SSO_SALT_SUPERSET;
       const result = SsoService.resolveSalt('superset');
       should(result.error).be.a.String();
       should(result.status).equal(500);
+      process.env.NODE_ENV = originalEnv;
     });
 
     it('should return error 500 when env var is empty', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
       process.env.SSO_SALT_SUPERSET = '';
       const result = SsoService.resolveSalt('superset');
       should(result.error).be.a.String();
       should(result.status).equal(500);
+      process.env.NODE_ENV = originalEnv;
     });
 
     it('should return error 500 when env var is whitespace only', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
       process.env.SSO_SALT_SUPERSET = '   ';
       const result = SsoService.resolveSalt('superset');
       should(result.error).be.a.String();
       should(result.status).equal(500);
+      process.env.NODE_ENV = originalEnv;
     });
 
     it('should return salt for valid product with configured env var', () => {

--- a/test/integration/4_routes/Sso/auth-token.test.js
+++ b/test/integration/4_routes/Sso/auth-token.test.js
@@ -1,0 +1,120 @@
+const supertest = require('supertest');
+const should = require('should');
+const jwt = require('jsonwebtoken');
+const TokenService = require('../../../../api/services/TokenService');
+
+describe('POST /api/v1/sso/auth-token', () => {
+  let authToken;
+  const testSalt = 'integration-test-superset-salt';
+
+  before(() => {
+    // Issue a valid GC auth token for an existing caver fixture
+    authToken = TokenService.issue(
+      { id: 1, groups: [], nickname: 'TestCaver' },
+      3600,
+      'Authentication'
+    );
+    process.env.SSO_SALT_SUPERSET = testSalt;
+  });
+
+  after(() => {
+    delete process.env.SSO_SALT_SUPERSET;
+  });
+
+  describe('Happy path', () => {
+    it('should return 200 with a valid JWT for product "superset"', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', `Bearer ${authToken}`)
+        .set('Content-Type', 'application/json')
+        .send({ product: 'superset' })
+        .expect(200);
+
+      should(res.body).have.property('token');
+      should(res.body.token).be.a.String();
+
+      // Verify the SSO token structure
+      const decoded = jwt.verify(res.body.token, testSalt);
+      should(decoded.sub).equal(1);
+      should(decoded.aud).equal('superset');
+      should(decoded.email).equal('1@grottocenter.org');
+      should(decoded).have.property('firstName');
+      should(decoded).have.property('lastName');
+      should(decoded).have.property('jti');
+      should(decoded.exp - decoded.iat).equal(30);
+    });
+  });
+
+  describe('Validation errors', () => {
+    it('should return 400 when product field is missing', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', `Bearer ${authToken}`)
+        .set('Content-Type', 'application/json')
+        .send({})
+        .expect(400);
+
+      should(res.body).be.an.Object();
+    });
+
+    it('should return 400 when product is empty string', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', `Bearer ${authToken}`)
+        .set('Content-Type', 'application/json')
+        .send({ product: '' })
+        .expect(400);
+
+      should(res.body).be.an.Object();
+    });
+
+    it('should return 400 for unsupported product', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', `Bearer ${authToken}`)
+        .set('Content-Type', 'application/json')
+        .send({ product: 'unknown_product' })
+        .expect(400);
+
+      should(res.body).be.an.Object();
+    });
+  });
+
+  describe('Authentication errors', () => {
+    it('should return 401 without bearer token', async () => {
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Content-Type', 'application/json')
+        .send({ product: 'superset' })
+        .expect(401);
+    });
+
+    it('should return 401 with invalid bearer token', async () => {
+      await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', 'Bearer invalid.token.here')
+        .set('Content-Type', 'application/json')
+        .send({ product: 'superset' })
+        .expect(401);
+    });
+  });
+
+  describe('Configuration errors', () => {
+    it('should return 500 when salt env var is not configured', async () => {
+      const originalSalt = process.env.SSO_SALT_SUPERSET;
+      delete process.env.SSO_SALT_SUPERSET;
+
+      const res = await supertest(sails.hooks.http.app)
+        .post('/api/v1/sso/auth-token')
+        .set('Authorization', `Bearer ${authToken}`)
+        .set('Content-Type', 'application/json')
+        .send({ product: 'superset' })
+        .expect(500);
+
+      should(res.body).be.an.Object();
+
+      // Restore
+      process.env.SSO_SALT_SUPERSET = originalSalt;
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

Implements product-agnostic SSO token issuance and a Superset custom security manager for seamless JIT authentication.

- New endpoint: `POST /api/v1/sso/auth-token` — issues a 30s JWT signed with a per-product salt
- Product registry pattern: add future products by setting an env var (no code changes)
- Superset custom security manager at `/login/sso` — verifies JWT, provisions user, establishes session
- JTI replay protection (in-memory, 30s eviction)
- Synthetic email (`{id}@grottocenter.org`) to avoid PII exposure
- GC_Creator role whitelist permissions script (runs on every boot)
- Closes #1694

## 🤷‍♂️ Why

Users currently need an admin to manually create their Superset account. This enables seamless access: click a button in Grottocenter → authenticated in Superset in a new tab, no separate credentials needed.

## 🔍 How

**GC API side:**
- `SsoService.js` — Product Registry maps `"superset"` → `SSO_SALT_SUPERSET` env var. Builds JWT payload with `sub`, `aud`, synthetic `email`, `firstName`, `lastName`, `jti`, `iat`, `exp`.
- Controller fetches the full caver record (for name/surname), delegates to SsoService.
- Route gated by `tokenAuth` policy (ban/revocation handled by existing `parseAuthToken` middleware).
- Dev fallback salt (gated by `NODE_ENV=development`) matches Superset's docker-compose default.

**Superset side:**
- `gc_security_manager.py` — registers `/login/sso` as a raw Flask route (bypasses FAB auth + CSRF).
- Verifies signature (HS256), audience (`"superset"`), iat freshness (30s), jti uniqueness.
- JIT provisions user with `GC_Creator` role or updates name if changed (never modifies roles on existing users).
- `gc_creator_permissions.py` — whitelist approach, runs on every boot to ensure the role has exactly the right permissions.
- `jti_store.py` — thread-safe in-memory store with automatic 30s eviction.

**Front-end integration** (not in this PR — tracked in grottocenter-front#1413):
- Hidden HTML form with `target="_blank"` submits the JWT to `/login/sso` in a new tab.

## 🧪 Testing

**Node.js (27 tests):**
```bash
npm run test -- --grep "SsoService"
```
- Unit tests: salt resolution, payload construction, token issuance
- Property-based tests (fast-check): payload correctness, signing round-trip, jti uniqueness, invalid product rejection, missing salt
- Integration tests (supertest): happy path, 400/401/500 error cases

**Python (21 tests):**
```bash
python3 -m pytest docker/superset/tests/ -v
```
- JTI store: add/contains/eviction
- JWT verification: signature, audience, expiry, iat freshness
- Property-based tests (hypothesis): verification gate, replay protection, error page safety

**Manual E2E:**
1. `npm run dev` (with or without `SSO_SALT_SUPERSET` — falls back in dev mode)
2. Rebuild Superset: local docker-compose passes `SUPERSET_SSO_SECRET` via env
3. Open `test-sso.html` in browser, click the button — Superset opens authenticated in a new tab

## 📸 Previews

N/A — backend change. The front-end "BI" button will be added in a separate PR (grottocenter-front#1413).
