### PR TITLE
chore(search): remove entrances array from caves Typesense index

### DIFF
--- a/api/dbSync/entities/cave.js
+++ b/api/dbSync/entities/cave.js
@@ -29,19 +29,6 @@ const query = `
 
 async function* processRows(source) {
   for await (const rows of source) {
-    // Keep until frontend migrates from entrances.length to nbEntrances
-    const joins = [
-      {
-        table: 't_entrance',
-        foreignField: 'id_cave',
-        rows,
-        localField: 'entrances',
-        fields: ['id'],
-        transform: (e) => e.id,
-      },
-    ];
-
-    await Promise.all(joins.map((e) => exportUtils.joinMany(e)));
     for (const row of rows) yield row;
   }
 }


### PR DESCRIPTION
## 🤔 What

- Remove the `entrances` array join from the caves Typesense sync pipeline (`api/dbSync/entities/cave.js`)
- Closes #1682

## 🤷‍♂️ Why

The `entrances` array was only indexed so the frontend could derive a count via `.length`. With `nbEntrances` as a first-class scalar (added in #1676), the array is redundant — it wastes index RAM and inflates payloads.

The frontend has migrated to use `nbEntrances` (GrottoCenter/grottocenter-front#1402).

## 🔍 How

Removed the `entrances` join from `processRows` in `api/dbSync/entities/cave.js`. The Typesense schema and `CaveService.updateInSearch` already only reference the `nbEntrances` scalar — no changes needed there.

After deploy, a full re-sync should be triggered to drop the stale `entrances` field from existing documents in Typesense.

## 🧪 Testing

All existing tests pass (261 passing, 0 failing). No new tests needed — this is a removal of dead code.

## 📸 Previews

N/A
