### PR TITLE
Fix temporal name resolution in entrance snapshot timeline

### DIFF
--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -20,6 +20,7 @@ const {
   computeDateLastModif,
 } = require('../../config/constants/entrance');
 const NameService = require('./NameService');
+const TemporalNameResolver = require('./TemporalNameResolver');
 const RiggingService = require('./RiggingService');
 const DescriptionService = require('./DescriptionService');
 const HistoryService = require('./HistoryService');
@@ -117,24 +118,48 @@ module.exports = {
       ? RightService.hasGroup(token?.groups, RightService.G.ADMINISTRATOR)
       : true; // No need to call hasRight if it's not a sensitive entrance
 
-    // Batch resolve entrance names — one call for all history entries
-    const entranceStubs = HEntrances.map((e) => ({ id: e.t_id }));
-    await NameService.setNames(entranceStubs, 'entrance');
-    const entranceNameMap = new Map(
-      entranceStubs.map((s) => [s.id, { names: s.names, name: s.name }])
-    );
+    // Fetch all HName records for the entrance (temporal resolution)
+    const entranceHNames = await HName.find({
+      entrance: entranceId,
+      isMain: true,
+    })
+      .populate('author')
+      .populate('reviewer');
 
-    // Batch resolve cave names for entries that have a cave
+    // Fetch current TName main name as fallback
+    const currentEntranceNames = await TName.find({
+      entrance: entranceId,
+      isMain: true,
+    });
+    const currentEntranceName =
+      currentEntranceNames.length > 0 ? currentEntranceNames[0].name : null;
+
+    // Collect unique cave IDs from HEntrance records
     const caveIds = [
       ...new Set(
         HEntrances.filter((e) => e.cave).map((e) => e.cave?.id ?? e.cave)
       ),
-    ];
-    const caveNameMap = new Map();
+    ].filter(Boolean);
+
+    // Batch-fetch cave h_name records and current cave names
+    const caveHNameMap = new Map();
+    const currentCaveNameMap = new Map();
     if (caveIds.length > 0) {
-      const caveStubs = caveIds.map((id) => ({ id }));
-      await NameService.setNames(caveStubs, 'cave');
-      caveStubs.forEach((s) => caveNameMap.set(s.id, s.name));
+      const caveHNames = await HName.find({ cave: caveIds, isMain: true });
+      for (const record of caveHNames) {
+        const caveId = record.cave?.id ?? record.cave;
+        if (!caveHNameMap.has(caveId)) caveHNameMap.set(caveId, []);
+        caveHNameMap.get(caveId).push(record);
+      }
+      const currentCaveNames = await TName.find({
+        cave: caveIds,
+        isMain: true,
+      });
+      for (const record of currentCaveNames) {
+        const caveId = record.cave?.id ?? record.cave;
+        if (!currentCaveNameMap.has(caveId))
+          currentCaveNameMap.set(caveId, record.name);
+      }
     }
 
     /* eslint-disable no-param-reassign */
@@ -144,18 +169,43 @@ module.exports = {
         entrance.longitude = null;
         entrance.latitude = null;
       }
-      const resolved = entranceNameMap.get(entrance.t_id);
-      entrance.names = resolved?.names ?? [];
-      entrance.name = resolved?.name ?? '';
-
-      if (entrance.cave) {
-        const caveId = entrance.cave?.id ?? entrance.cave;
-        entrance.caveName = caveNameMap.get(caveId) ?? null;
-      }
+      entrance.name = TemporalNameResolver.resolveNameAtDate(
+        entrance.id,
+        entranceHNames,
+        currentEntranceName
+      );
+      // Use current TName records so getMainLanguage can extract the language
+      // (names are immutable reference attributes, not temporal)
+      entrance.names = currentEntranceNames;
     });
     /* eslint-enable no-param-reassign */
 
-    return HEntrances;
+    TemporalNameResolver.resolveCaveNamesForSnapshots(
+      HEntrances,
+      caveHNameMap,
+      currentCaveNameMap
+    );
+
+    const resolveCaveNameFn = (snapshotDate) => {
+      // Uses the first cave seen in HEntrance history. For entrances that were
+      // reassigned to a different cave, this may pick the wrong cave — a known
+      // limitation affecting only multi-cave-history entrances (very rare).
+      const entranceCaveId = caveIds.length > 0 ? caveIds[0] : null;
+      if (!entranceCaveId) return null;
+      return TemporalNameResolver.resolveNameAtDate(
+        snapshotDate,
+        caveHNameMap.get(entranceCaveId) || [],
+        currentCaveNameMap.get(entranceCaveId) || null
+      );
+    };
+
+    const nameChangeSnapshots = TemporalNameResolver.buildNameChangeSnapshots(
+      entranceId,
+      entranceHNames,
+      resolveCaveNameFn
+    );
+
+    return TemporalNameResolver.mergeAndSort(HEntrances, nameChangeSnapshots);
   },
 
   createEntrance: async (req, entranceData, nameDescLocData) => {

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -103,17 +103,18 @@ module.exports = {
   },
 
   getHEntrancesWithName: async (entranceId, HEntrances, token) => {
-    const tEntranceSensitivity = await TEntrance.find({
+    const tEntranceRecords = await TEntrance.find({
       where: { id: entranceId },
-      select: ['isSensitive'],
+      select: ['isSensitive', 'cave'],
     });
     // Check if the entrance exist
-    if (Object.keys(tEntranceSensitivity).length === 0) {
+    if (Object.keys(tEntranceRecords).length === 0) {
       return {};
     }
-    const isEntranceSensitive = tEntranceSensitivity[0]
-      ? tEntranceSensitivity[0].isSensitive
+    const isEntranceSensitive = tEntranceRecords[0]
+      ? tEntranceRecords[0].isSensitive
       : true;
+    const currentCaveId = tEntranceRecords[0]?.cave ?? null;
     const hasRight = isEntranceSensitive
       ? RightService.hasGroup(token?.groups, RightService.G.ADMINISTRATOR)
       : true; // No need to call hasRight if it's not a sensitive entrance
@@ -126,20 +127,21 @@ module.exports = {
       .populate('author')
       .populate('reviewer');
 
-    // Fetch current TName main name as fallback
-    const currentEntranceNames = await TName.find({
-      entrance: entranceId,
-      isMain: true,
-    });
-    const currentEntranceName =
-      currentEntranceNames.length > 0 ? currentEntranceNames[0].name : null;
+    // Fetch all current TName records for the entrance (full names collection)
+    const allEntranceNames = await TName.find({ entrance: entranceId });
+    // Extract the main name as fallback for temporal resolution
+    const mainEntranceName = allEntranceNames.find((n) => n.isMain);
+    const currentEntranceName = mainEntranceName ? mainEntranceName.name : null;
 
-    // Collect unique cave IDs from HEntrance records
+    // Collect unique cave IDs from HEntrance records + current association
     const caveIds = [
       ...new Set(
-        HEntrances.filter((e) => e.cave).map((e) => e.cave?.id ?? e.cave)
+        [
+          currentCaveId,
+          ...HEntrances.filter((e) => e.cave).map((e) => e.cave?.id ?? e.cave),
+        ].filter(Boolean)
       ),
-    ].filter(Boolean);
+    ];
 
     // Batch-fetch cave h_name records and current cave names
     const caveHNameMap = new Map();
@@ -174,9 +176,8 @@ module.exports = {
         entranceHNames,
         currentEntranceName
       );
-      // Use current TName records so getMainLanguage can extract the language
-      // (names are immutable reference attributes, not temporal)
-      entrance.names = currentEntranceNames;
+      // Assign all current TName records so getMainLanguage can extract the language
+      entrance.names = allEntranceNames;
     });
     /* eslint-enable no-param-reassign */
 
@@ -187,15 +188,12 @@ module.exports = {
     );
 
     const resolveCaveNameFn = (snapshotDate) => {
-      // Uses the first cave seen in HEntrance history. For entrances that were
-      // reassigned to a different cave, this may pick the wrong cave — a known
-      // limitation affecting only multi-cave-history entrances (very rare).
-      const entranceCaveId = caveIds.length > 0 ? caveIds[0] : null;
-      if (!entranceCaveId) return null;
+      // Uses current cave association; historical cave-at-rename-time isn't tracked
+      if (!currentCaveId) return null;
       return TemporalNameResolver.resolveNameAtDate(
         snapshotDate,
-        caveHNameMap.get(entranceCaveId) || [],
-        currentCaveNameMap.get(entranceCaveId) || null
+        caveHNameMap.get(currentCaveId) || [],
+        currentCaveNameMap.get(currentCaveId) || null
       );
     };
 

--- a/api/services/TemporalNameResolver.js
+++ b/api/services/TemporalNameResolver.js
@@ -1,0 +1,129 @@
+/**
+ * TemporalNameResolver — pure functions for temporal name resolution
+ * in the entrance snapshot timeline.
+ *
+ * All functions are pure (no DB calls). Data is passed in as arguments.
+ */
+
+/* eslint-disable no-param-reassign */
+
+/**
+ * Resolve the name valid at a given snapshot date.
+ *
+ * The algorithm finds the h_name record whose date_reviewed is the smallest
+ * value still greater than snapshotDate. That record's `name` was the one
+ * active at snapshotDate (it was superseded after snapshotDate).
+ *
+ * @param {Date|string} snapshotDate - The date_reviewed of the snapshot
+ * @param {Array} hNameRecords - All h_name records for the entity (pre-filtered to is_main=true)
+ * @param {string|null} currentName - The current TName main name (fallback)
+ * @returns {string} The resolved name, or '' if none found
+ */
+const resolveNameAtDate = (snapshotDate, hNameRecords, currentName) => {
+  const snapshotTime = new Date(snapshotDate).getTime();
+
+  const futureRecords = (hNameRecords || [])
+    .filter((r) => new Date(r.dateReviewed).getTime() > snapshotTime)
+    .sort(
+      (a, b) =>
+        new Date(a.dateReviewed).getTime() - new Date(b.dateReviewed).getTime()
+    );
+
+  if (futureRecords.length > 0) {
+    return futureRecords[0].name;
+  }
+
+  if (currentName) {
+    return currentName;
+  }
+
+  return '';
+};
+
+/**
+ * Resolve cave names for multiple HEntrance snapshots.
+ * Pure function — all DB data is passed in as arguments.
+ *
+ * @param {Array} hEntrances - HEntrance snapshot objects (each with a `cave` field: number or object)
+ * @param {Map<number, Array>} caveHNameMap - Map of caveId → array of h_name records (is_main=true)
+ * @param {Map<number, string>} currentCaveNameMap - Map of caveId → current TName main name
+ * @returns {Array} The same hEntrances array with `caveName` set on each entry
+ */
+const resolveCaveNamesForSnapshots = (
+  hEntrances,
+  caveHNameMap,
+  currentCaveNameMap
+) => {
+  hEntrances.forEach((entrance) => {
+    const caveId = entrance.cave?.id ?? entrance.cave;
+
+    if (!caveId) {
+      entrance.caveName = null;
+      return;
+    }
+
+    const caveHNames = caveHNameMap.get(caveId) || [];
+    const currentCaveName = currentCaveNameMap.get(caveId) || null;
+
+    entrance.caveName = resolveNameAtDate(
+      entrance.id,
+      caveHNames,
+      currentCaveName
+    );
+  });
+
+  return hEntrances;
+};
+
+/**
+ * Build Name_Change_Snapshot objects from h_name records.
+ *
+ * @param {number} entranceId - The entrance ID
+ * @param {Array} hNameRecords - h_name records with is_main=true for the entrance
+ * @param {Function} resolveCaveNameFn - Function(snapshotDate) to resolve caveName for each synthetic snapshot
+ * @returns {Array} Array of synthetic snapshot objects
+ */
+const buildNameChangeSnapshots = (
+  entranceId,
+  hNameRecords,
+  resolveCaveNameFn
+) =>
+  (hNameRecords || []).map((record) => ({
+    id: record.dateReviewed,
+    t_id:
+      typeof entranceId === 'string' ? parseInt(entranceId, 10) : entranceId,
+    name: record.name,
+    author: record.author,
+    reviewer: record.reviewer,
+    dateInscription: record.dateInscription,
+    dateReviewed: record.dateReviewed,
+    caveName: resolveCaveNameFn(record.dateReviewed),
+    cave: null,
+    latitude: null,
+    longitude: null,
+    altitude: null,
+    isSensitive: false,
+    isDeleted: false,
+    names: [],
+    isNameChangeSnapshot: true,
+  }));
+
+/**
+ * Merge HEntrance snapshots with name-change snapshots, sorted chronologically.
+ * Uses Date parsing for comparison to avoid timezone-dependent string sort issues.
+ *
+ * @param {Array} hEntrances - HEntrance snapshot objects
+ * @param {Array} nameChangeSnapshots - Synthetic name-change snapshot objects
+ * @returns {Array} Merged and sorted array
+ */
+const mergeAndSort = (hEntrances, nameChangeSnapshots) =>
+  [...(hEntrances || []), ...(nameChangeSnapshots || [])].sort(
+    (a, b) => new Date(a.id).getTime() - new Date(b.id).getTime()
+  );
+
+module.exports = {
+  resolveNameAtDate,
+  resolveCaveNamesForSnapshots,
+  buildNameChangeSnapshots,
+  mergeAndSort,
+};

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -388,6 +388,8 @@ const c = {
     } else {
       result.massifs = toList('massifs', source.cave ?? {}, c.toSimpleMassif);
     }
+    result.caveName = source.caveName ?? null;
+    result.isNameChangeSnapshot = source.isNameChangeSnapshot ?? false;
     result.author = convertIfObject(source.author, c.toSimpleCaver);
     result.reviewer = convertIfObject(source.reviewer, c.toSimpleCaver);
     // Convert collections

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -388,8 +388,13 @@ const c = {
     } else {
       result.massifs = toList('massifs', source.cave ?? {}, c.toSimpleMassif);
     }
-    result.caveName = source.caveName ?? null;
-    result.isNameChangeSnapshot = source.isNameChangeSnapshot ?? false;
+    // Only include snapshot-specific fields when set by the snapshot code path
+    if (source.caveName !== undefined) {
+      result.caveName = source.caveName ?? null;
+    }
+    if (source.isNameChangeSnapshot !== undefined) {
+      result.isNameChangeSnapshot = source.isNameChangeSnapshot ?? false;
+    }
     result.author = convertIfObject(source.author, c.toSimpleCaver);
     result.reviewer = convertIfObject(source.reviewer, c.toSimpleCaver);
     // Convert collections

--- a/api/services/mapping/models/EntranceModel.js
+++ b/api/services/mapping/models/EntranceModel.js
@@ -11,8 +11,6 @@ module.exports = {
   author: undefined,
   reviewer: undefined,
   cave: undefined,
-  caveName: undefined,
-  isNameChangeSnapshot: undefined,
   caving: undefined,
   city: undefined,
   comments: [],

--- a/api/services/mapping/models/EntranceModel.js
+++ b/api/services/mapping/models/EntranceModel.js
@@ -11,6 +11,8 @@ module.exports = {
   author: undefined,
   reviewer: undefined,
   cave: undefined,
+  caveName: undefined,
+  isNameChangeSnapshot: undefined,
   caving: undefined,
   city: undefined,
   comments: [],

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -8037,6 +8037,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Name'
+        caveName:
+          type: string
+          nullable: true
+          description: >
+            The resolved cave name at the time of the snapshot. Only present on
+            snapshot responses. Null when the entrance has no cave association.
+        isNameChangeSnapshot:
+          type: boolean
+          default: false
+          description: >
+            True when this snapshot is a synthetic name-change entry injected
+            into the timeline (not a real HEntrance record).
         region:
           type: string
         riggings:

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -8041,14 +8041,16 @@ components:
           type: string
           nullable: true
           description: >
-            The resolved cave name at the time of the snapshot. Only present on
-            snapshot responses. Null when the entrance has no cave association.
+            The resolved cave name at the time of the snapshot. Present only on
+            snapshot responses (/snapshots and /all-snapshots). Null when the
+            entrance has no cave association.
         isNameChangeSnapshot:
           type: boolean
           default: false
           description: >
-            True when this snapshot is a synthetic name-change entry injected
-            into the timeline (not a real HEntrance record).
+            True when this entry is a synthetic name-change event injected
+            into the timeline (not a real HEntrance record). Present only on
+            snapshot responses.
         region:
           type: string
         riggings:

--- a/test/fixtureOrder.js
+++ b/test/fixtureOrder.js
@@ -52,6 +52,7 @@ module.exports = [
   'hlocation',
   'hdescription',
   'hentrance',
+  'hname',
   'hguideline',
   'vcaverroles',
   'vbibliographicmetadata',

--- a/test/fixtures/hname.json
+++ b/test/fixtures/hname.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "name": "Ancien Nom Entrée",
+    "isMain": true,
+    "author": 1,
+    "reviewer": 1,
+    "dateInscription": "2000-01-01T00:00:00.000Z",
+    "dateReviewed": "2005-01-15T10:00:00.000Z",
+    "language": "fra",
+    "entrance": 1,
+    "cave": null,
+    "massif": null,
+    "point": null,
+    "grotto": null
+  },
+  {
+    "id": 2,
+    "name": "Nom Entrée Courant",
+    "isMain": true,
+    "author": 1,
+    "reviewer": 1,
+    "dateInscription": "2005-01-16T00:00:00.000Z",
+    "dateReviewed": "2010-06-20T15:30:00.000Z",
+    "language": "fra",
+    "entrance": 1,
+    "cave": null,
+    "massif": null,
+    "point": null,
+    "grotto": null
+  },
+  {
+    "id": 3,
+    "name": "Grotte de la Montagne",
+    "isMain": true,
+    "author": 1,
+    "reviewer": 1,
+    "dateInscription": "2003-05-10T00:00:00.000Z",
+    "dateReviewed": "2009-03-12T08:00:00.000Z",
+    "language": "fra",
+    "entrance": null,
+    "cave": 3,
+    "massif": null,
+    "point": null,
+    "grotto": null
+  }
+]

--- a/test/integration/1_services/TemporalNameResolver.property.test.js
+++ b/test/integration/1_services/TemporalNameResolver.property.test.js
@@ -1,0 +1,335 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const TemporalNameResolver = require('../../../api/services/TemporalNameResolver');
+
+// --- Shared arbitraries ---
+
+// ISO date string arbitrary: generate a timestamp in ms then convert to ISO string
+const isoDateArb = fc
+  .integer({
+    min: new Date('2000-01-01T00:00:00.000Z').getTime(),
+    max: new Date('2030-12-31T23:59:59.999Z').getTime(),
+  })
+  .map((ts) => new Date(ts).toISOString());
+
+// Name string arbitrary (non-empty alphanumeric)
+const nameArb = fc
+  .string({ minLength: 1, maxLength: 50 })
+  .filter((s) => s.trim().length > 0);
+
+// Positive integer for IDs
+const positiveIntArb = fc.integer({ min: 1, max: 100000 });
+
+// h_name record arbitrary
+const hNameRecordArb = fc.record({
+  name: nameArb,
+  dateReviewed: isoDateArb,
+  dateInscription: isoDateArb,
+  author: fc.record({ id: positiveIntArb, name: nameArb }),
+  reviewer: fc.record({ id: positiveIntArb, name: nameArb }),
+});
+
+/**
+ * Property 1: Temporal entrance name resolution
+ *
+ * For any snapshot date S and any array of h_name records with various
+ * dateReviewed values, and a current name C:
+ * - If records exist with dateReviewed > S, the resolved name equals
+ *   the name of the record with the smallest such dateReviewed
+ * - If no records have dateReviewed > S, the resolved name equals C
+ * - If C is also null/empty, the resolved name is ''
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3, 1.4
+ */
+describe('TemporalNameResolver - Property 1: Temporal entrance name resolution', () => {
+  it('should resolve the correct name based on snapshot date, falling back to currentName then empty string', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(
+        isoDateArb,
+        fc.array(hNameRecordArb, { minLength: 0, maxLength: 20 }),
+        fc.option(nameArb, { nil: null }),
+        (snapshotDate, hNameRecords, currentName) => {
+          const result = TemporalNameResolver.resolveNameAtDate(
+            snapshotDate,
+            hNameRecords,
+            currentName
+          );
+
+          const snapshotTime = new Date(snapshotDate).getTime();
+
+          // Filter records with dateReviewed > snapshotDate
+          const futureRecords = hNameRecords
+            .filter((r) => new Date(r.dateReviewed).getTime() > snapshotTime)
+            .sort(
+              (a, b) =>
+                new Date(a.dateReviewed).getTime() -
+                new Date(b.dateReviewed).getTime()
+            );
+
+          if (futureRecords.length > 0) {
+            // Should equal the name of the record with smallest dateReviewed > S
+            should(result).equal(futureRecords[0].name);
+          } else if (currentName) {
+            // Should fall back to currentName
+            should(result).equal(currentName);
+          } else {
+            // Should fall back to empty string
+            should(result).equal('');
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 2: Temporal cave name resolution uses HEntrance's own id_cave
+ *
+ * For any array of HEntrance records with varying cave IDs (integer or
+ * object with .id) and cave h_name maps, resolveCaveNamesForSnapshots
+ * resolves each record's caveName using its own cave ID.
+ * When cave ID is falsy, caveName is set to null.
+ *
+ * Validates: Requirements 2.1, 2.2, 2.3, 2.4, 3.3
+ */
+describe('TemporalNameResolver - Property 2: Temporal cave name resolution uses HEntrance own id_cave', () => {
+  it('should resolve each entrance caveName from its own cave ID, setting null for falsy cave', function () {
+    this.timeout(30000);
+
+    // Cave ID arbitrary: either a plain integer or an object with .id
+    const caveIdArb = fc.oneof(
+      positiveIntArb,
+      positiveIntArb.map((id) => ({ id }))
+    );
+
+    // HEntrance record with a cave field and an id (snapshot date)
+    const hEntranceArb = fc.record({
+      id: isoDateArb,
+      cave: fc.oneof(caveIdArb, fc.constant(null), fc.constant(undefined)),
+    });
+
+    fc.assert(
+      fc.property(
+        fc.array(hEntranceArb, { minLength: 1, maxLength: 10 }),
+        fc.array(
+          fc.tuple(
+            positiveIntArb,
+            fc.array(hNameRecordArb, { minLength: 0, maxLength: 5 })
+          ),
+          { minLength: 0, maxLength: 5 }
+        ),
+        fc.array(fc.tuple(positiveIntArb, nameArb), {
+          minLength: 0,
+          maxLength: 5,
+        }),
+        (hEntrances, caveHNameEntries, currentCaveNameEntries) => {
+          // Build Maps from generated data
+          const caveHNameMap = new Map(caveHNameEntries);
+          const currentCaveNameMap = new Map(currentCaveNameEntries);
+
+          // Deep copy hEntrances to avoid mutation issues across runs
+          const entrancesCopy = hEntrances.map((e) => ({ ...e }));
+
+          const result = TemporalNameResolver.resolveCaveNamesForSnapshots(
+            entrancesCopy,
+            caveHNameMap,
+            currentCaveNameMap
+          );
+
+          should(result).be.an.Array();
+          should(result.length).equal(entrancesCopy.length);
+
+          for (const entrance of result) {
+            const caveId = entrance.cave?.id ?? entrance.cave;
+
+            if (!caveId) {
+              // Falsy cave → caveName must be null
+              should(entrance.caveName).be.null();
+            } else {
+              // Should resolve using resolveNameAtDate with the cave's data
+              const caveHNames = caveHNameMap.get(caveId) || [];
+              const currentCaveName = currentCaveNameMap.get(caveId) || null;
+              const expected = TemporalNameResolver.resolveNameAtDate(
+                entrance.id,
+                caveHNames,
+                currentCaveName
+              );
+              should(entrance.caveName).equal(expected);
+            }
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 3: Name-change snapshot injection completeness
+ *
+ * Output count from buildNameChangeSnapshots equals input record count.
+ * All required fields are present: id, t_id, name, author, reviewer,
+ * dateInscription, dateReviewed, caveName, isNameChangeSnapshot: true
+ *
+ * Validates: Requirements 3.1, 3.2, 3.5
+ */
+describe('TemporalNameResolver - Property 3: Name-change snapshot injection completeness', () => {
+  it('should produce one snapshot per h_name record with all required fields present', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(
+        positiveIntArb,
+        fc.array(hNameRecordArb, { minLength: 0, maxLength: 20 }),
+        (entranceId, hNameRecords) => {
+          // Simple resolveCaveNameFn that returns a fixed string
+          const resolveCaveNameFn = () => 'TestCave';
+
+          const result = TemporalNameResolver.buildNameChangeSnapshots(
+            entranceId,
+            hNameRecords,
+            resolveCaveNameFn
+          );
+
+          // Output count equals input count
+          should(result.length).equal(hNameRecords.length);
+
+          // All required fields are present on each snapshot
+          for (let i = 0; i < result.length; i += 1) {
+            const snapshot = result[i];
+            const source = hNameRecords[i];
+
+            should(snapshot).have.property('id', source.dateReviewed);
+            should(snapshot).have.property('t_id', entranceId);
+            should(snapshot).have.property('name', source.name);
+            should(snapshot).have.property('author', source.author);
+            should(snapshot).have.property('reviewer', source.reviewer);
+            should(snapshot).have.property(
+              'dateInscription',
+              source.dateInscription
+            );
+            should(snapshot).have.property('dateReviewed', source.dateReviewed);
+            should(snapshot).have.property('caveName');
+            should(snapshot).have.property('isNameChangeSnapshot', true);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 4: Merged timeline is sorted chronologically
+ *
+ * mergeAndSort output is always sorted by new Date(item.id).getTime()
+ * ascending, regardless of input order.
+ *
+ * Validates: Requirements 3.4
+ */
+describe('TemporalNameResolver - Property 4: Merged timeline is sorted chronologically', () => {
+  it('should produce a chronologically sorted output regardless of input order', function () {
+    this.timeout(30000);
+
+    // Simple snapshot-like object with an id (ISO date string)
+    const snapshotArb = fc.record({
+      id: isoDateArb,
+      name: nameArb,
+    });
+
+    fc.assert(
+      fc.property(
+        fc.array(snapshotArb, { minLength: 0, maxLength: 20 }),
+        fc.array(snapshotArb, { minLength: 0, maxLength: 20 }),
+        (hEntrances, nameChangeSnapshots) => {
+          const result = TemporalNameResolver.mergeAndSort(
+            hEntrances,
+            nameChangeSnapshots
+          );
+
+          // Total length is sum of both inputs
+          should(result.length).equal(
+            hEntrances.length + nameChangeSnapshots.length
+          );
+
+          // Verify chronological sort by Date comparison
+          for (let i = 1; i < result.length; i += 1) {
+            const prev = new Date(result[i - 1].id).getTime();
+            const curr = new Date(result[i].id).getTime();
+            should(prev).be.belowOrEqual(
+              curr,
+              `Items at index ${i - 1} and ${i} are not in chronological order: ${result[i - 1].id} > ${result[i].id}`
+            );
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 5: Converter caveName and isNameChangeSnapshot passthrough
+ *
+ * For any source object passed to toEntrance:
+ * - If source.caveName is a non-null string, then result.caveName equals it
+ * - If source.caveName is null or undefined, then result.caveName is null
+ * - If source.isNameChangeSnapshot is true, then result.isNameChangeSnapshot is true
+ * - If source.isNameChangeSnapshot is undefined or false, then result.isNameChangeSnapshot is false
+ *
+ * Validates: Requirements 4.2, 4.3
+ */
+describe('TemporalNameResolver - Property 5: Converter caveName and isNameChangeSnapshot passthrough', () => {
+  // eslint-disable-next-line global-require
+  const { toEntrance } = require('../../../api/services/mapping/converters');
+
+  it('should pass through caveName and isNameChangeSnapshot correctly for any source', function () {
+    this.timeout(30000);
+
+    const caveNameArb = fc.oneof(
+      nameArb,
+      fc.constant(null),
+      fc.constant(undefined)
+    );
+
+    const isNameChangeSnapshotArb = fc.oneof(
+      fc.constant(true),
+      fc.constant(false),
+      fc.constant(undefined)
+    );
+
+    fc.assert(
+      fc.property(
+        caveNameArb,
+        isNameChangeSnapshotArb,
+        (caveName, isNameChangeSnapshot) => {
+          const source = {
+            id: 1,
+            names: [],
+            caveName,
+            isNameChangeSnapshot,
+          };
+
+          const result = toEntrance(source);
+
+          // caveName passthrough
+          if (caveName != null) {
+            should(result.caveName).equal(caveName);
+          } else {
+            should(result.caveName).be.null();
+          }
+
+          // isNameChangeSnapshot passthrough
+          if (isNameChangeSnapshot === true) {
+            should(result.isNameChangeSnapshot).equal(true);
+          } else {
+            should(result.isNameChangeSnapshot).equal(false);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/TemporalNameResolver.property.test.js
+++ b/test/integration/1_services/TemporalNameResolver.property.test.js
@@ -314,15 +314,19 @@ describe('TemporalNameResolver - Property 5: Converter caveName and isNameChange
 
           const result = toEntrance(source);
 
-          // caveName passthrough
-          if (caveName != null) {
-            should(result.caveName).equal(caveName);
-          } else {
+          // caveName passthrough: only present when source has it defined
+          if (caveName === undefined) {
+            should(result).not.have.property('caveName');
+          } else if (caveName === null) {
             should(result.caveName).be.null();
+          } else {
+            should(result.caveName).equal(caveName);
           }
 
-          // isNameChangeSnapshot passthrough
-          if (isNameChangeSnapshot === true) {
+          // isNameChangeSnapshot passthrough: only present when source has it defined
+          if (isNameChangeSnapshot === undefined) {
+            should(result).not.have.property('isNameChangeSnapshot');
+          } else if (isNameChangeSnapshot === true) {
             should(result.isNameChangeSnapshot).equal(true);
           } else {
             should(result.isNameChangeSnapshot).equal(false);

--- a/test/integration/4_routes/Snapshots/get-snapshots-entrances.test.js
+++ b/test/integration/4_routes/Snapshots/get-snapshots-entrances.test.js
@@ -20,11 +20,16 @@ describe('Entrances snapshots features', () => {
           if (err) return done(err);
           const { body: entrances } = res;
           should(entrances).not.be.empty();
-          should(entrances.entrances[0]).not.be.null();
-          should(entrances.entrances[0].latitude).not.be.null();
-          should(entrances.entrances[0].longitude).not.be.null();
-          should(entrances.entrances[0].cave).equal(3);
-          should(entrances.entrances[0].caveName).not.be.null();
+          // Find the first regular (non-name-change) snapshot
+          const regularSnapshots = entrances.entrances.filter(
+            (e) => !e.isNameChangeSnapshot
+          );
+          should(regularSnapshots.length).be.above(0);
+          should(regularSnapshots[0].latitude).not.be.null();
+          should(regularSnapshots[0].longitude).not.be.null();
+          should(regularSnapshots[0].cave).equal(3);
+          should(regularSnapshots[0].caveName).be.a.String().and.not.be.empty();
+          should(regularSnapshots[0].caveName).equal('Grotte de la Montagne');
           return done();
         });
     });
@@ -58,6 +63,57 @@ describe('Entrances snapshots features', () => {
           should(entrances.entrances[0]).not.be.null();
           should(entrances.entrances[0].latitude).be.null();
           should(entrances.entrances[0].longitude).be.null();
+          return done();
+        });
+    });
+    it('should include name-change snapshots in the timeline (network)', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/1/snapshots?isNetwork=true')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: entrances } = res;
+          const nameChangeSnapshots = entrances.entrances.filter(
+            (e) => e.isNameChangeSnapshot === true
+          );
+          // We have 2 h_name records for entrance 1 with is_main=true
+          should(nameChangeSnapshots.length).equal(2);
+          nameChangeSnapshots.forEach((s) => {
+            should(s.isNameChangeSnapshot).equal(true);
+            should(s.name).be.a.String().and.not.be.empty();
+            should(s.t_id).equal(1);
+          });
+          return done();
+        });
+    });
+  });
+
+  describe('get-all-snapshots()', () => {
+    it('should return temporal caveName and name-change snapshots in entrances array (network)', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/entrances/1/all-snapshots?isNetwork=true')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body } = res;
+          should(body.entrances).be.an.Array().and.not.be.empty();
+          // Verify caveName is temporally resolved
+          const regularSnapshots = body.entrances.filter(
+            (e) => !e.isNameChangeSnapshot
+          );
+          should(regularSnapshots.length).be.above(0);
+          regularSnapshots.forEach((s) => {
+            should(s.caveName).be.a.String().and.not.be.empty();
+          });
+          // Verify name-change snapshots are injected
+          const nameChangeSnapshots = body.entrances.filter(
+            (e) => e.isNameChangeSnapshot === true
+          );
+          should(nameChangeSnapshots.length).equal(2);
           return done();
         });
     });


### PR DESCRIPTION
## 🤔 What

Fix four bugs in the entrance snapshot timeline endpoints (`GET /api/v1/entrances/:id/snapshots` and `GET /api/v1/entrances/:id/all-snapshots`):

- Each snapshot now displays the entrance name **valid at that snapshot's date**, not the current name
- Each snapshot now displays the cave name **valid at that snapshot's date**, using the HEntrance record's own `id_cave`
- Name-change events (`h_name` records) now appear as distinct entries in the timeline with `isNameChangeSnapshot: true`
- The `caveName` and `isNameChangeSnapshot` fields are now exposed in the API response (previously silently dropped by the converter)

Closes #1717

## 🤷‍♂️ Why

The snapshot timeline is supposed to show the historical state of an entrance at each point in time. The previous implementation used `NameService.setNames` which queries `t_name` (current state only), making all snapshots show the same current name regardless of when they were taken. This defeated the purpose of the history view.

Additionally, rename events were invisible in the timeline even though the database trigger archives old names into `h_name`.

## 🔍 How

- **New service: `TemporalNameResolver`** — pure functions (no DB calls) for temporal name resolution, enabling property-based testing:
  - `resolveNameAtDate(snapshotDate, hNameRecords, currentName)` — finds the h_name with smallest `date_reviewed > snapshotDate`
  - `resolveCaveNamesForSnapshots(hEntrances, caveHNameMap, currentCaveNameMap)` — resolves cave names per HEntrance record
  - `buildNameChangeSnapshots(entranceId, hNameRecords, resolveCaveNameFn)` — creates synthetic snapshot entries for rename events
  - `mergeAndSort(hEntrances, nameChangeSnapshots)` — chronological merge using Date comparison

- **Refactored `EntranceService.getHEntrancesWithName`** — replaced `NameService.setNames` calls with temporal resolution from `h_name` + `t_name` fallback. Both endpoints share this code path.

- **Updated `EntranceModel` and `toEntrance` converter** — added `caveName` and `isNameChangeSnapshot` passthrough.

## 🧪 Testing

- 5 property-based tests (fast-check, 100 runs each) validating all correctness properties
- Integration tests for both endpoints asserting temporal `caveName` values and name-change snapshot injection
- Full test suite passes (3117 passing, 2 pre-existing unrelated failures in `login-banned.test.js`)

Manual test:
```bash
curl http://localhost:1337/api/v1/entrances/36774/snapshots
curl http://localhost:1337/api/v1/entrances/36774/all-snapshots
```

Verify that `caveName` changes across snapshots reflecting the cave's name history, and that entries with `isNameChangeSnapshot: true` appear in the timeline.
