### PR TITLE
fix(search): resolve null entrances in cave search results

### DIFF
--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -79,7 +79,7 @@ const c = {
     temperature: source.temperature,
     isDiving: source.isDiving,
     nbEntrances: source.nbEntrances ?? source.entrances?.length ?? 0,
-    entrances: source.entrances?.map((e) => e.id),
+    entrances: source.entrances?.map((e) => e?.id ?? e),
   }),
 
   toCaver: (source, meta) => {

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -79,7 +79,9 @@ const c = {
     temperature: source.temperature,
     isDiving: source.isDiving,
     nbEntrances: source.nbEntrances ?? source.entrances?.length ?? 0,
-    entrances: source.entrances?.map((e) => e?.id ?? e),
+    entrances: source.entrances
+      ?.map((e) => e?.id ?? e)
+      .filter((e) => e != null),
   }),
 
   toCaver: (source, meta) => {

--- a/test/integration/1_services/Converters.test.js
+++ b/test/integration/1_services/Converters.test.js
@@ -237,6 +237,21 @@ describe('Converters Service', () => {
       should(result.entrances).deepEqual(['20', '21']);
     });
 
+    it('should filter out null entries from entrances array', () => {
+      const source = {
+        id: 1,
+        entrances: [{ id: 5 }, null, { id: 6 }, undefined],
+      };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).deepEqual([5, 6]);
+    });
+
+    it('should return an empty array when entrances is empty', () => {
+      const source = { id: 1, entrances: [] };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).deepEqual([]);
+    });
+
     it('should return undefined entrances when field is absent', () => {
       const source = { id: 1, nbEntrances: 0 };
       const result = converters.toSimpleCave(source);

--- a/test/integration/1_services/Converters.test.js
+++ b/test/integration/1_services/Converters.test.js
@@ -204,6 +204,44 @@ describe('Converters Service', () => {
       const result = converters.toSimpleCave(source);
       should(result.exploringOrganizations).be.undefined();
     });
+
+    it('should extract entrance IDs from Waterline objects', () => {
+      const source = {
+        id: 1,
+        entrances: [
+          { id: 5, name: 'Entrance A' },
+          { id: 6, name: 'Entrance B' },
+        ],
+      };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).deepEqual([5, 6]);
+    });
+
+    it('should pass through plain entrance IDs (Typesense format)', () => {
+      const source = {
+        id: 1,
+        nbEntrances: 3,
+        entrances: [20, 21, 25877],
+      };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).deepEqual([20, 21, 25877]);
+    });
+
+    it('should pass through string entrance IDs', () => {
+      const source = {
+        id: 1,
+        nbEntrances: 2,
+        entrances: ['20', '21'],
+      };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).deepEqual(['20', '21']);
+    });
+
+    it('should return undefined entrances when field is absent', () => {
+      const source = { id: 1, nbEntrances: 0 };
+      const result = converters.toSimpleCave(source);
+      should(result.entrances).be.undefined();
+    });
   });
 
   describe('toDocument()', () => {


### PR DESCRIPTION
## 🤔 What

- Fix `entrances` field in cave search results returning `[null, null, ...]` instead of actual entrance IDs
- Add regression tests for `toSimpleCave` entrance ID extraction

## 🤷‍♂️ Why

The quick-search endpoint (`POST /api/v1/search`) returns `null` values in the `entrances` array for cave results. This happens because the production Typesense index stores entrance IDs as plain integers (e.g., `[20, 21, 25877]`), but the `toSimpleCave` converter assumed they would always be Waterline objects with an `.id` property. Calling `.id` on a number yields `undefined`, which JSON serializes as `null`.

## 🔍 How

Changed `source.entrances?.map((e) => e.id)` to `source.entrances?.map((e) => e?.id ?? e)` in `toSimpleCave`. This handles both formats:
- Waterline objects (from DB queries with `.populate()`) → extracts `.id`
- Plain IDs (from Typesense indexed documents) → passes through as-is

## 🧪 Testing

```bash
npm run test -- --grep "toSimpleCave"
```

Four new test cases cover:
1. Waterline objects → extracts IDs
2. Plain numeric IDs (Typesense format) → passes through
3. String IDs → passes through
4. Absent `entrances` field → returns `undefined`
