### PR TITLE
fix(entrance): use raw SQL for h_name queries and filter redundant name changes

### DIFF
--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -121,12 +121,38 @@ module.exports = {
       : true; // No need to call hasRight if it's not a sensitive entrance
 
     // Fetch all HName records for the entrance (temporal resolution)
-    const entranceHNames = await HName.find({
-      entrance: entranceId,
-      isMain: true,
-    })
-      .populate('author')
-      .populate('reviewer');
+    // Use raw SQL because h_name has a composite PK (id, date_reviewed) but
+    // the Waterline model declares primaryKey: 'id'. When the same t_name row
+    // is updated multiple times, h_name contains multiple rows with the same id
+    // but different date_reviewed. Waterline deduplicates by id, losing records.
+    const numericEntranceId =
+      typeof entranceId === 'string' ? parseInt(entranceId, 10) : entranceId;
+    const entranceHNamesRaw = await CommonService.query(
+      `SELECT h.id, h.name, h.is_main, h.date_inscription, h.date_reviewed,
+              h.id_entrance, h.id_cave, h.id_author, h.id_reviewer,
+              a.nickname AS author_nickname, r.nickname AS reviewer_nickname
+       FROM h_name h
+       LEFT JOIN t_caver a ON a.id = h.id_author
+       LEFT JOIN t_caver r ON r.id = h.id_reviewer
+       WHERE h.id_entrance = $1 AND h.is_main = true
+       ORDER BY h.date_reviewed`,
+      [numericEntranceId]
+    );
+    const entranceHNames = (entranceHNamesRaw.rows || []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      isMain: row.is_main,
+      dateInscription: row.date_inscription,
+      dateReviewed: row.date_reviewed,
+      entrance: row.id_entrance,
+      cave: row.id_cave,
+      author: row.id_author
+        ? { id: row.id_author, nickname: row.author_nickname }
+        : null,
+      reviewer: row.id_reviewer
+        ? { id: row.id_reviewer, nickname: row.reviewer_nickname }
+        : null,
+    }));
 
     // Fetch all current TName records for the entrance (full names collection)
     const allEntranceNames = await TName.find({ entrance: entranceId });
@@ -148,11 +174,28 @@ module.exports = {
     const caveHNameMap = new Map();
     const currentCaveNameMap = new Map();
     if (caveIds.length > 0) {
-      const caveHNames = await HName.find({ cave: caveIds, isMain: true });
-      for (const record of caveHNames) {
-        const caveId = record.cave?.id ?? record.cave;
+      // Use raw SQL for the same composite PK deduplication reason as above.
+      // Author/reviewer not needed here — cave h_name records are only used
+      // for resolveNameAtDate which only reads `name` and `dateReviewed`.
+      const placeholders = caveIds.map((_, i) => `$${i + 1}`).join(', ');
+      const caveHNamesRaw = await CommonService.query(
+        `SELECT id, name, is_main, date_inscription, date_reviewed, id_cave
+         FROM h_name
+         WHERE id_cave IN (${placeholders}) AND is_main = true
+         ORDER BY date_reviewed`,
+        caveIds
+      );
+      for (const row of caveHNamesRaw.rows || []) {
+        const caveId = row.id_cave;
         if (!caveHNameMap.has(caveId)) caveHNameMap.set(caveId, []);
-        caveHNameMap.get(caveId).push(record);
+        caveHNameMap.get(caveId).push({
+          id: row.id,
+          name: row.name,
+          isMain: row.is_main,
+          dateInscription: row.date_inscription,
+          dateReviewed: row.date_reviewed,
+          cave: row.id_cave,
+        });
       }
       const currentCaveNames = await TName.find({
         cave: caveIds,
@@ -200,7 +243,10 @@ module.exports = {
 
     const nameChangeSnapshots = TemporalNameResolver.buildNameChangeSnapshots(
       entranceId,
-      entranceHNames,
+      TemporalNameResolver.filterToActualNameChanges(
+        entranceHNames,
+        currentEntranceName
+      ),
       resolveCaveNameFn
     );
 

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -31,6 +31,35 @@ const coerceBool = require('../utils/coerceBool');
 const { getQualityData } = require('../utils/computeEntranceDataQuality');
 const { computeCommentsRating } = require('../utils/commentsRating');
 
+/**
+ * Map a raw h_name SQL row to a camelCase object.
+ * @param {object} row - Raw row from the h_name query.
+ * @param {object} [options]
+ * @param {boolean} [options.includeAuthorReviewer=false] - Whether to include
+ *   author/reviewer nested objects (requires joined columns).
+ * @returns {object} Mapped h_name record.
+ */
+const mapHNameRow = (row, { includeAuthorReviewer = false } = {}) => {
+  const mapped = {
+    id: row.id,
+    name: row.name,
+    isMain: row.is_main,
+    dateInscription: row.date_inscription,
+    dateReviewed: row.date_reviewed,
+    entrance: row.id_entrance,
+    cave: row.id_cave,
+  };
+  if (includeAuthorReviewer) {
+    mapped.author = row.id_author
+      ? { id: row.id_author, nickname: row.author_nickname }
+      : null;
+    mapped.reviewer = row.id_reviewer
+      ? { id: row.id_reviewer, nickname: row.reviewer_nickname }
+      : null;
+  }
+  return mapped;
+};
+
 module.exports = {
   getConvertedNameFromClientRequest: (req) => {
     const result = {
@@ -127,6 +156,7 @@ module.exports = {
     // but different date_reviewed. Waterline deduplicates by id, losing records.
     const numericEntranceId =
       typeof entranceId === 'string' ? parseInt(entranceId, 10) : entranceId;
+    if (Number.isNaN(numericEntranceId)) return [];
     const entranceHNamesRaw = await CommonService.query(
       `SELECT h.id, h.name, h.is_main, h.date_inscription, h.date_reviewed,
               h.id_entrance, h.id_cave, h.id_author, h.id_reviewer,
@@ -138,21 +168,9 @@ module.exports = {
        ORDER BY h.date_reviewed`,
       [numericEntranceId]
     );
-    const entranceHNames = (entranceHNamesRaw.rows || []).map((row) => ({
-      id: row.id,
-      name: row.name,
-      isMain: row.is_main,
-      dateInscription: row.date_inscription,
-      dateReviewed: row.date_reviewed,
-      entrance: row.id_entrance,
-      cave: row.id_cave,
-      author: row.id_author
-        ? { id: row.id_author, nickname: row.author_nickname }
-        : null,
-      reviewer: row.id_reviewer
-        ? { id: row.id_reviewer, nickname: row.reviewer_nickname }
-        : null,
-    }));
+    const entranceHNames = (entranceHNamesRaw.rows || []).map((row) =>
+      mapHNameRow(row, { includeAuthorReviewer: true })
+    );
 
     // Fetch all current TName records for the entrance (full names collection)
     const allEntranceNames = await TName.find({ entrance: entranceId });
@@ -188,14 +206,7 @@ module.exports = {
       for (const row of caveHNamesRaw.rows || []) {
         const caveId = row.id_cave;
         if (!caveHNameMap.has(caveId)) caveHNameMap.set(caveId, []);
-        caveHNameMap.get(caveId).push({
-          id: row.id,
-          name: row.name,
-          isMain: row.is_main,
-          dateInscription: row.date_inscription,
-          dateReviewed: row.date_reviewed,
-          cave: row.id_cave,
-        });
+        caveHNameMap.get(caveId).push(mapHNameRow(row));
       }
       const currentCaveNames = await TName.find({
         cave: caveIds,

--- a/api/services/TemporalNameResolver.js
+++ b/api/services/TemporalNameResolver.js
@@ -76,6 +76,42 @@ const resolveCaveNamesForSnapshots = (
 };
 
 /**
+ * Filter h_name records to only those representing actual name changes.
+ *
+ * When a t_name row is updated for reasons other than a name change (e.g.
+ * date_reviewed is bumped by an unrelated edit), the trigger still copies
+ * the old row to h_name. This produces many h_name rows with the same name
+ * in sequence. This function keeps only the records where the name differs
+ * from the subsequent value in the timeline.
+ *
+ * @param {Array} hNameRecords - h_name records (need not be pre-sorted)
+ * @param {string|null} currentName - The current TName main name (the latest value).
+ *   Treated as empty string when null/undefined for comparison purposes.
+ * @returns {Array} Filtered records where name actually changed
+ */
+const filterToActualNameChanges = (hNameRecords, currentName) => {
+  if (!hNameRecords || hNameRecords.length === 0) return [];
+
+  // Sort defensively — callers may pass pre-sorted data but this function
+  // must not depend on caller ordering guarantees.
+  const sorted = [...hNameRecords].sort(
+    (a, b) =>
+      new Date(a.dateReviewed).getTime() - new Date(b.dateReviewed).getTime()
+  );
+
+  const effectiveCurrentName = currentName || '';
+  const result = [];
+  for (let i = 0; i < sorted.length; i += 1) {
+    const nextName =
+      i < sorted.length - 1 ? sorted[i + 1].name : effectiveCurrentName;
+    if (sorted[i].name !== nextName) {
+      result.push(sorted[i]);
+    }
+  }
+  return result;
+};
+
+/**
  * Build Name_Change_Snapshot objects from h_name records.
  *
  * @param {number} entranceId - The entrance ID
@@ -124,6 +160,7 @@ const mergeAndSort = (hEntrances, nameChangeSnapshots) =>
 module.exports = {
   resolveNameAtDate,
   resolveCaveNamesForSnapshots,
+  filterToActualNameChanges,
   buildNameChangeSnapshots,
   mergeAndSort,
 };

--- a/api/services/TemporalNameResolver.js
+++ b/api/services/TemporalNameResolver.js
@@ -99,7 +99,7 @@ const filterToActualNameChanges = (hNameRecords, currentName) => {
       new Date(a.dateReviewed).getTime() - new Date(b.dateReviewed).getTime()
   );
 
-  const effectiveCurrentName = currentName || '';
+  const effectiveCurrentName = currentName ?? '';
   const result = [];
   for (let i = 0; i < sorted.length; i += 1) {
     const nextName =

--- a/test/integration/1_services/TemporalNameResolver.property.test.js
+++ b/test/integration/1_services/TemporalNameResolver.property.test.js
@@ -271,7 +271,102 @@ describe('TemporalNameResolver - Property 4: Merged timeline is sorted chronolog
 });
 
 /**
- * Property 5: Converter caveName and isNameChangeSnapshot passthrough
+ * Property 5: filterToActualNameChanges removes records where name equals successor
+ *
+ * For any array of h_name records sorted by dateReviewed and a currentName:
+ * - Records whose name equals the next record's name (or currentName for the last)
+ *   are excluded from the result
+ * - Records whose name differs from the next value are kept
+ * - Output is always a subset of input (preserves reference identity)
+ * - Output length <= input length
+ *
+ * Validates: Only records representing actual name transitions produce snapshots
+ */
+describe('TemporalNameResolver - Property 5: filterToActualNameChanges removes redundant records', () => {
+  it('should keep only records where name differs from successor', function () {
+    this.timeout(30000);
+
+    // Generate arrays where some consecutive records share names
+    const namePoolArb = fc.array(nameArb, { minLength: 1, maxLength: 5 });
+
+    fc.assert(
+      fc.property(
+        namePoolArb,
+        fc.array(
+          fc.record({
+            dateReviewed: isoDateArb,
+            dateInscription: isoDateArb,
+            author: fc.record({ id: positiveIntArb, name: nameArb }),
+            reviewer: fc.record({ id: positiveIntArb, name: nameArb }),
+          }),
+          { minLength: 1, maxLength: 20 }
+        ),
+        fc.option(nameArb, { nil: null }),
+        (namePool, recordSkeletons, currentName) => {
+          // Assign names from a small pool to create duplicates
+          const records = recordSkeletons.map((r, i) => ({
+            ...r,
+            name: namePool[i % namePool.length],
+          }));
+
+          const result = TemporalNameResolver.filterToActualNameChanges(
+            records,
+            currentName
+          );
+
+          // Result is a subset — length must be <= input
+          should(result.length).be.belowOrEqual(records.length);
+
+          // Sort records by dateReviewed for verification
+          const sorted = [...records].sort(
+            (a, b) =>
+              new Date(a.dateReviewed).getTime() -
+              new Date(b.dateReviewed).getTime()
+          );
+
+          // Every kept record must have a different name from its successor
+          for (let i = 0; i < result.length; i += 1) {
+            const idx = sorted.indexOf(result[i]);
+            const nextName =
+              idx < sorted.length - 1
+                ? sorted[idx + 1].name
+                : (currentName ?? '');
+            should(result[i].name).not.equal(
+              nextName,
+              `Record at sorted index ${idx} has same name as successor but was not filtered`
+            );
+          }
+
+          // Every excluded record must have the same name as its successor
+          const excluded = sorted.filter((r) => !result.includes(r));
+          for (const r of excluded) {
+            const idx = sorted.indexOf(r);
+            const nextName =
+              idx < sorted.length - 1
+                ? sorted[idx + 1].name
+                : (currentName ?? '');
+            should(r.name).equal(
+              nextName,
+              `Record at sorted index ${idx} was filtered but name differs from successor`
+            );
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return empty array for null/undefined/empty input', () => {
+    should(TemporalNameResolver.filterToActualNameChanges(null, 'x')).eql([]);
+    should(TemporalNameResolver.filterToActualNameChanges(undefined, 'x')).eql(
+      []
+    );
+    should(TemporalNameResolver.filterToActualNameChanges([], 'x')).eql([]);
+  });
+});
+
+/**
+ * Property 6: Converter caveName and isNameChangeSnapshot passthrough
  *
  * For any source object passed to toEntrance:
  * - If source.caveName is a non-null string, then result.caveName equals it
@@ -281,7 +376,7 @@ describe('TemporalNameResolver - Property 4: Merged timeline is sorted chronolog
  *
  * Validates: Requirements 4.2, 4.3
  */
-describe('TemporalNameResolver - Property 5: Converter caveName and isNameChangeSnapshot passthrough', () => {
+describe('TemporalNameResolver - Property 6: Converter caveName and isNameChangeSnapshot passthrough', () => {
   // eslint-disable-next-line global-require
   const { toEntrance } = require('../../../api/services/mapping/converters');
 


### PR DESCRIPTION
## 🤔 What

- Replace Waterline `HName.find()` with raw SQL for `h_name` queries in `EntranceService.getHEntrancesWithName`
- Add `filterToActualNameChanges` to `TemporalNameResolver` to suppress redundant name-change snapshots
- Add property-based test (Property 5) and integration test coverage for the filtering logic
- Add fixture (`hname.json` id=4) to exercise the filter in route tests

## 🤷‍♂️ Why

`h_name` has a composite primary key `(id, date_reviewed)` but the Waterline model declares `primaryKey: 'id'`. When a `t_name` row is updated multiple times, `h_name` accumulates rows sharing the same `id` with different `date_reviewed`. Waterline deduplicates by `id`, silently losing history records.

Additionally, non-name edits (e.g. bumping `date_reviewed`) trigger the history trigger, producing `h_name` rows with unchanged names. These generated spurious name-change snapshots in the timeline.

## 🔍 How

1. **Raw SQL with parameterized queries** — bypass Waterline's deduplication by querying `h_name` directly with `$N` placeholders. The entrance query joins `t_caver` for author/reviewer; the cave query intentionally skips that join since `resolveNameAtDate` only needs `name` and `dateReviewed`.

2. **`filterToActualNameChanges`** — pure function that sorts records by `dateReviewed`, then keeps only those whose `name` differs from the next record's name (or the current `TName` for the last entry). Defensive sort ensures correctness regardless of caller ordering.

3. **Type safety** — `entranceId` is explicitly coerced to integer before passing to the SQL query.

## 🧪 Testing

- `npm run test` — all existing tests pass (the `login-banned` failures are a pre-existing Docker clock-drift issue unrelated to this change)
- Property 5 validates the filter with randomized inputs (100 runs, small name pool to force duplicates)
- Route test for `GET /api/v1/entrances/1/snapshots` asserts exactly 2 name-change snapshots and verifies the filtered-out name doesn't appear

## 📸 Previews

N/A — backend-only change.
