### PR TITLE
fix(search): populate name in KML/GPX exports with field mapping

### DIFF
--- a/api/controllers/v1/search/advanced-search-export.js
+++ b/api/controllers/v1/search/advanced-search-export.js
@@ -250,6 +250,7 @@ module.exports = async (req, res) => {
         docsToSerialize = filtered.map((doc) => {
           // Only include coordinates and id for geometry construction;
           // aliased fields are the sole user-visible properties.
+          // KML/GPX also need the entrance name for the <name> element.
           const mapped = {
             id: doc.id,
             latitude: doc.latitude,
@@ -257,6 +258,9 @@ module.exports = async (req, res) => {
           };
           if (doc.altitude != null) {
             mapped.altitude = doc.altitude;
+          }
+          if (format === 'kml' || format === 'gpx') {
+            mapped.name = doc.name;
           }
           fieldMapping.forEach(({ key, alias }) => {
             mapped[alias] = resolveField(doc, key);

--- a/test/integration/4_routes/AdvancedSearchExport/export-gpx.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-gpx.test.js
@@ -144,6 +144,31 @@ describe('Geo Export - GPX', () => {
         });
     });
 
+    it('should populate <name> even when field mapping is active', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=gpx')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+          columns: ['country'],
+          columnsName: ['Pays'],
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(/<name>Cave A<\/name>/);
+          should(body).match(/<name>Cave B<\/name>/);
+          return done();
+        });
+    });
+
     it('should include <ele> element only when altitude is non-null', (done) => {
       const SearchService = require('../../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({

--- a/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
+++ b/test/integration/4_routes/AdvancedSearchExport/export-kml.test.js
@@ -141,6 +141,31 @@ describe('Geo Export - KML', () => {
         });
     });
 
+    it('should populate <name> even when field mapping is active', (done) => {
+      const SearchService = require('../../../../api/services/SearchService');
+      sinon.stub(SearchService, 'collectionSearch').resolves({
+        hits: entranceHits,
+        found: 2,
+      });
+
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/advanced-search/export?format=kml')
+        .send({
+          query: 'test',
+          entity: 'entrances',
+          columns: ['country'],
+          columnsName: ['Pays'],
+        })
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const body = res.text;
+          should(body).match(/<name>Cave A<\/name>/);
+          should(body).match(/<name>Cave B<\/name>/);
+          return done();
+        });
+    });
+
     it('should omit altitude from coordinates when absent', (done) => {
       const SearchService = require('../../../../api/services/SearchService');
       sinon.stub(SearchService, 'collectionSearch').resolves({


### PR DESCRIPTION
## 🤔 What

- Fix KML and GPX exports missing entrance name in the `<name>` element when custom columns are selected
- Closes #1728

## 🤷‍♂️ Why

When exporting entrances to KML or GPX with field mapping (custom column selection), the `<name>` element was empty because the field-mapping logic only carried over `id`, coordinates, and the user-selected aliased fields. Tools like Google Earth, QGIS, and Marble rely on `<name>` to label placemarks/waypoints — without it, exported points appear unlabeled.

## 🔍 How

In the controller's field-mapping path (`advanced-search-export.js`), the `name` field from the original Typesense document is now always included in the mapped document when the format is `kml` or `gpx`. This ensures the serializers can populate the standard `<name>` element regardless of which columns the user selected.

GeoJSON is unaffected — it doesn't use a structural `<name>` element and the field-selection contract remains unchanged.

## 🧪 Testing

1. Start the local environment (`npm run dev:up && npm run dev`)
2. Export entrances to KML with custom columns:
   ```bash
   curl -s -X POST 'http://localhost:1337/api/v1/advanced-search/export?format=kml' \
     -H 'Content-Type: application/json' \
     -d '{"entity":"entrances","query":"*","columns":["name","country"],"columnsName":["Nom","Pays"]}'
   ```
3. Verify each `<Placemark>` has a non-empty `<name>` element
4. Repeat with `format=gpx` and verify each `<wpt>` has a non-empty `<name>` element
5. Verify GeoJSON export still excludes the raw `name` field from properties when field mapping is active
