### PR TITLE
feat(document): add image thumbnail generation on upload

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
     TSubstance: 'readonly',
     SubstanceService: 'readonly',
     PubChemService: 'readonly',
+    ThumbnailService: 'readonly',
     TType: 'readonly',
     TTokenBlacklist: 'readonly',
     TConversation: 'readonly',

--- a/api/models/TFile.js
+++ b/api/models/TFile.js
@@ -62,5 +62,26 @@ module.exports = {
       columnName: 'id_document',
       model: 'TDocument',
     },
+
+    thumbnailSmall: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'thumbnail_small',
+      maxLength: 1000,
+    },
+
+    thumbnailMedium: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'thumbnail_medium',
+      maxLength: 1000,
+    },
+
+    thumbnailLarge: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'thumbnail_large',
+      maxLength: 1000,
+    },
   },
 };

--- a/api/services/FileService.js
+++ b/api/services/FileService.js
@@ -86,6 +86,26 @@ module.exports = {
 
   isCredentials: !!credentials,
 
+  /**
+   * Test-only: Retrieve the current module-level credentials object.
+   * Used by tests to save original credentials before injecting mocks.
+   * @returns {object|null}
+   */
+  getCredentialsForTest() {
+    return credentials;
+  },
+
+  /**
+   * Test-only: Override the module-level credentials object.
+   * Allows integration tests to inject a mock blob client without
+   * reimplementing create/delete. Call with `null` to restore original.
+   * @param {object|null} mockCredentials
+   */
+  setCredentialsForTest(mockCredentials) {
+    credentials = mockCredentials;
+    this.isCredentials = !!mockCredentials;
+  },
+
   document: {
     getUrl(path) {
       // The documents container allow anonymous access

--- a/api/services/FileService.js
+++ b/api/services/FileService.js
@@ -126,7 +126,7 @@ module.exports = {
       if (foundFormat.length === 0) {
         throw new FileError(INVALID_FORMAT, name);
       }
-      const { mimeType } = foundFormat;
+      const { mimeType } = foundFormat[0];
 
       if (!credentials) {
         noCredentialWarning('Document upload', {
@@ -147,6 +147,21 @@ module.exports = {
         }
       }
 
+      let thumbnailPaths = { small: null, medium: null, large: null };
+      const fileMimeType = foundFormat[0].mimeType;
+      if (credentials && ThumbnailService.isProcessable(fileMimeType)) {
+        try {
+          thumbnailPaths = await ThumbnailService.generate(
+            file.buffer,
+            pathName,
+            credentials.documentsBlobClient
+          );
+        } catch (err) {
+          sails.log.error('Thumbnail generation failed:', err);
+          // Continue — thumbnails are optional
+        }
+      }
+
       const param = {
         dateInscription: new Date(),
         fileName: name,
@@ -154,6 +169,9 @@ module.exports = {
         fileFormat: foundFormat[0].id,
         path: pathName,
         isValidated,
+        thumbnailSmall: thumbnailPaths.small,
+        thumbnailMedium: thumbnailPaths.medium,
+        thumbnailLarge: thumbnailPaths.large,
       };
       if (fetchResult) {
         let createQuery = TFile.create(param);
@@ -187,6 +205,27 @@ module.exports = {
             destroyedRecord.path
           );
         await blockBlobClient.delete({ deleteSnapshots: 'include' });
+
+        // Best-effort cleanup of thumbnail blobs
+        const thumbnailPaths = [
+          destroyedRecord.thumbnailSmall,
+          destroyedRecord.thumbnailMedium,
+          destroyedRecord.thumbnailLarge,
+        ].filter(Boolean);
+        await Promise.all(
+          thumbnailPaths.map(async (thumbPath) => {
+            try {
+              const thumbBlobClient =
+                credentials.documentsBlobClient.getBlockBlobClient(thumbPath);
+              await thumbBlobClient.delete({ deleteSnapshots: 'include' });
+            } catch (err) {
+              sails.log.error(
+                `Failed to delete thumbnail blob ${thumbPath}:`,
+                err
+              );
+            }
+          })
+        );
       }
       return destroyedRecord;
     },

--- a/api/services/ThumbnailService.js
+++ b/api/services/ThumbnailService.js
@@ -1,0 +1,141 @@
+/**
+ * ThumbnailService.js
+ *
+ * @description :: Service for generating image thumbnails using sharp.
+ *   Encapsulates resize + WebP conversion logic and Azure upload for variants.
+ */
+
+const sharp = require('sharp');
+const path = require('path');
+
+/**
+ * MIME types that sharp can process for thumbnail generation.
+ * Excludes SVG (rasterization unreliable), PCX, DXF (unsupported by sharp).
+ * Note: image/webp is excluded because webp is not registered in t_file_format,
+ * so webp uploads are rejected before reaching this code.
+ */
+const PROCESSABLE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/tiff',
+  'image/x-ms-bmp',
+]);
+
+const VARIANTS = [
+  { name: 'small', width: 480 },
+  { name: 'medium', width: 1280 },
+  { name: 'large', width: 1920 },
+];
+
+const WEBP_QUALITY = 80;
+
+module.exports = {
+  PROCESSABLE_MIME_TYPES,
+  VARIANTS,
+  WEBP_QUALITY,
+
+  /**
+   * Determine if a MIME type is processable for thumbnails.
+   * @param {string} mimeType
+   * @returns {boolean}
+   */
+  isProcessable(mimeType) {
+    return PROCESSABLE_MIME_TYPES.has(mimeType);
+  },
+
+  /**
+   * Compute the thumbnail blob path for a given variant and original path.
+   * @param {string} variant - 'small' | 'medium' | 'large'
+   * @param {string} originalPath - e.g. '12345-cave-entrance.jpg'
+   * @returns {string} e.g. 'thumbnails/small/12345-cave-entrance.webp'
+   */
+  computeThumbnailPath(variant, originalPath) {
+    const ext = path.extname(originalPath);
+    const stem = originalPath.slice(0, originalPath.length - ext.length);
+    return `thumbnails/${variant}/${stem}.webp`;
+  },
+
+  /**
+   * Determine which variants should be generated based on original width.
+   * Only returns variants whose target width is strictly less than the original.
+   * @param {number} originalWidth - Width of the source image in pixels
+   * @returns {Array<{name: string, width: number}>}
+   */
+  getApplicableVariants(originalWidth) {
+    return VARIANTS.filter((v) => v.width < originalWidth);
+  },
+
+  /**
+   * Resize an image buffer to the target width, output as WebP.
+   * Preserves aspect ratio (no crop, no upscaling).
+   * Preserves alpha channel for PNG inputs and animation for GIF inputs.
+   * @param {Buffer} inputBuffer - The original image buffer
+   * @param {number} targetWidth - The target width in pixels
+   * @returns {Promise<Buffer>} The resized WebP buffer
+   */
+  async resize(inputBuffer, targetWidth) {
+    return sharp(inputBuffer, { animated: true })
+      .resize({ width: targetWidth, withoutEnlargement: true })
+      .webp({ quality: WEBP_QUALITY })
+      .toBuffer();
+  },
+
+  /**
+   * Generate all applicable thumbnail variants for an image.
+   * Uses an all-or-nothing approach: generates all buffers first, then uploads.
+   * If any step fails, returns all nulls.
+   *
+   * @param {Buffer} imageBuffer - The original image file buffer
+   * @param {string} originalPath - The blob path of the original
+   * @param {object} blobClient - Azure container client for uploading
+   * @returns {Promise<{small: string|null, medium: string|null, large: string|null}>}
+   */
+  async generate(imageBuffer, originalPath, blobClient) {
+    const result = { small: null, medium: null, large: null };
+
+    try {
+      const metadata = await sharp(imageBuffer).metadata();
+      const { width: originalWidth } = metadata;
+
+      if (!originalWidth) {
+        return result;
+      }
+
+      const applicableVariants = this.getApplicableVariants(originalWidth);
+
+      if (applicableVariants.length === 0) {
+        return result;
+      }
+
+      // Generate all buffers first (fail-fast before uploading)
+      const buffers = await Promise.all(
+        applicableVariants.map(async (variant) => ({
+          name: variant.name,
+          buffer: await this.resize(imageBuffer, variant.width),
+          path: this.computeThumbnailPath(variant.name, originalPath),
+        }))
+      );
+
+      // Upload all variants
+      await Promise.all(
+        buffers.map(async ({ path: blobPath, buffer }) => {
+          const blockBlobClient = blobClient.getBlockBlobClient(blobPath);
+          await blockBlobClient.uploadData(buffer, {
+            blobHTTPHeaders: { blobContentType: 'image/webp' },
+          });
+        })
+      );
+
+      // All uploads succeeded — populate result
+      buffers.forEach(({ name, path: blobPath }) => {
+        result[name] = blobPath;
+      });
+    } catch (err) {
+      sails.log.error('ThumbnailService.generate failed:', err);
+      return { small: null, medium: null, large: null };
+    }
+
+    return result;
+  },
+};

--- a/api/services/ThumbnailService.js
+++ b/api/services/ThumbnailService.js
@@ -84,15 +84,15 @@ module.exports = {
   /**
    * Generate all applicable thumbnail variants for an image.
    * Uses an all-or-nothing approach: generates all buffers first, then uploads.
-   * If any step fails, returns all nulls.
+   * If any step fails, returns all nulls with hadError: true.
    *
    * @param {Buffer} imageBuffer - The original image file buffer
    * @param {string} originalPath - The blob path of the original
    * @param {object} blobClient - Azure container client for uploading
-   * @returns {Promise<{small: string|null, medium: string|null, large: string|null}>}
+   * @returns {Promise<{small: string|null, medium: string|null, large: string|null, hadError: boolean}>}
    */
   async generate(imageBuffer, originalPath, blobClient) {
-    const result = { small: null, medium: null, large: null };
+    const result = { small: null, medium: null, large: null, hadError: false };
 
     try {
       const metadata = await sharp(imageBuffer).metadata();
@@ -118,6 +118,12 @@ module.exports = {
       );
 
       // Upload all variants
+      // NOTE: If a subset of uploads succeeds before one fails, the successful
+      // uploads become orphaned blobs in Azure (the catch block returns all-null,
+      // so the DB never stores those paths and FileService.document.delete won't
+      // clean them up). This is a known trade-off: orphaned blobs are rare and
+      // low-cost compared to the complexity of per-variant rollback. A periodic
+      // storage cleanup job could address this if it becomes a concern.
       await Promise.all(
         buffers.map(async ({ path: blobPath, buffer }) => {
           const blockBlobClient = blobClient.getBlockBlobClient(blobPath);
@@ -133,7 +139,7 @@ module.exports = {
       });
     } catch (err) {
       sails.log.error('ThumbnailService.generate failed:', err);
-      return { small: null, medium: null, large: null };
+      return { small: null, medium: null, large: null, hadError: true };
     }
 
     return result;

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -505,13 +505,30 @@ const c = {
     return result;
   },
 
-  toFile: (source) => ({
-    id: source.id,
-    dateInscription: source.dateInscription,
-    isValidated: source.isValidated,
-    fileName: source.fileName,
-    completePath: FileService.document.getUrl(source.path),
-  }),
+  toFile: (source) => {
+    const hasThumbnails =
+      source.thumbnailSmall || source.thumbnailMedium || source.thumbnailLarge;
+    return {
+      id: source.id,
+      dateInscription: source.dateInscription,
+      isValidated: source.isValidated,
+      fileName: source.fileName,
+      completePath: FileService.document.getUrl(source.path),
+      thumbnails: hasThumbnails
+        ? {
+            small: source.thumbnailSmall
+              ? FileService.document.getUrl(source.thumbnailSmall)
+              : null,
+            medium: source.thumbnailMedium
+              ? FileService.document.getUrl(source.thumbnailMedium)
+              : null,
+            large: source.thumbnailLarge
+              ? FileService.document.getUrl(source.thumbnailLarge)
+              : null,
+          }
+        : null,
+    };
+  },
 
   toSimpleHistory: (source) => {
     const result = {

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -8150,18 +8150,38 @@ components:
     File:
       type: object
       properties:
+        id:
+          type: integer
         dateInscription:
           type: string
-        dateReviewed:
-          type: string
-        document:
-          $ref: '#/components/schemas/Document'
-        fileFormat:
-          $ref: '#/components/schemas/File-format'
+        isValidated:
+          type: boolean
         fileName:
           type: string
-        path:
+        completePath:
           type: string
+          description: Full public URL to the original file in Azure Blob Storage.
+        thumbnails:
+          type: object
+          nullable: true
+          description: >
+            Resized WebP variants of the original image for responsive display.
+            Null entirely for non-image files or if thumbnail generation failed.
+            Individual variants may be null if the original image is smaller
+            than the target width (no upscaling).
+          properties:
+            small:
+              type: string
+              nullable: true
+              description: 480px wide variant for card previews (desktop 240 CSS × 2 DPR).
+            medium:
+              type: string
+              nullable: true
+              description: 1280px wide variant for mobile full-width cards (~430 CSS × 3 DPR).
+            large:
+              type: string
+              nullable: true
+              description: 1920px wide variant for lightbox default view.
 
     File-format:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "sails": "^1.5.17",
         "sails-hook-orm": "^4.0.3",
         "sails-postgresql": "^5.0.1",
+        "sharp": "^0.33.5",
         "typesense": "^3.0.6",
         "underscore.date": "^0.6.1",
         "underscore.string": "^3.3.6",
@@ -1273,6 +1274,16 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
@@ -1403,6 +1414,367 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3542,7 +3914,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3555,7 +3926,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -4305,6 +4675,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dezalgo": {
@@ -11639,6 +12018,68 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11798,6 +12239,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sails": "^1.5.17",
     "sails-hook-orm": "^4.0.3",
     "sails-postgresql": "^5.0.1",
+    "sharp": "^0.33.5",
     "typesense": "^3.0.6",
     "underscore.date": "^0.6.1",
     "underscore.string": "^3.3.6",

--- a/scripts/backfill-thumbnails.js
+++ b/scripts/backfill-thumbnails.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-await-in-loop, no-loop-func, global-require */
+
+/**
+ * Backfill Thumbnails Script
+ *
+ * Generates thumbnails for existing image files that don't have any.
+ * Lifts Sails to access models, config, and services.
+ *
+ * Usage:
+ *   node scripts/backfill-thumbnails.js
+ *   node scripts/backfill-thumbnails.js --dry-run
+ *   node scripts/backfill-thumbnails.js --batch-size 5
+ */
+
+const Sails = require('sails');
+const rc = require('sails/accessible/rc');
+const {
+  BlobServiceClient,
+  StorageSharedKeyCredential,
+} = require('@azure/storage-blob');
+
+// Parse CLI flags
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const batchSizeIndex = args.indexOf('--batch-size');
+const batchSize =
+  batchSizeIndex !== -1 ? parseInt(args[batchSizeIndex + 1], 10) || 10 : 10;
+
+async function run() {
+  // Lift Sails in non-server mode
+  const sailsApp = await new Promise((resolve, reject) => {
+    Sails.lift(
+      {
+        ...rc('sails'),
+        hooks: {
+          blueprints: false,
+          orm: require('sails-hook-orm'),
+          grunt: false,
+          pubsub: false,
+          sockets: false,
+          views: false,
+        },
+        log: { level: 'warn' },
+      },
+      (err, app) => {
+        if (err) return reject(err);
+        return resolve(app);
+      }
+    );
+  });
+
+  try {
+    // Query file records without thumbnails in pages to avoid loading all into memory
+    const pageSize = 500;
+    let skip = 0;
+    let page;
+    const imageFiles = [];
+
+    do {
+      page = await TFile.find({
+        where: {
+          thumbnailSmall: null,
+          thumbnailMedium: null,
+          thumbnailLarge: null,
+        },
+      })
+        .populate('fileFormat')
+        .limit(pageSize)
+        .skip(skip);
+
+      page.forEach((f) => {
+        if (!f.fileFormat || !f.fileFormat.mimeType) return;
+        const { mimeType } = f.fileFormat;
+        if (mimeType === 'image/svg+xml') return;
+        if (ThumbnailService.isProcessable(mimeType)) {
+          imageFiles.push(f);
+        }
+      });
+
+      skip += pageSize;
+    } while (page.length === pageSize);
+
+    console.log(`Found ${imageFiles.length} image files without thumbnails.`);
+
+    if (dryRun) {
+      console.log('[DRY RUN] Would process', imageFiles.length, 'files.');
+      console.log('[DRY RUN] No changes made.');
+      sailsApp.lower();
+      process.exit(0);
+      return;
+    }
+
+    if (imageFiles.length === 0) {
+      console.log('Nothing to process.');
+      sailsApp.lower();
+      process.exit(0);
+      return;
+    }
+
+    // Check Azure credentials
+    if (!process.env.AZURE_KEY) {
+      console.error(
+        'ERROR: Azure credentials not configured. Set AZURE_KEY environment variable.'
+      );
+      sailsApp.lower();
+      process.exit(1);
+      return;
+    }
+
+    // Build Azure container client
+    const sharedKeyCredential = new StorageSharedKeyCredential(
+      'grottocenter',
+      process.env.AZURE_KEY
+    );
+    const blobServiceClient = new BlobServiceClient(
+      'https://grottocenter.blob.core.windows.net/',
+      sharedKeyCredential
+    );
+    const containerClient = blobServiceClient.getContainerClient('documents');
+
+    let processed = 0;
+    let succeeded = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    // Process in batches
+    for (let i = 0; i < imageFiles.length; i += batchSize) {
+      const batch = imageFiles.slice(i, i + batchSize);
+
+      await Promise.all(
+        batch.map(async (file) => {
+          try {
+            // Download original from Azure
+            const blockBlobClient = containerClient.getBlockBlobClient(
+              file.path
+            );
+
+            const downloadResponse = await blockBlobClient.download(0);
+            const chunks = [];
+            for await (const chunk of downloadResponse.readableStreamBody) {
+              chunks.push(chunk);
+            }
+            const imageBuffer = Buffer.concat(chunks);
+
+            // Generate thumbnails
+            const thumbnailPaths = await ThumbnailService.generate(
+              imageBuffer,
+              file.path,
+              containerClient
+            );
+
+            // Update DB record
+            if (
+              thumbnailPaths.small ||
+              thumbnailPaths.medium ||
+              thumbnailPaths.large
+            ) {
+              await TFile.updateOne(file.id).set({
+                thumbnailSmall: thumbnailPaths.small,
+                thumbnailMedium: thumbnailPaths.medium,
+                thumbnailLarge: thumbnailPaths.large,
+              });
+              succeeded += 1;
+            } else {
+              skipped += 1;
+            }
+          } catch (err) {
+            console.error(`ERROR processing file ${file.id}:`, err.message);
+            failed += 1;
+          }
+          processed += 1;
+        })
+      );
+
+      console.log(
+        `Processed ${processed}/${imageFiles.length} files, ${failed} error(s)`
+      );
+    }
+
+    console.log('\n--- Summary ---');
+    console.log(`Total files: ${imageFiles.length}`);
+    console.log(`Succeeded: ${succeeded}`);
+    console.log(`Skipped (too small): ${skipped}`);
+    console.log(`Failed: ${failed}`);
+
+    sailsApp.lower();
+    process.exit(failed > 0 && succeeded === 0 ? 1 : 0);
+  } catch (err) {
+    console.error('Fatal error:', err);
+    sailsApp.lower();
+    process.exit(1);
+  }
+}
+
+run();

--- a/scripts/backfill-thumbnails.js
+++ b/scripts/backfill-thumbnails.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-await-in-loop, no-loop-func, global-require */
+/* eslint-disable no-await-in-loop, no-loop-func, global-require, no-console */
 
 /**
  * Backfill Thumbnails Script
@@ -163,6 +163,11 @@ async function run() {
                 thumbnailLarge: thumbnailPaths.large,
               });
               succeeded += 1;
+            } else if (thumbnailPaths.hadError) {
+              console.error(
+                `WARNING: file ${file.id} failed thumbnail generation (not just too small)`
+              );
+              failed += 1;
             } else {
               skipped += 1;
             }

--- a/sql/9_16_2026_07_05_file_thumbnail_columns.sql
+++ b/sql/9_16_2026_07_05_file_thumbnail_columns.sql
@@ -1,0 +1,5 @@
+\c grottoce;
+
+ALTER TABLE t_file ADD COLUMN IF NOT EXISTS thumbnail_small VARCHAR(1000);
+ALTER TABLE t_file ADD COLUMN IF NOT EXISTS thumbnail_medium VARCHAR(1000);
+ALTER TABLE t_file ADD COLUMN IF NOT EXISTS thumbnail_large VARCHAR(1000);

--- a/test/fixtures/tfileformat.json
+++ b/test/fixtures/tfileformat.json
@@ -73,5 +73,25 @@
     "id": 51,
     "extension": "txt",
     "mimeType": "text/plain"
+  },
+  {
+    "id": 100,
+    "extension": "jpg",
+    "mimeType": "image/jpeg"
+  },
+  {
+    "id": 101,
+    "extension": "png",
+    "mimeType": "image/png"
+  },
+  {
+    "id": 102,
+    "extension": "gif",
+    "mimeType": "image/gif"
+  },
+  {
+    "id": 103,
+    "extension": "svg",
+    "mimeType": "image/svg+xml"
   }
 ]

--- a/test/integration/1_services/FileService.thumbnails.test.js
+++ b/test/integration/1_services/FileService.thumbnails.test.js
@@ -2,145 +2,44 @@ const should = require('should');
 const sinon = require('sinon');
 const sharp = require('sharp');
 const FileService = require('../../../api/services/FileService');
-const ThumbnailService = require('../../../api/services/ThumbnailService');
 
 describe('FileService.document - Thumbnail Integration', () => {
-  // Store original methods for restoration
-  const originalCreate = FileService.document.create;
-  const originalDelete = FileService.document.delete;
-  const originalIsCredentials = FileService.isCredentials;
-
-  // Mock blob client
   let mockUploadData;
   let mockDeleteBlob;
-  let uploadedBlobs;
   let mockContainerClient;
+  let originalIsCredentials;
+  let originalCredentials;
 
   before(() => {
+    // Save original state to restore later
+    originalIsCredentials = FileService.isCredentials;
+    originalCredentials = FileService.getCredentialsForTest();
+
     mockUploadData = sinon.stub().resolves();
     mockDeleteBlob = sinon.stub().resolves();
-    uploadedBlobs = {};
 
     mockContainerClient = {
       getBlockBlobClient: (blobPath) => ({
-        uploadData: async (buffer, options) => {
-          uploadedBlobs[blobPath] = { buffer, options };
-          return mockUploadData(buffer, options);
-        },
-        delete: async (options) => {
-          mockDeleteBlob(blobPath, options);
-        },
+        uploadData: async (buffer, options) =>
+          mockUploadData(blobPath, buffer, options),
+        delete: async (options) => mockDeleteBlob(blobPath, options),
       }),
     };
 
-    // Patch create to use mock credentials
-    FileService.document.create = async function (
-      file,
-      idDocument,
-      fetchResult = false,
-      isValidated = true
-    ) {
-      const name = file.originalname;
-      const pathName = `${Math.random()
-        .toString()
-        .replace(/0\./, '')}-${name.replace(/ /, '_')}`;
-      const lastDot = name.lastIndexOf('.');
-      if (lastDot <= 0 || lastDot === name.length - 1) {
-        const err = new Error(FileService.INVALID_NAME);
-        err.fileName = name;
-        throw err;
-      }
-      const extension = name.slice(lastDot + 1).toLowerCase();
-
-      const foundFormat = await TFileFormat.find({ extension }).limit(1);
-      if (foundFormat.length === 0) {
-        const err = new Error(FileService.INVALID_FORMAT);
-        err.fileName = name;
-        throw err;
-      }
-
-      // Upload original
-      const blockBlobClient = mockContainerClient.getBlockBlobClient(pathName);
-      await blockBlobClient.uploadData(file.buffer, {
-        blobHTTPHeaders: { blobContentType: foundFormat[0].mimeType },
-      });
-
-      // Thumbnail generation (matches actual FileService logic)
-      let thumbnailPaths = { small: null, medium: null, large: null };
-      const fileMimeType = foundFormat[0].mimeType;
-      if (ThumbnailService.isProcessable(fileMimeType)) {
-        try {
-          thumbnailPaths = await ThumbnailService.generate(
-            file.buffer,
-            pathName,
-            mockContainerClient
-          );
-        } catch (err) {
-          sails.log.error('Thumbnail generation failed:', err);
-        }
-      }
-
-      const param = {
-        dateInscription: new Date(),
-        fileName: name,
-        document: idDocument,
-        fileFormat: foundFormat[0].id,
-        path: pathName,
-        isValidated,
-        thumbnailSmall: thumbnailPaths.small,
-        thumbnailMedium: thumbnailPaths.medium,
-        thumbnailLarge: thumbnailPaths.large,
-      };
-      if (fetchResult) {
-        return TFile.create(param).fetch();
-      }
-      return TFile.create(param);
-    };
-
-    // Patch delete to use mock credentials
-    FileService.document.delete = async function (file) {
-      const destroyedRecord = await TFile.destroyOne(file.id);
-      const blockBlobClient = mockContainerClient.getBlockBlobClient(
-        destroyedRecord.path
-      );
-      await blockBlobClient.delete({ deleteSnapshots: 'include' });
-
-      // Clean up thumbnail blobs
-      const thumbnailPaths = [
-        destroyedRecord.thumbnailSmall,
-        destroyedRecord.thumbnailMedium,
-        destroyedRecord.thumbnailLarge,
-      ].filter(Boolean);
-      await Promise.all(
-        thumbnailPaths.map(async (thumbPath) => {
-          try {
-            const thumbBlobClient =
-              mockContainerClient.getBlockBlobClient(thumbPath);
-            await thumbBlobClient.delete({ deleteSnapshots: 'include' });
-          } catch (err) {
-            sails.log.error(
-              `Failed to delete thumbnail blob ${thumbPath}:`,
-              err
-            );
-          }
-        })
-      );
-
-      return destroyedRecord;
-    };
-
-    FileService.isCredentials = true;
+    // Inject mock credentials so the real create/delete code paths run
+    FileService.setCredentialsForTest({
+      documentsBlobClient: mockContainerClient,
+    });
   });
 
   beforeEach(() => {
     mockUploadData.resetHistory();
     mockDeleteBlob.resetHistory();
-    uploadedBlobs = {};
   });
 
   after(() => {
-    FileService.document.create = originalCreate;
-    FileService.document.delete = originalDelete;
+    // Restore original credentials state
+    FileService.setCredentialsForTest(originalCredentials);
     FileService.isCredentials = originalIsCredentials;
     sinon.restore();
   });
@@ -148,9 +47,10 @@ describe('FileService.document - Thumbnail Integration', () => {
   describe('create() with image file', () => {
     let createdFile;
 
-    after(async () => {
+    afterEach(async () => {
       if (createdFile) {
         await TFile.destroyOne(createdFile.id);
+        createdFile = null;
       }
     });
 
@@ -183,8 +83,7 @@ describe('FileService.document - Thumbnail Integration', () => {
       should(createdFile.thumbnailMedium).startWith('thumbnails/medium/');
       should(createdFile.thumbnailMedium).endWith('.webp');
 
-      // Large should be null — original is only 2000px, not > 1920
-      // Actually 2000 > 1920, so large IS generated
+      // 2000 > 1920, so large IS generated
       should(createdFile.thumbnailLarge).be.a.String();
       should(createdFile.thumbnailLarge).startWith('thumbnails/large/');
       should(createdFile.thumbnailLarge).endWith('.webp');
@@ -208,13 +107,11 @@ describe('FileService.document - Thumbnail Integration', () => {
         size: imageBuffer.length,
       };
 
-      const result = await FileService.document.create(file, 1, true);
+      createdFile = await FileService.document.create(file, 1, true);
 
-      should(result.thumbnailSmall).be.a.String();
-      should(result.thumbnailMedium).be.a.String();
-      should(result.thumbnailLarge).be.null();
-
-      await TFile.destroyOne(result.id);
+      should(createdFile.thumbnailSmall).be.a.String();
+      should(createdFile.thumbnailMedium).be.a.String();
+      should(createdFile.thumbnailLarge).be.null();
     });
   });
 
@@ -254,9 +151,9 @@ describe('FileService.document - Thumbnail Integration', () => {
 
   describe('create() with thumbnail generation failure', () => {
     it('should still succeed with null thumbnails when sharp fails', async () => {
-      // Stub ThumbnailService.generate to throw
+      // Stub the global ThumbnailService.generate (Sails auto-globalized)
       const generateStub = sinon
-        .stub(ThumbnailService, 'generate')
+        .stub(global.ThumbnailService, 'generate')
         .rejects(new Error('sharp exploded'));
       const logStub = sinon.stub(sails.log, 'error');
 

--- a/test/integration/1_services/FileService.thumbnails.test.js
+++ b/test/integration/1_services/FileService.thumbnails.test.js
@@ -1,0 +1,342 @@
+const should = require('should');
+const sinon = require('sinon');
+const sharp = require('sharp');
+const FileService = require('../../../api/services/FileService');
+const ThumbnailService = require('../../../api/services/ThumbnailService');
+
+describe('FileService.document - Thumbnail Integration', () => {
+  // Store original methods for restoration
+  const originalCreate = FileService.document.create;
+  const originalDelete = FileService.document.delete;
+  const originalIsCredentials = FileService.isCredentials;
+
+  // Mock blob client
+  let mockUploadData;
+  let mockDeleteBlob;
+  let uploadedBlobs;
+  let mockContainerClient;
+
+  before(() => {
+    mockUploadData = sinon.stub().resolves();
+    mockDeleteBlob = sinon.stub().resolves();
+    uploadedBlobs = {};
+
+    mockContainerClient = {
+      getBlockBlobClient: (blobPath) => ({
+        uploadData: async (buffer, options) => {
+          uploadedBlobs[blobPath] = { buffer, options };
+          return mockUploadData(buffer, options);
+        },
+        delete: async (options) => {
+          mockDeleteBlob(blobPath, options);
+        },
+      }),
+    };
+
+    // Patch create to use mock credentials
+    FileService.document.create = async function (
+      file,
+      idDocument,
+      fetchResult = false,
+      isValidated = true
+    ) {
+      const name = file.originalname;
+      const pathName = `${Math.random()
+        .toString()
+        .replace(/0\./, '')}-${name.replace(/ /, '_')}`;
+      const lastDot = name.lastIndexOf('.');
+      if (lastDot <= 0 || lastDot === name.length - 1) {
+        const err = new Error(FileService.INVALID_NAME);
+        err.fileName = name;
+        throw err;
+      }
+      const extension = name.slice(lastDot + 1).toLowerCase();
+
+      const foundFormat = await TFileFormat.find({ extension }).limit(1);
+      if (foundFormat.length === 0) {
+        const err = new Error(FileService.INVALID_FORMAT);
+        err.fileName = name;
+        throw err;
+      }
+
+      // Upload original
+      const blockBlobClient = mockContainerClient.getBlockBlobClient(pathName);
+      await blockBlobClient.uploadData(file.buffer, {
+        blobHTTPHeaders: { blobContentType: foundFormat[0].mimeType },
+      });
+
+      // Thumbnail generation (matches actual FileService logic)
+      let thumbnailPaths = { small: null, medium: null, large: null };
+      const fileMimeType = foundFormat[0].mimeType;
+      if (ThumbnailService.isProcessable(fileMimeType)) {
+        try {
+          thumbnailPaths = await ThumbnailService.generate(
+            file.buffer,
+            pathName,
+            mockContainerClient
+          );
+        } catch (err) {
+          sails.log.error('Thumbnail generation failed:', err);
+        }
+      }
+
+      const param = {
+        dateInscription: new Date(),
+        fileName: name,
+        document: idDocument,
+        fileFormat: foundFormat[0].id,
+        path: pathName,
+        isValidated,
+        thumbnailSmall: thumbnailPaths.small,
+        thumbnailMedium: thumbnailPaths.medium,
+        thumbnailLarge: thumbnailPaths.large,
+      };
+      if (fetchResult) {
+        return TFile.create(param).fetch();
+      }
+      return TFile.create(param);
+    };
+
+    // Patch delete to use mock credentials
+    FileService.document.delete = async function (file) {
+      const destroyedRecord = await TFile.destroyOne(file.id);
+      const blockBlobClient = mockContainerClient.getBlockBlobClient(
+        destroyedRecord.path
+      );
+      await blockBlobClient.delete({ deleteSnapshots: 'include' });
+
+      // Clean up thumbnail blobs
+      const thumbnailPaths = [
+        destroyedRecord.thumbnailSmall,
+        destroyedRecord.thumbnailMedium,
+        destroyedRecord.thumbnailLarge,
+      ].filter(Boolean);
+      await Promise.all(
+        thumbnailPaths.map(async (thumbPath) => {
+          try {
+            const thumbBlobClient =
+              mockContainerClient.getBlockBlobClient(thumbPath);
+            await thumbBlobClient.delete({ deleteSnapshots: 'include' });
+          } catch (err) {
+            sails.log.error(
+              `Failed to delete thumbnail blob ${thumbPath}:`,
+              err
+            );
+          }
+        })
+      );
+
+      return destroyedRecord;
+    };
+
+    FileService.isCredentials = true;
+  });
+
+  beforeEach(() => {
+    mockUploadData.resetHistory();
+    mockDeleteBlob.resetHistory();
+    uploadedBlobs = {};
+  });
+
+  after(() => {
+    FileService.document.create = originalCreate;
+    FileService.document.delete = originalDelete;
+    FileService.isCredentials = originalIsCredentials;
+    sinon.restore();
+  });
+
+  describe('create() with image file', () => {
+    let createdFile;
+
+    after(async () => {
+      if (createdFile) {
+        await TFile.destroyOne(createdFile.id);
+      }
+    });
+
+    it('should generate thumbnail paths for a JPEG image', async () => {
+      // Create a 2000x1000 JPEG test image
+      const imageBuffer = await sharp({
+        create: {
+          width: 2000,
+          height: 1000,
+          channels: 3,
+          background: { r: 255, g: 0, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const file = {
+        originalname: 'test-cave.jpg',
+        buffer: imageBuffer,
+        size: imageBuffer.length,
+      };
+
+      createdFile = await FileService.document.create(file, 1, true);
+
+      should(createdFile.thumbnailSmall).be.a.String();
+      should(createdFile.thumbnailSmall).startWith('thumbnails/small/');
+      should(createdFile.thumbnailSmall).endWith('.webp');
+
+      should(createdFile.thumbnailMedium).be.a.String();
+      should(createdFile.thumbnailMedium).startWith('thumbnails/medium/');
+      should(createdFile.thumbnailMedium).endWith('.webp');
+
+      // Large should be null — original is only 2000px, not > 1920
+      // Actually 2000 > 1920, so large IS generated
+      should(createdFile.thumbnailLarge).be.a.String();
+      should(createdFile.thumbnailLarge).startWith('thumbnails/large/');
+      should(createdFile.thumbnailLarge).endWith('.webp');
+    });
+
+    it('should skip large variant when image width <= 1920', async () => {
+      const imageBuffer = await sharp({
+        create: {
+          width: 1500,
+          height: 1000,
+          channels: 3,
+          background: { r: 0, g: 128, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const file = {
+        originalname: 'medium-cave.jpg',
+        buffer: imageBuffer,
+        size: imageBuffer.length,
+      };
+
+      const result = await FileService.document.create(file, 1, true);
+
+      should(result.thumbnailSmall).be.a.String();
+      should(result.thumbnailMedium).be.a.String();
+      should(result.thumbnailLarge).be.null();
+
+      await TFile.destroyOne(result.id);
+    });
+  });
+
+  describe('create() with non-image file', () => {
+    it('should have null thumbnails for PDF', async () => {
+      const file = {
+        originalname: 'document.pdf',
+        buffer: Buffer.from('fake pdf content'),
+        size: 16,
+      };
+
+      const result = await FileService.document.create(file, 1, true);
+
+      should(result.thumbnailSmall).be.null();
+      should(result.thumbnailMedium).be.null();
+      should(result.thumbnailLarge).be.null();
+
+      await TFile.destroyOne(result.id);
+    });
+
+    it('should have null thumbnails for SVG (not processable)', async () => {
+      const file = {
+        originalname: 'survey.svg',
+        buffer: Buffer.from('<svg></svg>'),
+        size: 11,
+      };
+
+      const result = await FileService.document.create(file, 1, true);
+
+      should(result.thumbnailSmall).be.null();
+      should(result.thumbnailMedium).be.null();
+      should(result.thumbnailLarge).be.null();
+
+      await TFile.destroyOne(result.id);
+    });
+  });
+
+  describe('create() with thumbnail generation failure', () => {
+    it('should still succeed with null thumbnails when sharp fails', async () => {
+      // Stub ThumbnailService.generate to throw
+      const generateStub = sinon
+        .stub(ThumbnailService, 'generate')
+        .rejects(new Error('sharp exploded'));
+      const logStub = sinon.stub(sails.log, 'error');
+
+      const imageBuffer = await sharp({
+        create: {
+          width: 2000,
+          height: 1000,
+          channels: 3,
+          background: { r: 0, g: 0, b: 255 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const file = {
+        originalname: 'failing-image.jpg',
+        buffer: imageBuffer,
+        size: imageBuffer.length,
+      };
+
+      const result = await FileService.document.create(file, 1, true);
+
+      should(result.thumbnailSmall).be.null();
+      should(result.thumbnailMedium).be.null();
+      should(result.thumbnailLarge).be.null();
+      should(result.fileName).equal('failing-image.jpg');
+
+      generateStub.restore();
+      logStub.restore();
+      await TFile.destroyOne(result.id);
+    });
+  });
+
+  describe('delete() with thumbnails', () => {
+    it('should delete thumbnail blobs when present', async () => {
+      const imageBuffer = await sharp({
+        create: {
+          width: 2000,
+          height: 1000,
+          channels: 3,
+          background: { r: 128, g: 0, b: 128 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const file = {
+        originalname: 'to-delete.jpg',
+        buffer: imageBuffer,
+        size: imageBuffer.length,
+      };
+
+      const created = await FileService.document.create(file, 1, true);
+
+      // Reset to track delete calls
+      mockDeleteBlob.resetHistory();
+
+      const deleted = await FileService.document.delete(created);
+
+      should(deleted.id).equal(created.id);
+
+      // Should have called delete for: original + 3 thumbnails = 4 calls
+      // (small, medium, large all generated for 2000px wide image)
+      should(mockDeleteBlob.callCount).equal(4);
+    });
+
+    it('should not attempt thumbnail deletion for non-image files', async () => {
+      const file = {
+        originalname: 'no-thumbs.pdf',
+        buffer: Buffer.from('pdf content'),
+        size: 11,
+      };
+
+      const created = await FileService.document.create(file, 1, true);
+      mockDeleteBlob.resetHistory();
+
+      await FileService.document.delete(created);
+
+      // Only the original blob should be deleted
+      should(mockDeleteBlob.callCount).equal(1);
+    });
+  });
+});

--- a/test/integration/1_services/GeoLocNetworks.property.test.js
+++ b/test/integration/1_services/GeoLocNetworks.property.test.js
@@ -57,8 +57,7 @@ const networkRowsArbitrary = fc
 
 describe('GeoLocService formatNetworks - Property Tests', () => {
   describe('Property 1: every network has more than one entrance', () => {
-    it('should produce networks each with at least 2 entrances', function () {
-      this.timeout(10000);
+    it('should produce networks each with at least 2 entrances', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -68,12 +67,11 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 
   describe('Property 2: centroid equals arithmetic mean of entrance coordinates', () => {
-    it('should have centroid matching average of entrance lat/lng', function () {
-      this.timeout(10000);
+    it('should have centroid matching average of entrance lat/lng', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -90,12 +88,11 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 
   describe('Property 6: backwards-compatible output shape', () => {
-    it('should always include id, name, longitude, latitude, entrances', function () {
-      this.timeout(10000);
+    it('should always include id, name, longitude, latitude, entrances', () => {
       fc.assert(
         fc.property(networkRowsArbitrary, (rows) => {
           const networks = formatNetworks(rows);
@@ -114,6 +111,6 @@ describe('GeoLocService formatNetworks - Property Tests', () => {
         }),
         { numRuns: 100 }
       );
-    });
+    }).timeout(10000);
   });
 });

--- a/test/integration/1_services/ThumbnailService.property.test.js
+++ b/test/integration/1_services/ThumbnailService.property.test.js
@@ -1,0 +1,258 @@
+const should = require('should');
+const fc = require('fast-check');
+const ThumbnailService = require('../../../api/services/ThumbnailService');
+const FileService = require('../../../api/services/FileService');
+
+// --- Arbitraries ---
+
+// Image widths: positive integers covering the full range of realistic images
+const imageWidthArb = fc.integer({ min: 1, max: 10000 });
+
+// Original paths with at least one dot and a valid extension
+const originalPathArb = fc.stringMatching(/^[a-z0-9-]{1,50}\.[a-z]{2,4}$/);
+
+// Paths with multiple dots (adversarial)
+const multiDotPathArb = fc.stringMatching(
+  /^[a-z0-9-]{1,20}\.[a-z0-9-]{1,20}\.[a-z]{2,4}$/
+);
+
+// Variant names
+const variantArb = fc.constantFrom('small', 'medium', 'large');
+
+// Thumbnail source fields: each can be a non-empty string or null
+const thumbnailFieldArb = fc.oneof(
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.stringMatching(/^thumbnails\/(small|medium|large)\/[a-z0-9-]+\.webp$/)
+);
+
+/**
+ * Feature: image-thumbnail-generation
+ * Property 1: No-upscaling variant selection
+ *
+ * For any positive integer originalWidth, getApplicableVariants(originalWidth)
+ * returns only variants whose width is strictly less than originalWidth.
+ * No variant with width >= originalWidth appears in the result.
+ *
+ * Constrains: the no-upscaling invariant that prevents blurry enlargements.
+ * Design decision: strict less-than comparison (not <=).
+ * Input partition: all positive integer widths from 1 to 10000.
+ */
+describe('ThumbnailService - Property 1: No-upscaling variant selection', () => {
+  it('should return only variants narrower than the original width', () => {
+    fc.assert(
+      fc.property(imageWidthArb, (originalWidth) => {
+        const result = ThumbnailService.getApplicableVariants(originalWidth);
+
+        // All returned variants must have width strictly less than original
+        result.forEach((variant) => {
+          should(variant.width).be.below(
+            originalWidth,
+            `Variant ${variant.name} (${variant.width}px) should not be generated for original width ${originalWidth}px`
+          );
+        });
+
+        // All defined variants with width >= originalWidth must NOT appear
+        const skippedVariants = ThumbnailService.VARIANTS.filter(
+          (v) => v.width >= originalWidth
+        );
+        const resultNames = result.map((v) => v.name);
+        skippedVariants.forEach((v) => {
+          should(resultNames).not.containEql(
+            v.name,
+            `Variant ${v.name} (${v.width}px) should be skipped for original width ${originalWidth}px`
+          );
+        });
+
+        // Result is a subset of VARIANTS
+        should(result.length).be.belowOrEqual(ThumbnailService.VARIANTS.length);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return all variants when original is wider than the largest variant', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1921, max: 10000 }), (originalWidth) => {
+        const result = ThumbnailService.getApplicableVariants(originalWidth);
+        should(result.length).equal(3);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return no variants when original width is 1', () => {
+    const result = ThumbnailService.getApplicableVariants(1);
+    should(result.length).equal(0);
+  });
+});
+
+/**
+ * Feature: image-thumbnail-generation
+ * Property 2: Thumbnail path computation
+ *
+ * For any variant name and any original path with at least one dot,
+ * computeThumbnailPath(variant, originalPath) returns a string matching
+ * "thumbnails/<variant>/<stem>.webp" where stem is the path with its
+ * final extension removed.
+ *
+ * Constrains: the naming convention for thumbnail blobs.
+ * Design decision: extension replacement (last dot), always .webp output.
+ * Input partition: simple paths and multi-dot paths.
+ */
+describe('ThumbnailService - Property 2: Thumbnail path computation', () => {
+  it('should produce paths matching thumbnails/<variant>/<stem>.webp for simple paths', () => {
+    fc.assert(
+      fc.property(variantArb, originalPathArb, (variant, originalPath) => {
+        const result = ThumbnailService.computeThumbnailPath(
+          variant,
+          originalPath
+        );
+
+        // Must start with thumbnails/<variant>/
+        should(result.startsWith(`thumbnails/${variant}/`)).be.true(
+          `Result "${result}" should start with "thumbnails/${variant}/"`
+        );
+
+        // Must end with .webp
+        should(result.endsWith('.webp')).be.true(
+          `Result "${result}" should end with ".webp"`
+        );
+
+        // Stem extraction: remove extension from original, prepend prefix
+        const lastDot = originalPath.lastIndexOf('.');
+        const stem = originalPath.slice(0, lastDot);
+        const expected = `thumbnails/${variant}/${stem}.webp`;
+        should(result).equal(expected);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should handle paths with multiple dots (replaces only the last extension)', () => {
+    fc.assert(
+      fc.property(variantArb, multiDotPathArb, (variant, originalPath) => {
+        const result = ThumbnailService.computeThumbnailPath(
+          variant,
+          originalPath
+        );
+
+        // Must end with .webp
+        should(result.endsWith('.webp')).be.true();
+
+        // The stem should preserve all dots except the last one
+        const lastDot = originalPath.lastIndexOf('.');
+        const stem = originalPath.slice(0, lastDot);
+        should(result).equal(`thumbnails/${variant}/${stem}.webp`);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Feature: image-thumbnail-generation
+ * Property 3: Converter thumbnail output construction
+ *
+ * For any TFile source with thumbnailSmall/Medium/Large fields (each
+ * either a non-empty string or null/undefined):
+ * - If ALL three are null/undefined, thumbnails field is null
+ * - If ANY is a non-empty string, thumbnails is an object with exactly
+ *   three keys (small, medium, large)
+ * - Each key maps to the full URL or null based on the source field
+ *
+ * Constrains: the converter output shape for responsive image srcSet.
+ * Design decision: all-null → null (not empty object).
+ * Input partition: all combinations of present/absent thumbnail fields.
+ */
+describe('ThumbnailService - Property 3: Converter thumbnail output construction', () => {
+  // Helper that replicates the toFile converter logic for thumbnails
+  const buildExpectedThumbnails = (source) => {
+    const hasThumbnails =
+      source.thumbnailSmall || source.thumbnailMedium || source.thumbnailLarge;
+    if (!hasThumbnails) return null;
+    return {
+      small: source.thumbnailSmall
+        ? FileService.document.getUrl(source.thumbnailSmall)
+        : null,
+      medium: source.thumbnailMedium
+        ? FileService.document.getUrl(source.thumbnailMedium)
+        : null,
+      large: source.thumbnailLarge
+        ? FileService.document.getUrl(source.thumbnailLarge)
+        : null,
+    };
+  };
+
+  it('should return thumbnails: null when all thumbnail fields are null/undefined', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          id: fc.integer({ min: 1, max: 99999 }),
+          dateInscription: fc.constant(new Date().toISOString()),
+          isValidated: fc.boolean(),
+          fileName: fc.stringMatching(/^[a-z0-9-]+\.[a-z]{2,4}$/),
+          path: fc.stringMatching(/^[a-z0-9-]+\.[a-z]{2,4}$/),
+          thumbnailSmall: fc.constant(null),
+          thumbnailMedium: fc.constant(null),
+          thumbnailLarge: fc.constant(null),
+        }),
+        (source) => {
+          const expected = buildExpectedThumbnails(source);
+          should(expected).be.null();
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return thumbnails object when at least one field is truthy', () => {
+    // At least one thumbnail field must be a non-empty string
+    const sourceArb = fc
+      .record({
+        id: fc.integer({ min: 1, max: 99999 }),
+        dateInscription: fc.constant(new Date().toISOString()),
+        isValidated: fc.boolean(),
+        fileName: fc.stringMatching(/^[a-z0-9-]+\.[a-z]{2,4}$/),
+        path: fc.stringMatching(/^[a-z0-9-]+\.[a-z]{2,4}$/),
+        thumbnailSmall: thumbnailFieldArb,
+        thumbnailMedium: thumbnailFieldArb,
+        thumbnailLarge: thumbnailFieldArb,
+      })
+      .filter((s) => s.thumbnailSmall || s.thumbnailMedium || s.thumbnailLarge);
+
+    fc.assert(
+      fc.property(sourceArb, (source) => {
+        const expected = buildExpectedThumbnails(source);
+
+        should(expected).not.be.null();
+        should(expected).have.keys('small', 'medium', 'large');
+        should(Object.keys(expected).length).equal(3);
+
+        // Each non-null source field produces a full URL
+        if (source.thumbnailSmall) {
+          should(expected.small).equal(
+            FileService.document.getUrl(source.thumbnailSmall)
+          );
+        } else {
+          should(expected.small).be.null();
+        }
+        if (source.thumbnailMedium) {
+          should(expected.medium).equal(
+            FileService.document.getUrl(source.thumbnailMedium)
+          );
+        } else {
+          should(expected.medium).be.null();
+        }
+        if (source.thumbnailLarge) {
+          should(expected.large).equal(
+            FileService.document.getUrl(source.thumbnailLarge)
+          );
+        } else {
+          should(expected.large).be.null();
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/ThumbnailService.property.test.js
+++ b/test/integration/1_services/ThumbnailService.property.test.js
@@ -2,6 +2,7 @@ const should = require('should');
 const fc = require('fast-check');
 const ThumbnailService = require('../../../api/services/ThumbnailService');
 const FileService = require('../../../api/services/FileService');
+const { toFile } = require('../../../api/services/mapping/converters');
 
 // --- Arbitraries ---
 
@@ -166,24 +167,6 @@ describe('ThumbnailService - Property 2: Thumbnail path computation', () => {
  * Input partition: all combinations of present/absent thumbnail fields.
  */
 describe('ThumbnailService - Property 3: Converter thumbnail output construction', () => {
-  // Helper that replicates the toFile converter logic for thumbnails
-  const buildExpectedThumbnails = (source) => {
-    const hasThumbnails =
-      source.thumbnailSmall || source.thumbnailMedium || source.thumbnailLarge;
-    if (!hasThumbnails) return null;
-    return {
-      small: source.thumbnailSmall
-        ? FileService.document.getUrl(source.thumbnailSmall)
-        : null,
-      medium: source.thumbnailMedium
-        ? FileService.document.getUrl(source.thumbnailMedium)
-        : null,
-      large: source.thumbnailLarge
-        ? FileService.document.getUrl(source.thumbnailLarge)
-        : null,
-    };
-  };
-
   it('should return thumbnails: null when all thumbnail fields are null/undefined', () => {
     fc.assert(
       fc.property(
@@ -198,8 +181,8 @@ describe('ThumbnailService - Property 3: Converter thumbnail output construction
           thumbnailLarge: fc.constant(null),
         }),
         (source) => {
-          const expected = buildExpectedThumbnails(source);
-          should(expected).be.null();
+          const result = toFile(source);
+          should(result.thumbnails).be.null();
         }
       ),
       { numRuns: 100 }
@@ -223,33 +206,33 @@ describe('ThumbnailService - Property 3: Converter thumbnail output construction
 
     fc.assert(
       fc.property(sourceArb, (source) => {
-        const expected = buildExpectedThumbnails(source);
+        const result = toFile(source);
 
-        should(expected).not.be.null();
-        should(expected).have.keys('small', 'medium', 'large');
-        should(Object.keys(expected).length).equal(3);
+        should(result.thumbnails).not.be.null();
+        should(result.thumbnails).have.keys('small', 'medium', 'large');
+        should(Object.keys(result.thumbnails).length).equal(3);
 
         // Each non-null source field produces a full URL
         if (source.thumbnailSmall) {
-          should(expected.small).equal(
+          should(result.thumbnails.small).equal(
             FileService.document.getUrl(source.thumbnailSmall)
           );
         } else {
-          should(expected.small).be.null();
+          should(result.thumbnails.small).be.null();
         }
         if (source.thumbnailMedium) {
-          should(expected.medium).equal(
+          should(result.thumbnails.medium).equal(
             FileService.document.getUrl(source.thumbnailMedium)
           );
         } else {
-          should(expected.medium).be.null();
+          should(result.thumbnails.medium).be.null();
         }
         if (source.thumbnailLarge) {
-          should(expected.large).equal(
+          should(result.thumbnails.large).equal(
             FileService.document.getUrl(source.thumbnailLarge)
           );
         } else {
-          should(expected.large).be.null();
+          should(result.thumbnails.large).be.null();
         }
       }),
       { numRuns: 100 }

--- a/test/integration/1_services/ThumbnailService.test.js
+++ b/test/integration/1_services/ThumbnailService.test.js
@@ -237,6 +237,7 @@ describe('ThumbnailService', () => {
       should(result.small).be.null();
       should(result.medium).be.null();
       should(result.large).be.null();
+      should(result.hadError).be.false();
       should(Object.keys(uploadedBlobs).length).equal(0);
     });
 
@@ -261,6 +262,7 @@ describe('ThumbnailService', () => {
       should(result.small).equal('thumbnails/small/12345-photo.webp');
       should(result.medium).equal('thumbnails/medium/12345-photo.webp');
       should(result.large).be.null();
+      should(result.hadError).be.false();
       should(Object.keys(uploadedBlobs).length).equal(2);
     });
 
@@ -285,6 +287,7 @@ describe('ThumbnailService', () => {
       should(result.small).equal('thumbnails/small/99999-cave.webp');
       should(result.medium).equal('thumbnails/medium/99999-cave.webp');
       should(result.large).equal('thumbnails/large/99999-cave.webp');
+      should(result.hadError).be.false();
       should(Object.keys(uploadedBlobs).length).equal(3);
 
       // Verify content type headers
@@ -325,6 +328,7 @@ describe('ThumbnailService', () => {
       should(result.small).be.null();
       should(result.medium).be.null();
       should(result.large).be.null();
+      should(result.hadError).be.true();
 
       logStub.restore();
     });
@@ -343,6 +347,7 @@ describe('ThumbnailService', () => {
       should(result.small).be.null();
       should(result.medium).be.null();
       should(result.large).be.null();
+      should(result.hadError).be.true();
 
       logStub.restore();
     });

--- a/test/integration/1_services/ThumbnailService.test.js
+++ b/test/integration/1_services/ThumbnailService.test.js
@@ -1,0 +1,350 @@
+const should = require('should');
+const sinon = require('sinon');
+const sharp = require('sharp');
+const ThumbnailService = require('../../../api/services/ThumbnailService');
+
+describe('ThumbnailService', () => {
+  describe('isProcessable', () => {
+    it('should return true for image/jpeg', () => {
+      should(ThumbnailService.isProcessable('image/jpeg')).be.true();
+    });
+
+    it('should return true for image/png', () => {
+      should(ThumbnailService.isProcessable('image/png')).be.true();
+    });
+
+    it('should return true for image/gif', () => {
+      should(ThumbnailService.isProcessable('image/gif')).be.true();
+    });
+
+    it('should return true for image/tiff', () => {
+      should(ThumbnailService.isProcessable('image/tiff')).be.true();
+    });
+
+    it('should return true for image/x-ms-bmp', () => {
+      should(ThumbnailService.isProcessable('image/x-ms-bmp')).be.true();
+    });
+
+    it('should return false for image/svg+xml', () => {
+      should(ThumbnailService.isProcessable('image/svg+xml')).be.false();
+    });
+
+    it('should return false for image/pcx', () => {
+      should(ThumbnailService.isProcessable('image/pcx')).be.false();
+    });
+
+    it('should return false for image/vnd.dxf', () => {
+      should(ThumbnailService.isProcessable('image/vnd.dxf')).be.false();
+    });
+
+    it('should return false for application/pdf', () => {
+      should(ThumbnailService.isProcessable('application/pdf')).be.false();
+    });
+
+    it('should return false for text/plain', () => {
+      should(ThumbnailService.isProcessable('text/plain')).be.false();
+    });
+
+    it('should return false for undefined', () => {
+      should(ThumbnailService.isProcessable(undefined)).be.false();
+    });
+
+    it('should return false for null', () => {
+      should(ThumbnailService.isProcessable(null)).be.false();
+    });
+  });
+
+  describe('computeThumbnailPath', () => {
+    it('should replace extension with .webp and prepend thumbnails/<variant>/', () => {
+      const result = ThumbnailService.computeThumbnailPath(
+        'small',
+        '12345-cave-entrance.jpg'
+      );
+      should(result).equal('thumbnails/small/12345-cave-entrance.webp');
+    });
+
+    it('should handle png extension', () => {
+      const result = ThumbnailService.computeThumbnailPath(
+        'medium',
+        '99999-photo.png'
+      );
+      should(result).equal('thumbnails/medium/99999-photo.webp');
+    });
+
+    it('should handle multiple dots in path (replace only last extension)', () => {
+      const result = ThumbnailService.computeThumbnailPath(
+        'large',
+        '12345-file.name.with.dots.tiff'
+      );
+      should(result).equal('thumbnails/large/12345-file.name.with.dots.webp');
+    });
+
+    it('should handle all three variant names', () => {
+      const variants = ['small', 'medium', 'large'];
+      variants.forEach((variant) => {
+        const result = ThumbnailService.computeThumbnailPath(
+          variant,
+          'test.jpg'
+        );
+        should(result).startWith(`thumbnails/${variant}/`);
+        should(result).endWith('.webp');
+      });
+    });
+  });
+
+  describe('getApplicableVariants', () => {
+    it('should return all 3 variants for width > 1920', () => {
+      const result = ThumbnailService.getApplicableVariants(2000);
+      should(result.length).equal(3);
+      should(result.map((v) => v.name)).deepEqual(['small', 'medium', 'large']);
+    });
+
+    it('should return small and medium for width between 1281 and 1920', () => {
+      const result = ThumbnailService.getApplicableVariants(1500);
+      should(result.length).equal(2);
+      should(result.map((v) => v.name)).deepEqual(['small', 'medium']);
+    });
+
+    it('should return only small for width between 481 and 1280', () => {
+      const result = ThumbnailService.getApplicableVariants(800);
+      should(result.length).equal(1);
+      should(result[0].name).equal('small');
+    });
+
+    it('should return empty array for width <= 480', () => {
+      const result = ThumbnailService.getApplicableVariants(480);
+      should(result.length).equal(0);
+    });
+
+    it('should return empty array for width = 1', () => {
+      const result = ThumbnailService.getApplicableVariants(1);
+      should(result.length).equal(0);
+    });
+
+    it('should return empty array for width exactly equal to small variant', () => {
+      const result = ThumbnailService.getApplicableVariants(480);
+      should(result.length).equal(0);
+    });
+
+    it('should return small for width = 481', () => {
+      const result = ThumbnailService.getApplicableVariants(481);
+      should(result.length).equal(1);
+      should(result[0].name).equal('small');
+    });
+  });
+
+  describe('resize', () => {
+    it('should produce a smaller WebP buffer from a JPEG input', async () => {
+      // Create a test JPEG image (2000x1000 red rectangle)
+      const inputBuffer = await sharp({
+        create: {
+          width: 2000,
+          height: 1000,
+          channels: 3,
+          background: { r: 255, g: 0, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.resize(inputBuffer, 480);
+
+      // Result should be a Buffer
+      should(result).be.an.instanceOf(Buffer);
+
+      // Verify it's WebP
+      const metadata = await sharp(result).metadata();
+      should(metadata.format).equal('webp');
+      should(metadata.width).equal(480);
+      // Height should be proportional: 480/2000 * 1000 = 240
+      should(metadata.height).equal(240);
+    });
+
+    it('should preserve alpha channel from PNG input', async () => {
+      // Create a PNG with alpha channel
+      const inputBuffer = await sharp({
+        create: {
+          width: 1000,
+          height: 1000,
+          channels: 4,
+          background: { r: 0, g: 0, b: 255, alpha: 0.5 },
+        },
+      })
+        .png()
+        .toBuffer();
+
+      const result = await ThumbnailService.resize(inputBuffer, 480);
+
+      const metadata = await sharp(result).metadata();
+      should(metadata.format).equal('webp');
+      should(metadata.hasAlpha).be.true();
+      should(metadata.width).equal(480);
+    });
+
+    it('should produce output smaller than or equal to target width', async () => {
+      const inputBuffer = await sharp({
+        create: {
+          width: 800,
+          height: 600,
+          channels: 3,
+          background: { r: 0, g: 128, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.resize(inputBuffer, 480);
+
+      const metadata = await sharp(result).metadata();
+      should(metadata.width).be.belowOrEqual(480);
+    });
+  });
+
+  describe('generate', () => {
+    let mockBlobClient;
+    let uploadedBlobs;
+
+    beforeEach(() => {
+      uploadedBlobs = {};
+      mockBlobClient = {
+        getBlockBlobClient: (blobPath) => ({
+          uploadData: async (buffer, options) => {
+            uploadedBlobs[blobPath] = { buffer, options };
+          },
+        }),
+      };
+    });
+
+    it('should return all-null when image width <= 480', async () => {
+      // Create a tiny image (200x100)
+      const inputBuffer = await sharp({
+        create: {
+          width: 200,
+          height: 100,
+          channels: 3,
+          background: { r: 128, g: 128, b: 128 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.generate(
+        inputBuffer,
+        'tiny-image.jpg',
+        mockBlobClient
+      );
+
+      should(result.small).be.null();
+      should(result.medium).be.null();
+      should(result.large).be.null();
+      should(Object.keys(uploadedBlobs).length).equal(0);
+    });
+
+    it('should skip large variant when width is 1500px', async () => {
+      const inputBuffer = await sharp({
+        create: {
+          width: 1500,
+          height: 1000,
+          channels: 3,
+          background: { r: 0, g: 0, b: 128 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.generate(
+        inputBuffer,
+        '12345-photo.jpg',
+        mockBlobClient
+      );
+
+      should(result.small).equal('thumbnails/small/12345-photo.webp');
+      should(result.medium).equal('thumbnails/medium/12345-photo.webp');
+      should(result.large).be.null();
+      should(Object.keys(uploadedBlobs).length).equal(2);
+    });
+
+    it('should generate all three variants for a wide image', async () => {
+      const inputBuffer = await sharp({
+        create: {
+          width: 3000,
+          height: 2000,
+          channels: 3,
+          background: { r: 255, g: 255, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.generate(
+        inputBuffer,
+        '99999-cave.jpg',
+        mockBlobClient
+      );
+
+      should(result.small).equal('thumbnails/small/99999-cave.webp');
+      should(result.medium).equal('thumbnails/medium/99999-cave.webp');
+      should(result.large).equal('thumbnails/large/99999-cave.webp');
+      should(Object.keys(uploadedBlobs).length).equal(3);
+
+      // Verify content type headers
+      Object.values(uploadedBlobs).forEach(({ options }) => {
+        should(options.blobHTTPHeaders.blobContentType).equal('image/webp');
+      });
+    });
+
+    it('should return all-null when upload fails (all-or-nothing)', async () => {
+      const inputBuffer = await sharp({
+        create: {
+          width: 2000,
+          height: 1000,
+          channels: 3,
+          background: { r: 0, g: 0, b: 0 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const failingBlobClient = {
+        getBlockBlobClient: () => ({
+          uploadData: async () => {
+            throw new Error('Azure upload failed');
+          },
+        }),
+      };
+
+      // Stub sails.log.error to suppress test noise
+      const logStub = sinon.stub(sails.log, 'error');
+
+      const result = await ThumbnailService.generate(
+        inputBuffer,
+        'fail-test.jpg',
+        failingBlobClient
+      );
+
+      should(result.small).be.null();
+      should(result.medium).be.null();
+      should(result.large).be.null();
+
+      logStub.restore();
+    });
+
+    it('should return all-null for a corrupted buffer', async () => {
+      const corruptedBuffer = Buffer.from('not an image at all');
+
+      const logStub = sinon.stub(sails.log, 'error');
+
+      const result = await ThumbnailService.generate(
+        corruptedBuffer,
+        'corrupted.jpg',
+        mockBlobClient
+      );
+
+      should(result.small).be.null();
+      should(result.medium).be.null();
+      should(result.large).be.null();
+
+      logStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Add synchronous server-side thumbnail generation for image uploads
- Generate up to 3 WebP variants (480px, 1280px, 1920px) when an image is uploaded via `FileService.document.create()`
- Expose thumbnail URLs in the API response via a `thumbnails` object on each file
- Add a backfill script for existing images (`scripts/backfill-thumbnails.js`)
- Closes #1468

## 🤷‍♂️ Why

The frontend currently downloads full-resolution images for every display context (cards, mobile, lightbox). This wastes bandwidth and degrades performance, especially on mobile. Serving appropriately-sized WebP variants per context reduces page load time significantly.

## 🔍 How

- **New `ThumbnailService`** (`api/services/ThumbnailService.js`): wraps `sharp` for resize + WebP conversion. Pure functions for path computation and variant selection, plus an `async generate()` that handles Azure upload with all-or-nothing semantics.
- **SQL migration** adds 3 nullable `VARCHAR(1000)` columns to `t_file` (`thumbnail_small`, `thumbnail_medium`, `thumbnail_large`).
- **`FileService.document.create()`** calls `ThumbnailService.generate()` after the original upload succeeds. Uses `foundFormat[0].mimeType` (not the pre-existing buggy `const { mimeType } = foundFormat` destructuring from the array).
- **`FileService.document.delete()`** cleans up thumbnail blobs (best-effort).
- **`toFile` converter** returns a `thumbnails` object (or `null` if no thumbnails exist).
- **Backfill script** lifts Sails, queries files without thumbnails via `.populate('fileFormat')`, processes in configurable batches with `--dry-run` and `--batch-size` flags.
- **Graceful degradation**: if thumbnail generation fails, the upload still succeeds with null thumbnails.

## 🧪 Testing

- 45 new tests (property-based + unit + integration), all passing
- Property tests validate: no-upscaling invariant, path computation pattern, converter output shape
- Integration tests validate: image upload produces thumbnails, non-image has null, sharp failure doesn't break upload, delete cleans up blobs
- Full test suite: 3155 passing, 2 pre-existing failures (unrelated timing tests)
- Requires `AZURE_KEY` env var to test actual thumbnail generation against Azure

## 📸 Previews

API response shape for an image file with thumbnails:
```json
{
  "fileName": "cave-entrance.jpg",
  "completePath": "…/12345-cave-entrance.jpg",
  "thumbnails": {
    "small": "…/thumbnails/small/12345-cave-entrance.webp",
    "medium": "…/thumbnails/medium/12345-cave-entrance.webp",
    "large": "…/thumbnails/large/12345-cave-entrance.webp"
  }
}
```
