### PR TITLE
fix(rateLimit): exempt explored entrance DELETE from IP rate limiter

### DIFF
--- a/config/rateLimit/rateLimiter.js
+++ b/config/rateLimit/rateLimiter.js
@@ -134,6 +134,13 @@ module.exports = {
         return true;
       }
 
+      // Removing an entrance from a user's exploration list is a low-risk
+      // self-service action (tokenAuth already ensures ownership). Skip the
+      // restrictive DELETE rate limit so users can freely manage their list.
+      if (/^\/api\/v1\/entrances\/\d+\/cavers\/\d+$/.test(req.path)) {
+        return true;
+      }
+
       // Third-party origins are always limited (handled by generalRateLimit)
       if (req.token && req.headers.origin !== sails.config.custom.baseUrl) {
         sails.log.error(

--- a/test/integration/2_utils/rateLimiter.test.js
+++ b/test/integration/2_utils/rateLimiter.test.js
@@ -291,6 +291,22 @@ describe('Rate Limiter', () => {
           await agent.delete('/test').expect(200);
         }
       });
+
+      it('should skip rate limiting for explored entrance DELETE route', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete(
+          '/api/v1/entrances/:entranceId/cavers/:caverId',
+          (req, res) => res.status(200).send('ok')
+        );
+
+        const agent = supertest.agent(app);
+        // Send more than the user delete limit — all should pass
+        for (let i = 0; i < TEST_USER_DELETE_LIMIT + 5; i += 1) {
+          await agent.delete('/api/v1/entrances/42/cavers/7').expect(200);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

- Exempt the `DELETE /api/v1/entrances/:entranceId/cavers/:caverId` route from the IP-based `deleteRateLimit` middleware.
- Add a unit test confirming the exemption.

## 🤷‍♂️ Why

The `deleteRateLimit` allows regular users only 1 DELETE request per hour per IP. This makes it impractical for a user to manage their exploration list (removing multiple entrances in a session). The endpoint is already protected by `tokenAuth` and only allows users to remove their own entries, so the destructive-action rate limit adds no meaningful protection here.

## 🔍 How

Added a path-based `skip` check in `config/rateLimit/rateLimiter.js` that matches `/api/v1/entrances/<digits>/cavers/<digits>` and returns `true` (skip). The general rate limiter still applies to this route, so it's not unprotected.

## 🧪 Testing

```bash
npm run test -- --grep "Rate Limiter"
```

All 13 rate limiter tests pass, including the new one.

## 📸 Previews

N/A
