### PR TITLE
Feat/1684 massif sensitivity status lock

### DIFF
--- a/api/controllers/v1/entrance/create.js
+++ b/api/controllers/v1/entrance/create.js
@@ -1,5 +1,6 @@
 const ControllerService = require('../../../services/ControllerService');
 const EntranceService = require('../../../services/EntranceService');
+const RightService = require('../../../services/RightService');
 const { validateNameLength } = require('../../../utils/nameValidation');
 
 module.exports = async (req, res) => {
@@ -29,6 +30,15 @@ module.exports = async (req, res) => {
     dateInscription: new Date(),
     isOfInterest: false,
   };
+
+  // Only administrators can lock sensitivity at creation time
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  if (!isAdmin) {
+    delete cleanedData.isSensitiveLocked;
+  }
 
   const nameDescLocData =
     EntranceService.getConvertedNameFromClientRequest(req);

--- a/api/controllers/v1/entrance/update.js
+++ b/api/controllers/v1/entrance/update.js
@@ -40,7 +40,7 @@ module.exports = async (req, res) => {
       newIsSensitiveValue !== currentEntrance.isSensitive;
     if (currentEntrance.isSensitiveLocked && wantsSensitiveChange) {
       return res.forbidden(
-        `The sensitivity of this entrance is locked. Only an administrator can change it.`
+        'The sensitivity of this entrance is locked. Only an administrator can change it.'
       );
     }
   }

--- a/api/controllers/v1/entrance/update.js
+++ b/api/controllers/v1/entrance/update.js
@@ -29,6 +29,22 @@ module.exports = async (req, res) => {
 
   // Check if sensitive change is permitted
   const newIsSensitiveValue = cleanedData.isSensitive;
+
+  if (!isAdmin) {
+    // Non-admins cannot change the sensitivity lock
+    delete cleanedData.isSensitiveLocked;
+
+    // When sensitivity is locked, only admins may change isSensitive (either way)
+    const wantsSensitiveChange =
+      newIsSensitiveValue !== undefined &&
+      newIsSensitiveValue !== currentEntrance.isSensitive;
+    if (currentEntrance.isSensitiveLocked && wantsSensitiveChange) {
+      return res.forbidden(
+        `The sensitivity of this entrance is locked. Only an administrator can change it.`
+      );
+    }
+  }
+
   if (
     !isAdmin &&
     newIsSensitiveValue === false &&

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -24,6 +24,15 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
+  // Sensitivity is frozen while the massif is locked
+  if (massif.isSensitiveLocked) {
+    return res.forbidden('The sensitivity of this massif is locked.');
+  }
+
+  // Count entrances that will be skipped because their sensitivity is locked
+  const skippedLockedCount =
+    await MassifService.countLockedUnsensitiveEntrances(massifId);
+
   // Idempotency: skip if already sensitive
   if (massif.isSensitive) {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
@@ -32,6 +41,7 @@ module.exports = async (req, res) => {
       null,
       {
         count: 0,
+        skippedLockedCount,
         massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.mark-sensitive' },
@@ -66,6 +76,7 @@ module.exports = async (req, res) => {
       null,
       {
         count: updatedEntranceIds.length,
+        skippedLockedCount,
         massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.mark-sensitive' },

--- a/api/controllers/v1/massif/mark-sensitive.js
+++ b/api/controllers/v1/massif/mark-sensitive.js
@@ -29,11 +29,7 @@ module.exports = async (req, res) => {
     return res.forbidden('The sensitivity of this massif is locked.');
   }
 
-  // Count entrances that will be skipped because their sensitivity is locked
-  const skippedLockedCount =
-    await MassifService.countLockedUnsensitiveEntrances(massifId);
-
-  // Idempotency: skip if already sensitive
+  // Idempotency: skip if already sensitive (no entrances are touched)
   if (massif.isSensitive) {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);
     return ControllerService.treat(
@@ -41,13 +37,17 @@ module.exports = async (req, res) => {
       null,
       {
         count: 0,
-        skippedLockedCount,
+        skippedLockedCount: 0,
         massif: toMassif(updatedMassif),
       },
       { controllerMethod: 'MassifController.mark-sensitive' },
       res
     );
   }
+
+  // Count entrances that will be skipped because their sensitivity is locked
+  const skippedLockedCount =
+    await MassifService.countLockedUnsensitiveEntrances(massifId);
 
   try {
     // Set the massif as sensitive and get IDs of entrances that were updated

--- a/api/controllers/v1/massif/preview-sensitive.js
+++ b/api/controllers/v1/massif/preview-sensitive.js
@@ -24,11 +24,13 @@ module.exports = async (req, res) => {
 
   try {
     const count = await MassifService.countUnsensitiveEntrances(massifId);
+    const lockedCount =
+      await MassifService.countLockedUnsensitiveEntrances(massifId);
 
     return ControllerService.treat(
       req,
       null,
-      { count },
+      { count, lockedCount },
       { controllerMethod: 'MassifController.preview-sensitive' },
       res
     );

--- a/api/controllers/v1/massif/unmark-sensitive.js
+++ b/api/controllers/v1/massif/unmark-sensitive.js
@@ -23,6 +23,11 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
+  // Sensitivity is frozen while the massif is locked
+  if (massif.isSensitiveLocked) {
+    return res.forbidden('The sensitivity of this massif is locked.');
+  }
+
   // Idempotency: skip if already non-sensitive
   if (!massif.isSensitive) {
     const updatedMassif = await MassifService.getPopulatedMassif(massifId);

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -1,6 +1,7 @@
 const ControllerService = require('../../../services/ControllerService');
 const MassifService = require('../../../services/MassifService');
 const NotificationService = require('../../../services/NotificationService');
+const RightService = require('../../../services/RightService');
 const { toMassif } = require('../../../services/mapping/converters');
 const { validateNameLength } = require('../../../utils/nameValidation');
 
@@ -28,6 +29,15 @@ module.exports = async (req, res) => {
   }
   // Sensitivity is managed exclusively via mark-sensitive / unmark-sensitive
   delete cleanedData.isSensitive;
+
+  // Only administrators can change the sensitivity lock
+  const isAdmin = RightService.hasGroup(
+    req.token.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  if (!isAdmin) {
+    delete cleanedData.isSensitiveLocked;
+  }
 
   // Validate name length
   const nameText = req.body.name?.text;

--- a/api/models/HEntrance.js
+++ b/api/models/HEntrance.js
@@ -98,6 +98,13 @@ module.exports = {
       defaultsTo: false,
     },
 
+    isSensitiveLocked: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive_locked',
+      defaultsTo: false,
+    },
+
     hasBat: {
       type: 'boolean',
       allowNull: false,

--- a/api/models/HMassif.js
+++ b/api/models/HMassif.js
@@ -53,5 +53,12 @@ module.exports = {
       columnName: 'is_sensitive',
       defaultsTo: false,
     },
+
+    isSensitiveLocked: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive_locked',
+      defaultsTo: false,
+    },
   },
 };

--- a/api/models/TEntrance.js
+++ b/api/models/TEntrance.js
@@ -106,6 +106,13 @@ module.exports = {
       defaultsTo: false,
     },
 
+    isSensitiveLocked: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive_locked',
+      defaultsTo: false,
+    },
+
     hasBat: {
       type: 'boolean',
       allowNull: false,

--- a/api/models/TMassif.js
+++ b/api/models/TMassif.js
@@ -56,6 +56,13 @@ module.exports = {
       defaultsTo: false,
     },
 
+    isSensitiveLocked: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_sensitive_locked',
+      defaultsTo: false,
+    },
+
     redirectTo: {
       type: 'number',
       allowNull: true,

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -53,6 +53,7 @@ module.exports = {
       yearDiscovery: coerceToInt(reqBodyWithoutId.yearDiscovery),
       geology: req.body.geology ?? 'Q35758',
       isSensitive: coerceBool(req, 'isSensitive'),
+      isSensitiveLocked: coerceBool(req, 'isSensitiveLocked'),
       hasBat: coerceBool(req, 'hasBat'),
       dangerFlooding: coerceBool(req, 'dangerFlooding'),
       dangerCo2: coerceBool(req, 'dangerCo2'),
@@ -169,12 +170,19 @@ module.exports = {
     /* eslint-disable no-param-reassign */
     entranceData.geology = entranceData.geology ?? 'Q35758';
     entranceData.isSensitive = entranceData.isSensitive ?? false;
+    entranceData.isSensitiveLocked = entranceData.isSensitiveLocked ?? false;
     entranceData.dateInscription = entranceData.dateInscription ?? new Date();
     /* eslint-enable no-param-reassign */
 
     let autoMarkedSensitive = false;
-    // Automatically inherit sensitivity from the massif
-    if (entranceData.latitude !== null && entranceData.longitude !== null) {
+    // Automatically inherit sensitivity from the massif, unless the entrance's
+    // sensitivity is locked (an admin explicitly froze it, so it's exempt from
+    // the massif's sensitivity — mirrors the mark-sensitive cascade skip).
+    if (
+      !entranceData.isSensitiveLocked &&
+      entranceData.latitude !== null &&
+      entranceData.longitude !== null
+    ) {
       /* eslint-disable no-param-reassign */
       const isPointInSensitiveMassif =
         await MassifService.isPointInSensitiveMassif(

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -126,6 +126,20 @@ const COUNT_UNSENSITIVE_ENTRANCES_IN_MASSIF = `
   WHERE m.id = $1
   AND e.is_deleted = false
   AND e.is_sensitive = false
+  AND e.is_sensitive_locked = false
+`;
+
+// Counts non-sensitive entrances within the massif whose sensitivity is locked.
+// These are the entrances the cascade will skip.
+const COUNT_LOCKED_UNSENSITIVE_ENTRANCES_IN_MASSIF = `
+  SELECT COUNT(e.id)::integer AS count
+  FROM t_entrance AS e
+  JOIN t_massif AS m
+  ON e.point_geom && m.geog_polygon AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
+  WHERE m.id = $1
+  AND e.is_deleted = false
+  AND e.is_sensitive = false
+  AND e.is_sensitive_locked = true
 `;
 
 async function safeDBQuery(sql, param) {
@@ -212,6 +226,7 @@ module.exports = {
     geogPolygon: req.param('geogPolygon'),
     names: req.param('names'),
     isSensitive: coerceBool(req, 'isSensitive'),
+    isSensitiveLocked: coerceBool(req, 'isSensitiveLocked'),
   }),
 
   async getPopulatedMassif(massifId) {
@@ -288,6 +303,21 @@ module.exports = {
       throw e;
     }
   },
+  countLockedUnsensitiveEntrances: async (massifId) => {
+    try {
+      const result = await CommonService.query(
+        COUNT_LOCKED_UNSENSITIVE_ENTRANCES_IN_MASSIF,
+        [massifId]
+      );
+      return result.rows[0]?.count ?? 0;
+    } catch (e) {
+      sails.log.error(
+        `Error counting locked unsensitive entrances for massif ${massifId}:`,
+        e
+      );
+      throw e;
+    }
+  },
   getNetworks: async (massifId) =>
     safeDBQuery(FIND_NETWORKS_IN_MASSIF, massifId),
 
@@ -347,7 +377,8 @@ module.exports = {
    * @returns {Promise<number[]>} IDs of entrances whose sensitivity was changed
    */
   async propagateSensitivityToEntrances(massifId, reviewerId, db) {
-    // Find IDs of non-sensitive entrances within the massif
+    // Find IDs of non-sensitive entrances within the massif.
+    // Entrances whose sensitivity is locked are skipped (left unchanged).
     const findEntrancesQuery = `
       SELECT e.id
       FROM t_entrance AS e
@@ -356,6 +387,7 @@ module.exports = {
       AND e.point_geom && m.geog_polygon
       AND ST_Contains(m.geog_polygon::geometry, e.point_geom)
       AND e.is_sensitive = false
+      AND e.is_sensitive_locked = false
     `;
     const result = await CommonService.query(
       findEntrancesQuery,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -339,6 +339,8 @@ const c = {
     }
     result.isDeleted = source.isDeleted;
     result.isSensitive = isSensitive;
+    result.isSensitiveLocked =
+      source.isSensitiveLocked ?? source.is_sensitive_locked ?? false;
     result.hasBat = source.hasBat;
     result.dangerFlooding = source.dangerFlooding;
     result.dangerCo2 = source.dangerCo2;
@@ -583,6 +585,7 @@ const c = {
     '@id': String(source.id),
     isDeleted: source.isDeleted,
     isSensitive: source.isSensitive,
+    isSensitiveLocked: source.isSensitiveLocked ?? false,
     redirectTo: source.redirectTo,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),

--- a/api/services/mapping/models/EntranceModel.js
+++ b/api/services/mapping/models/EntranceModel.js
@@ -29,6 +29,7 @@ module.exports = {
   id: undefined,
   isDeleted: undefined,
   isSensitive: undefined,
+  isSensitiveLocked: undefined,
   hasBat: undefined,
   dangerFlooding: undefined,
   dangerCo2: undefined,

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4211,6 +4211,12 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: isSensitiveLocked
+          in: query
+          description: When true, only administrators can change isSensitive (administrator-only field)
+          schema:
+            type: boolean
+            default: false
         - name: hasBat
           in: query
           description: The cave is a known bat habitat
@@ -5448,6 +5454,9 @@ paths:
                   description: List of names ids
                   items:
                     type: object
+                isSensitiveLocked:
+                  type: boolean
+                  description: When true, only administrators can change the massif sensitivity. Administrator-only field; stripped for other users.
                 name:
                   type: object
                   description: Optional. Update the main name inline (text and/or language).
@@ -5632,12 +5641,15 @@ paths:
                   count:
                     type: integer
                     description: Number of entrances marked as sensitive
+                  skippedLockedCount:
+                    type: integer
+                    description: Number of entrances skipped because their sensitivity is locked
                   massif:
                     $ref: '#/components/schemas/Massif'
         '401':
           description: Authentication required.
         '403':
-          description: Only administrators can perform this action.
+          description: The user is not an administrator, or the massif sensitivity is locked.
         '404':
           description: Massif not found
 
@@ -5669,7 +5681,7 @@ paths:
         '401':
           description: Authentication required.
         '403':
-          description: Only administrators can perform this action.
+          description: The user is not an administrator, or the massif sensitivity is locked.
         '404':
           description: Massif not found
 
@@ -5695,7 +5707,10 @@ paths:
                 properties:
                   count:
                     type: integer
-                    description: Number of affected entrances
+                    description: Number of non-sensitive, non-locked entrances that would be affected
+                  lockedCount:
+                    type: integer
+                    description: Number of non-sensitive entrances that would be skipped because their sensitivity is locked
         '401':
           description: Authentication required.
         '403':
@@ -7993,6 +8008,10 @@ components:
           type: integer
         isSensitive:
           type: boolean
+        isSensitiveLocked:
+          type: boolean
+          default: false
+          description: When true, only administrators can change isSensitive
         hasBat:
           type: boolean
           default: false
@@ -8386,6 +8405,10 @@ components:
         isSensitive:
           type: boolean
           description: Whether the massif is marked as sensitive
+        isSensitiveLocked:
+          type: boolean
+          default: false
+          description: When true, only administrators can change the massif sensitivity
         name:
           type: string
         names:

--- a/sql/9_16_2026_06_29_entrance_massif_is_sensitive_locked.sql
+++ b/sql/9_16_2026_06_29_entrance_massif_is_sensitive_locked.sql
@@ -1,0 +1,162 @@
+\c grottoce;
+
+BEGIN;
+
+-- Add is_sensitive_locked column to t_entrance
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 't_entrance' AND column_name = 'is_sensitive_locked'
+    ) THEN
+        ALTER TABLE t_entrance ADD COLUMN is_sensitive_locked bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Add is_sensitive_locked column to h_entrance
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'h_entrance' AND column_name = 'is_sensitive_locked'
+    ) THEN
+        ALTER TABLE h_entrance ADD COLUMN is_sensitive_locked bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Add is_sensitive_locked column to t_massif
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 't_massif' AND column_name = 'is_sensitive_locked'
+    ) THEN
+        ALTER TABLE t_massif ADD COLUMN is_sensitive_locked bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Add is_sensitive_locked column to h_massif
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'h_massif' AND column_name = 'is_sensitive_locked'
+    ) THEN
+        ALTER TABLE h_massif ADD COLUMN is_sensitive_locked bool NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- Update the entrance history trigger to archive is_sensitive_locked
+-- (mirrors the existing is_sensitive handling)
+CREATE OR REPLACE FUNCTION histo_update_entrance() RETURNS trigger AS $$
+DECLARE date_r timestamp;
+BEGIN --prise en compte du cas de la première modif d'un enregistrement
+if new.date_reviewed is null then date_r := NEW.date_inscription;
+else date_r := NEW.date_reviewed;
+end if;
+--si is_deleted change d'état c'est qu'on est face à une suppression ou une réactivation de la ligne, donc on n'historise pas !
+if NEW.is_deleted = OLD.is_deleted then --copie dans la table d'historisation
+INSERT INTO h_entrance (
+        id,
+        "type",
+        id_author,
+        id_reviewer,
+        region,
+        county,
+        city,
+        iso_3166_2,
+        year_discovery,
+        external_url,
+        date_inscription,
+        date_reviewed,
+        is_public,
+        is_sensitive,
+        is_sensitive_locked,
+        contact,
+        modalities,
+        has_contributions,
+        latitude,
+        longitude,
+        altitude,
+        is_of_interest,
+        id_cave,
+        id_country,
+        id_geology
+    )
+VALUES (
+        OLD.id,
+        OLD."type",
+        OLD.id_author,
+        OLD.id_reviewer,
+        OLD.region,
+        OLD.county,
+        OLD.city,
+        OLD.iso_3166_2,
+        OLD.year_discovery,
+        OLD.external_url,
+        OLD.date_inscription,
+        date_r,
+        OLD.is_public,
+        OLD.is_sensitive,
+        OLD.is_sensitive_locked,
+        OLD.contact,
+        OLD.modalities,
+        OLD.has_contributions,
+        OLD.latitude,
+        OLD.longitude,
+        OLD.altitude,
+        OLD.is_of_interest,
+        OLD.id_cave,
+        OLD.id_country,
+        OLD.id_geology
+    );
+end if;
+--on insert la valeur de la date de modification dans t_entrance
+NEW.date_reviewed := now();
+
+-- point_geom is now maintained by the set_entrance_point_geom trigger
+-- (BEFORE INSERT OR UPDATE), so no duplication here.
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update the massif history trigger to archive is_sensitive_locked
+CREATE OR REPLACE FUNCTION histo_update_massif() RETURNS trigger AS $$
+DECLARE date_r timestamp;
+BEGIN
+    -- Determine the reference date
+    if new.date_reviewed is null then date_r := NEW.date_inscription;
+    else date_r := NEW.date_reviewed;
+    end if;
+
+    -- Only archive if it's not a soft delete or restore (is_deleted hasn't changed)
+    if NEW.is_deleted = OLD.is_deleted then
+        INSERT INTO h_massif (
+            id,
+            id_author,
+            id_reviewer,
+            date_inscription,
+            date_reviewed,
+            geog_polygon,
+            is_sensitive,
+            is_sensitive_locked
+        )
+        VALUES (
+            OLD.id,
+            OLD.id_author,
+            OLD.id_reviewer,
+            OLD.date_inscription,
+            date_r,
+            OLD.geog_polygon,
+            OLD.is_sensitive,
+            OLD.is_sensitive_locked
+        );
+    end if;
+
+    -- Update modification date in the main table
+    NEW.date_reviewed := now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/test/integration/1_services/Converters.test.js
+++ b/test/integration/1_services/Converters.test.js
@@ -427,6 +427,24 @@ describe('Converters Service', () => {
       const result = converters.toEntrance(source);
       should(result.dateLastModif).equal(1700000000000);
     });
+
+    it('should include isSensitiveLocked from source', () => {
+      const result = converters.toEntrance({ id: 1, isSensitiveLocked: true });
+      should(result.isSensitiveLocked).be.true();
+    });
+
+    it('should default isSensitiveLocked to false when absent (legacy rows)', () => {
+      const result = converters.toEntrance({ id: 1 });
+      should(result.isSensitiveLocked).be.false();
+    });
+
+    it('should read isSensitiveLocked from the snake_case column', () => {
+      const result = converters.toEntrance({
+        id: 1,
+        is_sensitive_locked: true,
+      });
+      should(result.isSensitiveLocked).be.true();
+    });
   });
 
   describe('toSimpleEntrance()', () => {
@@ -705,6 +723,14 @@ describe('Converters Service', () => {
     it('should return an empty array when organizations is empty', () => {
       const result = converters.toMassif({ id: 1, organizations: [] });
       should(result.organizations).eql([]);
+    });
+
+    it('should include isSensitiveLocked, defaulting to false when absent', () => {
+      should(converters.toMassif({ id: 1 }).isSensitiveLocked).be.false();
+      should(
+        converters.toMassif({ id: 1, isSensitiveLocked: true })
+          .isSensitiveLocked
+      ).be.true();
     });
   });
 });

--- a/test/integration/1_services/EntranceService.test.js
+++ b/test/integration/1_services/EntranceService.test.js
@@ -78,6 +78,17 @@ describe('EntranceService', () => {
       should(result.isSensitive).be.true();
     });
 
+    it('should coerce isSensitiveLocked from string "true"', () => {
+      const req = {
+        body: {},
+        param: sinon.stub(),
+      };
+      req.param.withArgs('isSensitive').returns(undefined);
+      req.param.withArgs('isSensitiveLocked').returns('true');
+      const result = EntranceService.getConvertedDataFromClientRequest(req);
+      should(result.isSensitiveLocked).be.true();
+    });
+
     it('should set default geology', () => {
       const req = {
         body: {},

--- a/test/integration/1_services/GeoLocNetworks.property.test.js
+++ b/test/integration/1_services/GeoLocNetworks.property.test.js
@@ -57,8 +57,7 @@ const networkRowsArbitrary = fc
 
 describe('GeoLocService formatNetworks - Property Tests', () => {
   describe('Property 1: every network has more than one entrance', () => {
-    it('should produce networks each with at least 2 entrances', function () {
-      this.timeout(10000);
+    it('should produce networks each with at least 2 entrances', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -68,12 +67,11 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 
   describe('Property 2: centroid equals arithmetic mean of entrance coordinates', () => {
-    it('should have centroid matching average of entrance lat/lng', function () {
-      this.timeout(10000);
+    it('should have centroid matching average of entrance lat/lng', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -90,12 +88,11 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 
   describe('Property 6: backwards-compatible output shape', () => {
-    it('should always include id, name, longitude, latitude, entrances', function () {
-      this.timeout(10000);
+    it('should always include id, name, longitude, latitude, entrances', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -114,6 +111,6 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 });

--- a/test/integration/4_routes/Entrances/create.test.js
+++ b/test/integration/4_routes/Entrances/create.test.js
@@ -252,6 +252,153 @@ describe('Entrance features', () => {
           });
       }).timeout(10000);
 
+      it('should ignore isSensitiveLocked sent by a non-admin (defaults to false)', (done) => {
+        const entranceData = {
+          cave: 1,
+          name: { text: 'Non-admin Lock Entrance', language: 'eng' },
+          latitude: 49.0,
+          longitude: 5.0,
+          isSensitiveLocked: true,
+        };
+
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send(entranceData)
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: entrance } = res;
+              createdEntranceIds.push(entrance.id);
+              const persisted = await TEntrance.findOne(entrance.id);
+              should(persisted.isSensitiveLocked).equal(false);
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      }).timeout(10000);
+
+      it('should persist isSensitiveLocked when set by an admin', (done) => {
+        const entranceData = {
+          cave: 1,
+          name: { text: 'Admin Lock Entrance', language: 'eng' },
+          latitude: 49.5,
+          longitude: 5.5,
+          isSensitiveLocked: true,
+        };
+
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send(entranceData)
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: entrance } = res;
+              createdEntranceIds.push(entrance.id);
+              const persisted = await TEntrance.findOne(entrance.id);
+              should(persisted.isSensitiveLocked).equal(true);
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      }).timeout(10000);
+
+      it('should default isSensitiveLocked to false when omitted', (done) => {
+        const entranceData = {
+          cave: 1,
+          name: { text: 'Default Lock Entrance', language: 'eng' },
+          latitude: 49.8,
+          longitude: 5.8,
+        };
+
+        supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send(entranceData)
+          .expect(200)
+          .end(async (err, res) => {
+            if (err) return done(err);
+            try {
+              const { body: entrance } = res;
+              createdEntranceIds.push(entrance.id);
+              const persisted = await TEntrance.findOne(entrance.id);
+              should(persisted.isSensitiveLocked).equal(false);
+              return done();
+            } catch (testErr) {
+              return done(testErr);
+            }
+          });
+      }).timeout(10000);
+
+      it('should not auto-inherit massif sensitivity when the entrance is locked', async () => {
+        const massif = await TMassif.create({
+          isSensitive: true,
+          author: 1,
+          geogPolygon: 'SRID=4326;POLYGON((44 44, 45 44, 45 45, 44 45, 44 44))',
+        }).fetch();
+
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({
+            cave: 1,
+            name: { text: 'Locked exempt entrance', language: 'eng' },
+            latitude: 44.5,
+            longitude: 44.5,
+            isSensitive: false,
+            isSensitiveLocked: true,
+          })
+          .expect(200);
+
+        createdEntranceIds.push(res.body.id);
+        const persisted = await TEntrance.findOne(res.body.id);
+        should(persisted.isSensitive).equal(false);
+        should(persisted.isSensitiveLocked).equal(true);
+
+        await TMassif.destroyOne(massif.id);
+      }).timeout(10000);
+
+      it('should auto-inherit massif sensitivity when the entrance is not locked', async () => {
+        const massif = await TMassif.create({
+          isSensitive: true,
+          author: 1,
+          geogPolygon: 'SRID=4326;POLYGON((46 46, 47 46, 47 47, 46 47, 46 46))',
+        }).fetch();
+
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/entrances')
+          .set('Authorization', adminToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({
+            cave: 1,
+            name: { text: 'Auto sensitive entrance', language: 'eng' },
+            latitude: 46.5,
+            longitude: 46.5,
+            isSensitive: false,
+          })
+          .expect(200);
+
+        createdEntranceIds.push(res.body.id);
+        const persisted = await TEntrance.findOne(res.body.id);
+        should(persisted.isSensitive).equal(true);
+
+        await TMassif.destroyOne(massif.id);
+      }).timeout(10000);
+
       it('should populate point_geom from latitude/longitude on INSERT', (done) => {
         const lat = 48.8566;
         const lon = 2.3522;

--- a/test/integration/4_routes/Entrances/update.test.js
+++ b/test/integration/4_routes/Entrances/update.test.js
@@ -307,5 +307,85 @@ describe('Entrance features', () => {
         should(entrance.isSensitive).be.true();
       }).timeout(10000);
     });
+
+    describe('Sensitivity lock', () => {
+      let caveId;
+      let lockedEntranceId;
+
+      beforeEach(async () => {
+        const cave = await TCave.create({ author: 1 }).fetch();
+        caveId = cave.id;
+        const entrance = await TEntrance.create({
+          author: 1,
+          cave: caveId,
+          latitude: 12.3,
+          longitude: 45.6,
+          isSensitive: true,
+          isSensitiveLocked: true,
+        }).fetch();
+        lockedEntranceId = entrance.id;
+        await TName.create({
+          entrance: lockedEntranceId,
+          name: 'Locked entrance',
+          isMain: true,
+          author: 1,
+          language: 'eng',
+        });
+      });
+
+      afterEach(async () => {
+        await TName.destroy({ entrance: lockedEntranceId });
+        await TEntrance.destroyOne(lockedEntranceId);
+        await TCave.destroyOne(caveId);
+      });
+
+      it('should return 403 when a non-admin changes isSensitive on a locked entrance', async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/entrances/${lockedEntranceId}`)
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .send({ isSensitive: false })
+          .expect(403);
+
+        const entrance = await TEntrance.findOne(lockedEntranceId);
+        should(entrance.isSensitive).be.true();
+      });
+
+      it('should allow an admin to change isSensitive on a locked entrance', async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/entrances/${lockedEntranceId}`)
+          .set('Authorization', allGroupsToken)
+          .set('Content-type', 'application/json')
+          .send({ isSensitive: false })
+          .expect(200);
+
+        const entrance = await TEntrance.findOne(lockedEntranceId);
+        should(entrance.isSensitive).be.false();
+      });
+
+      it('should ignore isSensitiveLocked sent by a non-admin', async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/entrances/${lockedEntranceId}`)
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .send({ isSensitiveLocked: false })
+          .expect(200);
+
+        const entrance = await TEntrance.findOne(lockedEntranceId);
+        should(entrance.isSensitiveLocked).be.true();
+      });
+
+      it('should let an admin unlock the entrance', async () => {
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/entrances/${lockedEntranceId}`)
+          .set('Authorization', allGroupsToken)
+          .set('Content-type', 'application/json')
+          .send({ isSensitiveLocked: false })
+          .expect(200);
+
+        const entrance = await TEntrance.findOne(lockedEntranceId);
+        should(entrance.isSensitiveLocked).be.false();
+      });
+    });
   });
 });

--- a/test/integration/4_routes/Massifs/mark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/mark-sensitive.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const AuthTokenService = require('../../AuthTokenService');
 const EntranceService = require('../../../../api/services/EntranceService');
 const MassifService = require('../../../../api/services/MassifService');
+const CommonService = require('../../../../api/services/CommonService');
 
 describe('Massif mark-sensitive route features', () => {
   let adminToken;
@@ -94,6 +95,77 @@ describe('Massif mark-sensitive route features', () => {
 
       // Cleanup
       await TName.destroy({ massif: massif.id });
+      await TMassif.destroyOne(massif.id);
+    });
+
+    it('should return 403 when the massif sensitivity is locked', async () => {
+      const massif = await TMassif.create({
+        isSensitive: false,
+        isSensitiveLocked: true,
+        author: 1,
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/mark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(403);
+
+      // The massif must remain non-sensitive
+      const modified = await TMassif.findOne(massif.id);
+      modified.isSensitive.should.be.false();
+
+      await TMassif.destroyOne(massif.id);
+    });
+
+    it('should skip locked entrances during the cascade and report skippedLockedCount', async () => {
+      sinon.stub(EntranceService, 'updateInSearch').resolves();
+      sinon.stub(MassifService, 'updateInSearch').resolves();
+
+      const massif = await TMassif.create({
+        isSensitive: false,
+        author: 1,
+        geogPolygon: 'SRID=4326;POLYGON((20 20, 21 20, 21 21, 20 21, 20 20))',
+      }).fetch();
+      const cave = await TCave.create({ author: 1 }).fetch();
+
+      // One unlocked + one locked non-sensitive entrance within the polygon
+      const unlocked = await TEntrance.create({
+        author: 1,
+        latitude: 20.5,
+        longitude: 20.5,
+        cave: cave.id,
+        isSensitive: false,
+        isSensitiveLocked: false,
+      }).fetch();
+      const locked = await TEntrance.create({
+        author: 1,
+        latitude: 20.6,
+        longitude: 20.6,
+        cave: cave.id,
+        isSensitive: false,
+        isSensitiveLocked: true,
+      }).fetch();
+      await CommonService.query(
+        'UPDATE t_entrance SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) WHERE id = ANY($1)',
+        [[unlocked.id, locked.id]]
+      );
+
+      const response = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/mark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      response.body.count.should.equal(1);
+      response.body.skippedLockedCount.should.equal(1);
+
+      const updatedUnlocked = await TEntrance.findOne(unlocked.id);
+      updatedUnlocked.isSensitive.should.be.true();
+      const updatedLocked = await TEntrance.findOne(locked.id);
+      updatedLocked.isSensitive.should.be.false();
+
+      // Cleanup
+      await TEntrance.destroy({ id: [unlocked.id, locked.id] });
+      await TCave.destroyOne(cave.id);
       await TMassif.destroyOne(massif.id);
     });
   });

--- a/test/integration/4_routes/Massifs/preview-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/preview-sensitive.test.js
@@ -2,6 +2,7 @@ const supertest = require('supertest');
 const sinon = require('sinon');
 const should = require('should');
 const AuthTokenService = require('../../AuthTokenService');
+const CommonService = require('../../../../api/services/CommonService');
 
 describe('Massif preview-sensitive route features', () => {
   let adminToken;
@@ -38,8 +39,53 @@ describe('Massif preview-sensitive route features', () => {
         .expect(200)
         .expect((res) => {
           should(res.body).have.property('count', 0);
+          should(res.body).have.property('lockedCount', 0);
         })
         .end(done);
+    });
+
+    it('should report lockedCount and exclude locked entrances from count', async () => {
+      const massif = await TMassif.create({
+        isSensitive: false,
+        author: 1,
+        geogPolygon: 'SRID=4326;POLYGON((30 30, 31 30, 31 31, 30 31, 30 30))',
+      }).fetch();
+      const cave = await TCave.create({ author: 1 }).fetch();
+
+      const unlocked = await TEntrance.create({
+        author: 1,
+        latitude: 30.4,
+        longitude: 30.4,
+        cave: cave.id,
+        isSensitive: false,
+        isSensitiveLocked: false,
+      }).fetch();
+      const locked = await TEntrance.create({
+        author: 1,
+        latitude: 30.6,
+        longitude: 30.6,
+        cave: cave.id,
+        isSensitive: false,
+        isSensitiveLocked: true,
+      }).fetch();
+      await CommonService.query(
+        'UPDATE t_entrance SET point_geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) WHERE id = ANY($1)',
+        [[unlocked.id, locked.id]]
+      );
+
+      await supertest(sails.hooks.http.app)
+        .get(`/api/v1/massifs/${massif.id}/preview-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(200)
+        .expect((res) => {
+          should(res.body).have.property('count', 1);
+          should(res.body).have.property('lockedCount', 1);
+        });
+
+      // Cleanup
+      await TEntrance.destroy({ id: [unlocked.id, locked.id] });
+      await TCave.destroyOne(cave.id);
+      await TMassif.destroyOne(massif.id);
     });
   });
 });

--- a/test/integration/4_routes/Massifs/unmark-sensitive.test.js
+++ b/test/integration/4_routes/Massifs/unmark-sensitive.test.js
@@ -96,5 +96,24 @@ describe('Massif unmark-sensitive route features', () => {
       await TName.destroy({ massif: massif.id });
       await TMassif.destroyOne(massif.id);
     });
+
+    it('should return 403 when the massif sensitivity is locked', async () => {
+      const massif = await TMassif.create({
+        isSensitive: true,
+        isSensitiveLocked: true,
+        author: 1,
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .post(`/api/v1/massifs/${massif.id}/unmark-sensitive`)
+        .set('Authorization', adminToken)
+        .expect(403);
+
+      // The massif must remain sensitive
+      const modified = await TMassif.findOne(massif.id);
+      modified.isSensitive.should.be.true();
+
+      await TMassif.destroyOne(massif.id);
+    });
   });
 });

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -8,6 +8,7 @@ const EntranceService = require('../../../../api/services/EntranceService');
 
 describe('Massif features', () => {
   let userToken;
+  let adminToken;
   let testMassifId;
   let testDoc1Id;
   let testDoc2Id;
@@ -16,6 +17,7 @@ describe('Massif features', () => {
 
   before(async () => {
     userToken = await AuthTokenService.getRawBearerUserToken();
+    adminToken = await AuthTokenService.getRawBearerAllGroupsToken();
     const massif = await TMassif.create({ author: 1, reviewer: 2 }).fetch();
     testMassifId = massif.id;
     const doc1 = await TDocument.create({
@@ -263,6 +265,42 @@ describe('Massif features', () => {
         .set('Content-type', 'application/json')
         .set('Accept', 'application/json')
         .expect(400, done);
+    });
+
+    it('should strip isSensitiveLocked when sent by a non-admin', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ isSensitiveLocked: true })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(async (err) => {
+          if (err) return done(err);
+          const massif = await TMassif.findOne(testMassifId);
+          should(massif.isSensitiveLocked).be.false();
+          return done();
+        });
+    });
+
+    it('should persist isSensitiveLocked when sent by an admin', (done) => {
+      supertest(sails.hooks.http.app)
+        .put(`/api/v1/massifs/${testMassifId}`)
+        .send({ isSensitiveLocked: true })
+        .set('Authorization', adminToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(async (err) => {
+          if (err) return done(err);
+          const massif = await TMassif.findOne(testMassifId);
+          should(massif.isSensitiveLocked).be.true();
+          // Reset
+          await TMassif.updateOne(testMassifId).set({
+            isSensitiveLocked: false,
+          });
+          return done();
+        });
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

Adds an `isSensitiveLocked` boolean to **entrances** and **massifs**. When an administrator locks the sensitivity of an entity, only administrators can subsequently change its `isSensitive` value. The lock is a deliberate, symmetric admin action; it can freeze sensitivity in either state (on or off). Closes  #1684.

- New `is_sensitive_locked` column (`NOT NULL DEFAULT false`) on `t_entrance`, `h_entrance`, `t_massif`, `h_massif`
- `isSensitiveLocked` exposed in entrance and massif API responses
- Entrance & massif sensitivity changes are blocked for non-admins when the entity is locked
- Massif sensitivity cascade (`mark-sensitive`) now skips locked entrances and reports how many were skipped
- `preview-sensitive` reports how many entrances would be skipped due to the lock

## 🤷‍♂️ Why

Marking an entrance/massif as sensitive hides its coordinates from non-privileged users. Until now, a non-admin could still flip an entrance's sensitivity back, and there was no way for an admin to freeze the sensitivity state of an entity (e.g. an entrance that must stay non-sensitive even though it sits inside a sensitive massif, or one that must stay sensitive regardless of edits). `isSensitiveLocked` gives administrators that explicit control.

## 🔍 How

The feature mirrors the existing `isSensitive` plumbing end-to-end.

- **Migration** (`sql/9_16_2026_06_29_entrance_massif_is_sensitive_locked.sql`): idempotent `ADD COLUMN` on the four tables, plus a `CREATE OR REPLACE` of `histo_update_entrance()` and `histo_update_massif()` (based on their current production bodies) so the history triggers archive the new column.
- **Models / converters**: `isSensitiveLocked` attribute on `TEntrance`/`TMassif`; `toEntrance`/`toMassif` emit it, defaulting `null`/`undefined` to `false` for pre-migration rows.
- **Entrance create**: the field is admin-only — stripped for non-admins (defaults to `false`). A locked entrance is **exempt from massif sensitivity auto-inheritance** at creation, mirroring the cascade skip.
- **Entrance update**: a non-admin attempting to change `isSensitive` on a locked entrance gets **403**; non-admin lock changes are stripped; admins are unaffected.
- **Massif `mark-sensitive` / `unmark-sensitive`**: return **403** when the massif is locked. The cascade query excludes `is_sensitive_locked = true` entrances; `mark-sensitive` returns a new `skippedLockedCount`.
- **Massif `preview-sensitive`**: `count` now reflects only non-sensitive, non-locked entrances; a new `lockedCount` reports how many would be skipped.
- **Massif update**: admins can set `isSensitiveLocked`; it is stripped for everyone else (same pattern as `isSensitive`).

## 🧪 Testing

- **Converters**: `isSensitiveLocked` is emitted and defaults to `false`.
- **Entrance create route**: non-admin value ignored → `false`; admin value persisted; omitted → `false`.
- **Entrance update route**: locked + non-admin sensitivity change → 403; admin allowed; non-admin lock change ignored; admin unlock works.
- **Massif mark-sensitive route**: 403 when locked; cascade skips locked entrances and returns correct `count` + `skippedLockedCount`.
- **Massif unmark-sensitive route**: 403 when locked.
- **Massif preview-sensitive route**: `count` excludes locked entrances and `lockedCount` is reported.
- **Massif update route**: lock persisted for admin, stripped for non-admin.

Migration verified against a local `grottoce` DB: columns present on all four tables, idempotent re-run is a no-op, and both history triggers fire correctly with the new column.

## 📸 Previews

_N/A — backend only._
