### PR TITLE
Fix/1208 legislation guidelines

### DIFF
--- a/api/controllers/v1/guideline/delete.js
+++ b/api/controllers/v1/guideline/delete.js
@@ -54,19 +54,16 @@ module.exports = async (req, res) => {
       );
     }
 
-    // Remove FK-referencing children before the hard delete
-    await sails.sendNativeQuery(
-      'DELETE FROM j_guideline_country WHERE id_guideline = $1',
-      [guidelineId]
-    );
-    await sails.sendNativeQuery(
-      'DELETE FROM j_guideline_region WHERE id_guideline = $1',
-      [guidelineId]
-    );
-    await sails.sendNativeQuery(
-      'DELETE FROM j_guideline_massif WHERE id_guideline = $1',
-      [guidelineId]
-    );
+    // Remove FK-referencing children before the hard delete. Unlike
+    // device/delete.js and sensor-configuration/delete.js, we don't pre-check
+    // for children and return res.conflict(): the only rows pointing at
+    // t_guideline are these junction tables (countries/regions/massifs), which
+    // we own and delete outright. If a future FK to t_guideline is added that
+    // isn't cleared here, the phase-2 hard delete will surface a raw DB error
+    // instead of a friendly 409 — add the corresponding cleanup (or a guard) then.
+    await JGuidelineCountry.destroy({ guideline: guidelineId });
+    await JGuidelineRegion.destroy({ guideline: guidelineId });
+    await JGuidelineMassif.destroy({ guideline: guidelineId });
     await HGuideline.destroy({ t_id: guidelineId });
 
     await TGuideline.destroyOne({ id: guidelineId }); // Phase 2: hard-delete
@@ -90,6 +87,10 @@ module.exports = async (req, res) => {
 
   // The row is gone after a hard delete, so reuse the already-fetched record
   // rather than re-querying (which would return null). Reflect the deleted state.
+  // The populated countries/regions/massifs arrays on this object still reflect
+  // the pre-delete state; this matches the previous behaviour (which re-fetched
+  // right after the soft-delete) and relies on the `change_guideline` trigger
+  // not cascading to the junction rows on soft-delete — an implicit contract.
   guideline.isDeleted = true;
 
   return ControllerService.treatAndConvert(

--- a/api/controllers/v1/guideline/delete.js
+++ b/api/controllers/v1/guideline/delete.js
@@ -25,7 +25,11 @@ module.exports = async (req, res) => {
     });
   }
 
-  const isPermanent = !!req.param('isPermanent');
+  // The web client sends `?isPermanent=1`; accept the common truthy encodings
+  // ('1'/'true', or a real boolean from a JSON body) while treating explicit
+  // falsy values ('0'/'false') and an absent param as a soft delete. A bare
+  // `!!req.param(...)` would wrongly treat `isPermanent=0`/`false` as permanent.
+  const isPermanent = [true, 'true', '1'].includes(req.param('isPermanent'));
 
   if (isPermanent) {
     // Permanent (irreversible) deletion is gated to administrators; moderators

--- a/api/controllers/v1/guideline/delete.js
+++ b/api/controllers/v1/guideline/delete.js
@@ -25,27 +25,73 @@ module.exports = async (req, res) => {
     });
   }
 
-  if (guideline.isDeleted) {
-    return res.notFound({
-      message: `Guideline of id ${guidelineId} is already deleted.`,
-    });
-  }
-  await TGuideline.destroyOne({ id: guidelineId }); // Trigger soft-deletes
-  const deletedGuideline = await GuidelineService.getGuideline(guidelineId);
+  const isPermanent = req.param('isPermanent') === 'true';
 
-  // The DB trigger `change_guideline` automatically inserts a `t_last_change` row on soft-delete
-  // (which is an UPDATE under the hood). We update that row's author here to specify the moderator.
-  await RecentChangeService.setDeleteRestoreAuthor(
-    'delete',
-    'guideline',
-    guidelineId,
-    req.token.id
-  );
+  if (isPermanent) {
+    // Permanent (irreversible) deletion is gated to administrators; moderators
+    // may only soft-delete (matches device/delete.js, sensor-configuration/delete.js).
+    if (!isAdmin) {
+      return res.forbidden(
+        'You are not authorized to permanently delete guidelines.'
+      );
+    }
+
+    // Two-phase delete via the histo_delete() trigger:
+    // This pattern is shared across all soft-deletable entities in the project.
+    if (!guideline.isDeleted) {
+      await TGuideline.destroyOne({ id: guidelineId });
+      // The `change_guideline` trigger inserts the `t_last_change` 'delete' row
+      // on this soft-delete; attribute it to the admin.
+      await RecentChangeService.setDeleteRestoreAuthor(
+        'delete',
+        'guideline',
+        guidelineId,
+        req.token.id
+      );
+    }
+
+    // Remove FK-referencing children before the hard delete
+    await sails.sendNativeQuery(
+      'DELETE FROM j_guideline_country WHERE id_guideline = $1',
+      [guidelineId]
+    );
+    await sails.sendNativeQuery(
+      'DELETE FROM j_guideline_region WHERE id_guideline = $1',
+      [guidelineId]
+    );
+    await sails.sendNativeQuery(
+      'DELETE FROM j_guideline_massif WHERE id_guideline = $1',
+      [guidelineId]
+    );
+    await HGuideline.destroy({ t_id: guidelineId });
+
+    await TGuideline.destroyOne({ id: guidelineId }); // Phase 2: hard-delete
+  } else {
+    if (guideline.isDeleted) {
+      return res.notFound({
+        message: `Guideline of id ${guidelineId} is already deleted.`,
+      });
+    }
+    await TGuideline.destroyOne({ id: guidelineId }); // Trigger soft-deletes
+
+    // The DB trigger `change_guideline` automatically inserts a `t_last_change` row on soft-delete
+    // (which is an UPDATE under the hood). We update that row's author here to specify the moderator.
+    await RecentChangeService.setDeleteRestoreAuthor(
+      'delete',
+      'guideline',
+      guidelineId,
+      req.token.id
+    );
+  }
+
+  // The row is gone after a hard delete, so reuse the already-fetched record
+  // rather than re-querying (which would return null). Reflect the deleted state.
+  guideline.isDeleted = true;
 
   return ControllerService.treatAndConvert(
     req,
     null,
-    deletedGuideline,
+    guideline,
     { controllerMethod: 'GuidelineController.delete' },
     res,
     toSimpleGuideline

--- a/api/controllers/v1/guideline/delete.js
+++ b/api/controllers/v1/guideline/delete.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     });
   }
 
-  const isPermanent = req.param('isPermanent') === 'true';
+  const isPermanent = !!req.param('isPermanent');
 
   if (isPermanent) {
     // Permanent (irreversible) deletion is gated to administrators; moderators

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3479,7 +3479,11 @@ paths:
     delete:
       tags:
         - guidelines
-      description: Soft-delete a guideline. Authenticated action (moderator only).
+      description: >
+        Delete a guideline. By default this is a reversible soft-delete
+        (moderator or administrator). When `isPermanent=true`, the guideline and
+        its history snapshots and entity associations are permanently removed —
+        this is irreversible and restricted to administrators.
       security:
         - bearerAuth: []
       parameters:
@@ -3489,9 +3493,19 @@ paths:
           schema:
             type: integer
           description: Guideline ID to delete
+        - name: isPermanent
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: >
+            When true, permanently (hard) delete the guideline instead of
+            soft-deleting it. Administrators only.
       responses:
         '200':
-          description: Successful operation. Returns the soft-deleted guideline.
+          description: >
+            Successful operation. Returns the deleted guideline (with
+            `isDeleted: true`).
           content:
             application/json:
               schema:
@@ -3499,9 +3513,11 @@ paths:
         '401':
           description: Unauthorized (missing or invalid JWT token).
         '403':
-          description: Forbidden (user is not authorized to delete guidelines).
+          description: >
+            Forbidden (user is not authorized to delete guidelines, or is not an
+            administrator when requesting a permanent deletion).
         '404':
-          description: Guideline not found or already deleted.
+          description: Guideline not found, or already soft-deleted (non-permanent delete only).
           content:
             application/json:
               schema:

--- a/test/integration/4_routes/Guidelines/delete.test.js
+++ b/test/integration/4_routes/Guidelines/delete.test.js
@@ -5,9 +5,11 @@ const AuthTokenService = require('../../AuthTokenService');
 describe('Guideline delete', () => {
   let userToken;
   let moderatorToken;
+  let adminToken;
   before(async () => {
     userToken = await AuthTokenService.getRawBearerUserToken();
     moderatorToken = await AuthTokenService.getRawBearerModeratorToken();
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
   });
 
   describe('delete', () => {
@@ -63,6 +65,84 @@ describe('Guideline delete', () => {
         .delete(`/api/v1/guidelines/${guideline.id}`)
         .set('Authorization', moderatorToken)
         .expect(404);
+    });
+  });
+
+  describe('permanent delete', () => {
+    it('should return 403 when a moderator requests a permanent delete', async () => {
+      const guideline = await TGuideline.create({
+        title: 'Moderator Cannot Hard Delete',
+        author: 3,
+        language: 'fra',
+        dateInscription: new Date(),
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${guideline.id}?isPermanent=true`)
+        .set('Authorization', moderatorToken)
+        .expect(403);
+
+      // The guideline must remain untouched (not even soft-deleted).
+      const stillThere = await TGuideline.findOne(guideline.id);
+      should(stillThere).be.ok();
+      should(stillThere.isDeleted).be.false();
+
+      await TGuideline.destroy({ id: guideline.id }); // cleanup (soft-delete)
+    });
+
+    it('should hard delete a guideline along with its history and associations', async () => {
+      const guideline = await TGuideline.create({
+        title: 'Hard Delete Me',
+        author: 3,
+        language: 'fra',
+        dateInscription: new Date(),
+      }).fetch();
+      await TGuideline.addToCollection(guideline.id, 'countries', ['FR']);
+      await TGuideline.addToCollection(guideline.id, 'massifs', [1]);
+
+      const res = await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${guideline.id}?isPermanent=true`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      should(res.body.isDeleted).be.true();
+
+      // The row and all FK-referencing children must be gone.
+      const remaining = await TGuideline.findOne(guideline.id);
+      should(remaining).be.undefined();
+
+      const snapshots = await HGuideline.find({ t_id: guideline.id });
+      should(snapshots.length).equal(0);
+
+      const countryLinks = await sails.sendNativeQuery(
+        'SELECT 1 FROM j_guideline_country WHERE id_guideline = $1',
+        [guideline.id]
+      );
+      should(countryLinks.rows.length).equal(0);
+
+      const massifLinks = await sails.sendNativeQuery(
+        'SELECT 1 FROM j_guideline_massif WHERE id_guideline = $1',
+        [guideline.id]
+      );
+      should(massifLinks.rows.length).equal(0);
+    });
+
+    it('should hard delete a guideline that was already soft-deleted', async () => {
+      const guideline = await TGuideline.create({
+        title: 'Already Soft Deleted, Now Permanent',
+        author: 3,
+        language: 'fra',
+        dateInscription: new Date(),
+        isDeleted: true,
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${guideline.id}?isPermanent=true`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      const remaining = await TGuideline.findOne(guideline.id);
+      should(remaining).be.undefined();
     });
   });
 });

--- a/test/integration/4_routes/Guidelines/delete.test.js
+++ b/test/integration/4_routes/Guidelines/delete.test.js
@@ -144,5 +144,48 @@ describe('Guideline delete', () => {
       const remaining = await TGuideline.findOne(guideline.id);
       should(remaining).be.undefined();
     });
+
+    // The web client sends `?isPermanent=1` (not `=true`); this must hard delete.
+    it('should hard delete when isPermanent=1 (the web client encoding)', async () => {
+      const guideline = await TGuideline.create({
+        title: 'Hard Delete Via isPermanent=1',
+        author: 3,
+        language: 'fra',
+        dateInscription: new Date(),
+        isDeleted: true,
+      }).fetch();
+
+      await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${guideline.id}?isPermanent=1`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      const remaining = await TGuideline.findOne(guideline.id);
+      should(remaining).be.undefined();
+    });
+
+    // An explicit falsy value must NOT trigger a permanent delete.
+    it('should treat isPermanent=0 as a soft delete, not a permanent one', async () => {
+      const guideline = await TGuideline.create({
+        title: 'isPermanent=0 Is Soft',
+        author: 3,
+        language: 'fra',
+        dateInscription: new Date(),
+      }).fetch();
+
+      const res = await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${guideline.id}?isPermanent=0`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      should(res.body.isDeleted).be.true();
+
+      // The row must still exist (soft-deleted), not be hard-deleted.
+      const remaining = await TGuideline.findOne(guideline.id);
+      should(remaining).be.ok();
+      should(remaining.isDeleted).be.true();
+
+      await TGuideline.destroy({ id: guideline.id }); // cleanup
+    });
   });
 });

--- a/test/integration/4_routes/Guidelines/delete.test.js
+++ b/test/integration/4_routes/Guidelines/delete.test.js
@@ -98,6 +98,7 @@ describe('Guideline delete', () => {
         dateInscription: new Date(),
       }).fetch();
       await TGuideline.addToCollection(guideline.id, 'countries', ['FR']);
+      await TGuideline.addToCollection(guideline.id, 'regions', ['FR-01']);
       await TGuideline.addToCollection(guideline.id, 'massifs', [1]);
 
       const res = await supertest(sails.hooks.http.app)
@@ -119,6 +120,12 @@ describe('Guideline delete', () => {
         [guideline.id]
       );
       should(countryLinks.rows.length).equal(0);
+
+      const regionLinks = await sails.sendNativeQuery(
+        'SELECT 1 FROM j_guideline_region WHERE id_guideline = $1',
+        [guideline.id]
+      );
+      should(regionLinks.rows.length).equal(0);
 
       const massifLinks = await sails.sendNativeQuery(
         'SELECT 1 FROM j_guideline_massif WHERE id_guideline = $1',


### PR DESCRIPTION
## 🤔 What

Adds the missing permanent (hard) delete mode to the guideline delete endpoint, gated to administrators.

- `DELETE /v1/guidelines/{id}` now accepts an `isPermanent` query parameter
- Default behavior is unchanged: a reversible soft-delete (moderator or admin)
- `isPermanent=true` fully removes the guideline, its history snapshots, and its entity associations — **irreversible, administrators only**
- Updated Swagger docs and added integration tests for both delete modes

## 🤷‍♂️ Why

The issue's requirements now as  for a way to permanently remove a guideline, while keeping the destructive operation restricted to administrators (consistent with the permanent-delete pattern already used for devices and sensor configurations).

## 🔍 How

In [api/controllers/v1/guideline/delete.js](api/controllers/v1/guideline/delete.js):

- **Parameter parsing:** `isPermanent` is treated as permanent only for `true`/`'true'`/`'1'`. Explicit falsy values (`'0'`/`'false'`) and an absent param fall back to soft-delete — avoiding the `!!req.param(...)` pitfall where `isPermanent=0` would read as truthy. The web client sends `?isPermanent=1`.
- **Authorization:** permanent deletion returns `403` for non-admins; soft-delete remains available to moderators.
- **Permanent delete (two-phase):**
  1. If the guideline isn't already soft-deleted, `destroyOne` fires the `change_guideline` trigger (soft-delete) and the `t_last_change` 'delete' row is attributed to the admin via `RecentChangeService.setDeleteRestoreAuthor`.
  2. FK-referencing children (`j_guideline_country`, `j_guideline_region`, `j_guideline_massif`) and history rows (`HGuideline`) are removed, then a second `destroyOne` performs the hard delete.
- **Response:** after a hard delete the row no longer exists, so instead of re-querying (which would return `null`), the already-fetched record is reused with `isDeleted` set to `true`.

Swagger ([assets/swaggerV1.yaml](assets/swaggerV1.yaml)) updated to document the `isPermanent` param, the admin restriction, and the refined `403`/`404` responses.

## 🧪 Testing

Integration tests in [test/integration/4_routes/Guidelines/delete.test.js](test/integration/4_routes/Guidelines/delete.test.js) cover both paths.