### PR TITLE
feat(auth): add anti-bot protection to signup endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ Example:
 docker exec grotto-postgres psql -U root -d grottoce -c "SELECT id, id_country, iso_3166_2 FROM t_entrance WHERE id_country = 'US' LIMIT 5;"
 ```
 
+### Cloudflare Turnstile (anti-bot CAPTCHA)
+
+The signup endpoint is protected by Cloudflare Turnstile. Turnstile requires a domain registered in the Cloudflare dashboard, so it **cannot be tested end-to-end on localhost with real keys** — the widget will fail to load and the front-end won't be able to generate a token.
+
+Two options for local development:
+
+**Option 1 — disable Turnstile** (CAPTCHA check is skipped entirely):
+
+Set in `docker/.env`:
+```
+TURNSTILE_ENABLED=false
+```
+
+**Option 2 — use Cloudflare's always-pass test keys** (widget renders and tokens always validate):
+
+Set in `docker/.env`:
+```
+TURNSTILE_ENABLED=true
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+```
+And use site key `1x0000000000000000000000000000000AA` on the front-end side.
+
+For staging and production, `TURNSTILE_ENABLED=true` must be set alongside the real `TURNSTILE_SECRET_KEY`. The app refuses to start if `TURNSTILE_ENABLED=true` without a secret key configured.
+
 ### Refresh materialized views (development only)
 
 The database uses materialized views for performance optimization. These views need to be refreshed periodically to reflect the latest data. In development, you can manually refresh them using the provided cron scripts:

--- a/README.md
+++ b/README.md
@@ -119,23 +119,7 @@ docker exec grotto-postgres psql -U root -d grottoce -c "SELECT id, id_country, 
 
 The signup endpoint is protected by Cloudflare Turnstile. Turnstile requires a domain registered in the Cloudflare dashboard, so it **cannot be tested end-to-end on localhost with real keys** — the widget will fail to load and the front-end won't be able to generate a token.
 
-Two options for local development:
-
-**Option 1 — disable Turnstile** (CAPTCHA check is skipped entirely):
-
-Set in `docker/.env`:
-```
-TURNSTILE_ENABLED=false
-```
-
-**Option 2 — use Cloudflare's always-pass test keys** (widget renders and tokens always validate):
-
-Set in `docker/.env`:
-```
-TURNSTILE_ENABLED=true
-TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
-```
-And use site key `1x0000000000000000000000000000000AA` on the front-end side.
+See `docker/sample.env` for the two local development options (disable entirely, or use Cloudflare's always-pass test keys). The environment variables must be **exported in your shell** before running `npm run dev` — they are not read from `docker/.env`, which is only used by docker-compose for the database and search containers.
 
 For staging and production, `TURNSTILE_ENABLED=true` must be set alongside the real `TURNSTILE_SECRET_KEY`. The app refuses to start if `TURNSTILE_ENABLED=true` without a secret key configured.
 

--- a/api/controllers/v1/auth/sign-up.js
+++ b/api/controllers/v1/auth/sign-up.js
@@ -1,8 +1,46 @@
 const AuthService = require('../../../services/AuthService');
 const CaverService = require('../../../services/CaverService');
+const HoneypotGuard = require('../../../services/HoneypotGuard');
 const LanguageService = require('../../../services/LanguageService');
+const TurnstileService = require('../../../services/TurnstileService');
 
 module.exports = async (req, res) => {
+  // --- Anti-bot defense layers (order matters) ---
+
+  // Layer 1: Honeypot
+  const honeypotResult = HoneypotGuard.check(req.body);
+  if (honeypotResult.trapped) {
+    sails.log.warn('[AntiBot:Honeypot] Bot trapped', {
+      ip: req.ip,
+      website: honeypotResult.value,
+    });
+    return res.ok(); // Deceptive response — res.ok() returns 204 to mimic normal signup success
+  }
+
+  // Layer 2: Turnstile
+  if (TurnstileService.isEnabled()) {
+    const turnstileResult = await TurnstileService.verifyToken(
+      req.body.captchaToken,
+      req.ip
+    );
+    if (!turnstileResult.pass) {
+      sails.log.warn('[AntiBot:Turnstile] Rejected', {
+        ip: req.ip,
+        errorCode: turnstileResult.errorCode,
+      });
+      const statusMap = {
+        CAPTCHA_MISSING: 400,
+        CAPTCHA_INVALID: 400,
+        CAPTCHA_SERVICE_UNAVAILABLE: 503,
+      };
+      return res.status(statusMap[turnstileResult.errorCode] || 500).json({
+        error: turnstileResult.errorCode,
+      });
+    }
+  }
+
+  // --- Existing signup logic (unchanged) ---
+
   // Check params
   let email = req.param('email');
   if (!email || !CaverService.isARealCaver(email)) {

--- a/api/controllers/v1/auth/sign-up.js
+++ b/api/controllers/v1/auth/sign-up.js
@@ -8,11 +8,11 @@ module.exports = async (req, res) => {
   // --- Anti-bot defense layers (order matters) ---
 
   // Layer 1: Honeypot
-  const honeypotResult = HoneypotGuard.check(req.body);
+  const honeypotResult = HoneypotGuard.check(req.allParams());
   if (honeypotResult.trapped) {
     sails.log.warn('[AntiBot:Honeypot] Bot trapped', {
       ip: req.ip,
-      website: honeypotResult.value,
+      website: String(honeypotResult.value).slice(0, 200),
     });
     return res.ok(); // Deceptive response — res.ok() returns 204 to mimic normal signup success
   }
@@ -20,7 +20,7 @@ module.exports = async (req, res) => {
   // Layer 2: Turnstile
   if (TurnstileService.isEnabled()) {
     const turnstileResult = await TurnstileService.verifyToken(
-      req.body.captchaToken,
+      req.param('captchaToken'),
       req.ip
     );
     if (!turnstileResult.pass) {
@@ -28,14 +28,10 @@ module.exports = async (req, res) => {
         ip: req.ip,
         errorCode: turnstileResult.errorCode,
       });
-      const statusMap = {
-        CAPTCHA_MISSING: 400,
-        CAPTCHA_INVALID: 400,
-        CAPTCHA_SERVICE_UNAVAILABLE: 503,
-      };
-      return res.status(statusMap[turnstileResult.errorCode] || 500).json({
-        error: turnstileResult.errorCode,
-      });
+      if (turnstileResult.errorCode === 'CAPTCHA_SERVICE_UNAVAILABLE') {
+        return res.status(503).json({ error: turnstileResult.errorCode });
+      }
+      return res.badRequest({ error: turnstileResult.errorCode });
     }
   }
 

--- a/api/services/HoneypotGuard.js
+++ b/api/services/HoneypotGuard.js
@@ -1,0 +1,26 @@
+/**
+ * HoneypotGuard.js
+ *
+ * @description :: Stateless utility that inspects the request body for a
+ *                 hidden decoy `website` field. Bots that auto-fill all form
+ *                 fields will populate this invisible field, allowing cheap
+ *                 detection without external API calls.
+ */
+
+const isNonBlankString = require('../utils/isNonBlankString');
+
+module.exports = {
+  /**
+   * Check whether the honeypot field indicates bot activity.
+   *
+   * @param {Object} body - The parsed request body
+   * @returns {{ trapped: boolean, value: string|undefined }}
+   */
+  check(body) {
+    const value = body && body.website;
+    if (isNonBlankString(value)) {
+      return { trapped: true, value };
+    }
+    return { trapped: false };
+  },
+};

--- a/api/services/HoneypotGuard.js
+++ b/api/services/HoneypotGuard.js
@@ -17,7 +17,12 @@ module.exports = {
    * @returns {{ trapped: boolean, value: string|undefined }}
    */
   check(body) {
-    const value = body && body.website;
+    const rawValue = body && body.website;
+    if (rawValue === undefined || rawValue === null) {
+      return { trapped: false };
+    }
+    // Coerce to string so non-string types (arrays, objects) also trigger the trap
+    const value = String(rawValue);
     if (isNonBlankString(value)) {
       return { trapped: true, value };
     }

--- a/api/services/TurnstileService.js
+++ b/api/services/TurnstileService.js
@@ -61,6 +61,12 @@ module.exports = {
       return { pass: false, errorCode: 'CAPTCHA_MISSING' };
     }
 
+    // Cloudflare Turnstile tokens are bounded at ~2 KB; reject oversized values
+    // before making an outbound call — cheap defense against log/payload abuse.
+    if (token.length > 2048) {
+      return { pass: false, errorCode: 'CAPTCHA_INVALID' };
+    }
+
     const secret = process.env.TURNSTILE_SECRET_KEY;
 
     try {
@@ -75,20 +81,10 @@ module.exports = {
         signal: AbortSignal.timeout(TIMEOUT_MS),
       });
 
-      // Treat 5xx or non-2xx as service unavailable
-      if (response.status >= 500) {
-        return { pass: false, errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE' };
-      }
+      // Any non-2xx response means Cloudflare's siteverify is unavailable or
+      // unreachable. Cloudflare always returns 200 for invalid tokens (with
+      // success: false in the body), so a non-2xx is never a token error.
       if (!response.ok) {
-        // Non-2xx, non-5xx — try to parse for success: false
-        try {
-          const data = await response.json();
-          if (data.success === false) {
-            return { pass: false, errorCode: 'CAPTCHA_INVALID' };
-          }
-        } catch {
-          // Cannot parse — treat as service unavailable
-        }
         return { pass: false, errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE' };
       }
 

--- a/api/services/TurnstileService.js
+++ b/api/services/TurnstileService.js
@@ -1,0 +1,107 @@
+/**
+ * TurnstileService.js
+ *
+ * @description :: Verifies Cloudflare Turnstile CAPTCHA tokens by calling the
+ *                 Cloudflare siteverify API. Designed as a reusable service for
+ *                 any endpoint that needs bot protection (signup, login, etc.).
+ *
+ *                 Configuration via environment variables:
+ *                 - TURNSTILE_ENABLED: case-insensitive "true" enables verification
+ *                 - TURNSTILE_SECRET_KEY: the secret key for siteverify API calls
+ *
+ *                 Fail-closed: any unexpected error returns CAPTCHA_SERVICE_UNAVAILABLE.
+ */
+
+const SITEVERIFY_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const TIMEOUT_MS = 3000;
+
+/**
+ * @typedef {Object} TurnstileResult
+ * @property {boolean} pass - Whether verification passed
+ * @property {string|null} errorCode - One of: CAPTCHA_MISSING, CAPTCHA_INVALID, CAPTCHA_SERVICE_UNAVAILABLE
+ */
+
+module.exports = {
+  /**
+   * Check if Turnstile verification is enabled.
+   * @returns {boolean}
+   */
+  isEnabled() {
+    const value = process.env.TURNSTILE_ENABLED;
+    return typeof value === 'string' && value.toLowerCase() === 'true';
+  },
+
+  /**
+   * Validate startup configuration. Call during app bootstrap.
+   * Throws if TURNSTILE_ENABLED=true but TURNSTILE_SECRET_KEY is missing/empty.
+   */
+  validateConfig() {
+    if (!this.isEnabled()) {
+      return;
+    }
+    const secret = process.env.TURNSTILE_SECRET_KEY;
+    if (!secret || secret.trim().length === 0) {
+      throw new Error(
+        'TURNSTILE_SECRET_KEY is required when TURNSTILE_ENABLED is set to true'
+      );
+    }
+  },
+
+  /**
+   * Verify a Turnstile captcha token against the Cloudflare siteverify API.
+   *
+   * @param {string|undefined|null} token - The captchaToken from the request body
+   * @param {string} clientIp - The client IP (req.ip)
+   * @returns {Promise<TurnstileResult>}
+   */
+  async verifyToken(token, clientIp) {
+    // Check for missing or whitespace-only token
+    if (!token || typeof token !== 'string' || token.trim().length === 0) {
+      return { pass: false, errorCode: 'CAPTCHA_MISSING' };
+    }
+
+    const secret = process.env.TURNSTILE_SECRET_KEY;
+
+    try {
+      const response = await fetch(SITEVERIFY_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          secret,
+          response: token,
+          remoteip: clientIp,
+        }),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+
+      // Treat 5xx or non-2xx as service unavailable
+      if (response.status >= 500) {
+        return { pass: false, errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE' };
+      }
+      if (!response.ok) {
+        // Non-2xx, non-5xx — try to parse for success: false
+        try {
+          const data = await response.json();
+          if (data.success === false) {
+            return { pass: false, errorCode: 'CAPTCHA_INVALID' };
+          }
+        } catch {
+          // Cannot parse — treat as service unavailable
+        }
+        return { pass: false, errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE' };
+      }
+
+      const data = await response.json();
+
+      if (data.success === true) {
+        return { pass: true, errorCode: null };
+      }
+
+      return { pass: false, errorCode: 'CAPTCHA_INVALID' };
+    } catch {
+      // Network error, timeout (AbortError), or any unexpected error
+      return { pass: false, errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE' };
+    }
+  },
+};

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -12,6 +12,7 @@
 const dbSync = require('../api/dbSync/dbSync');
 const sesSuppressionPoller = require('../api/sesSuppressionPoller/sesSuppressionPoller');
 const logger = require('../api/utils/logger');
+const TurnstileService = require('../api/services/TurnstileService');
 
 // eslint-disable-next-line func-names
 module.exports.bootstrap = async function (done) {
@@ -111,6 +112,15 @@ module.exports.bootstrap = async function (done) {
       err
     );
   });
+
+  // Validate Turnstile configuration — app refuses to start if misconfigured
+  TurnstileService.validateConfig();
+
+  if (!TurnstileService.isEnabled()) {
+    sails.log.warn(
+      '[AntiBot:Turnstile] Turnstile verification is disabled — signup endpoint will skip CAPTCHA validation'
+    );
+  }
 
   return done();
 };

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -16,6 +16,15 @@ const TurnstileService = require('../api/services/TurnstileService');
 
 // eslint-disable-next-line func-names
 module.exports.bootstrap = async function (done) {
+  // Validate Turnstile configuration first — fail fast before any I/O if misconfigured
+  TurnstileService.validateConfig();
+
+  if (!TurnstileService.isEnabled()) {
+    sails.log.warn(
+      '[AntiBot:Turnstile] Turnstile verification is disabled — signup endpoint will skip CAPTCHA validation'
+    );
+  }
+
   logger.patchSailsLog();
 
   // Condense primary key validation warnings for all models to save on log output
@@ -112,15 +121,6 @@ module.exports.bootstrap = async function (done) {
       err
     );
   });
-
-  // Validate Turnstile configuration — app refuses to start if misconfigured
-  TurnstileService.validateConfig();
-
-  if (!TurnstileService.isEnabled()) {
-    sails.log.warn(
-      '[AntiBot:Turnstile] Turnstile verification is disabled — signup endpoint will skip CAPTCHA validation'
-    );
-  }
 
   return done();
 };

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -15,15 +15,20 @@ SEARCH_API_KEY=localhost_typesense_api_key
 # Cloudflare Turnstile (anti-bot CAPTCHA for the signup endpoint)
 # Turnstile cannot be tested end-to-end on localhost with real keys because
 # Cloudflare only issues tokens for registered domains.
-# Use the options below to work locally:
+#
+# NOTE: These variables are read by the Sails process from the shell environment,
+# NOT from this file (which is only used by docker-compose for DB/search containers).
+# Export them in your shell before running `npm run dev`:
+#   export TURNSTILE_ENABLED=false
 #
 # Option 1 — disable entirely (CAPTCHA check is skipped):
-#   TURNSTILE_ENABLED=false
+#   export TURNSTILE_ENABLED=false
 #
 # Option 2 — use Cloudflare's always-pass test keys (widget renders, token always validates):
-#   TURNSTILE_ENABLED=true
-#   TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
-#   (pair with site key 1x0000000000000000000000000000000AA on the front-end)
+#   export TURNSTILE_ENABLED=true
+#   export TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+#   Pair with front-end site key: 1x00000000000000000000AA
+#   (see https://developers.cloudflare.com/turnstile/troubleshooting/testing/)
 #
 # For staging/production, set TURNSTILE_ENABLED=true and provide the real secret key.
 TURNSTILE_ENABLED=false

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -11,3 +11,20 @@ POSTGRES_DATABASE=grottoce
 SEARCH_CONTAINER_NAME=grotto-typesense
 SEARCH_LOCAL_PORT=8108
 SEARCH_API_KEY=localhost_typesense_api_key
+
+# Cloudflare Turnstile (anti-bot CAPTCHA for the signup endpoint)
+# Turnstile cannot be tested end-to-end on localhost with real keys because
+# Cloudflare only issues tokens for registered domains.
+# Use the options below to work locally:
+#
+# Option 1 — disable entirely (CAPTCHA check is skipped):
+#   TURNSTILE_ENABLED=false
+#
+# Option 2 — use Cloudflare's always-pass test keys (widget renders, token always validates):
+#   TURNSTILE_ENABLED=true
+#   TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+#   (pair with site key 1x0000000000000000000000000000000AA on the front-end)
+#
+# For staging/production, set TURNSTILE_ENABLED=true and provide the real secret key.
+TURNSTILE_ENABLED=false
+# TURNSTILE_SECRET_KEY=

--- a/test/integration/1_services/HoneypotGuard.property.test.js
+++ b/test/integration/1_services/HoneypotGuard.property.test.js
@@ -18,45 +18,47 @@ const whitespaceOnly = fc
   )
   .map((chars) => chars.join(''));
 
-/**
- * Property 3: Non-empty-after-trim website field triggers honeypot
- *
- * For any string that contains at least one non-whitespace character,
- * HoneypotGuard.check() returns { trapped: true } with the original value.
- *
- * Validates: Requirements 2.1
- */
-describe('Feature: signup-anti-bot-protection, Property 3: Non-empty-after-trim website field triggers honeypot', () => {
-  it('should return trapped: true with the original value for any non-empty-after-trim website field', function () {
-    this.timeout(30000);
-    fc.assert(
-      fc.property(nonEmptyAfterTrim, (website) => {
-        const result = HoneypotGuard.check({ website });
-        should(result.trapped).be.true();
-        should(result.value).equal(website);
-      }),
-      { numRuns: 100 }
-    );
+describe('signup-anti-bot-protection', () => {
+  /**
+   * Property 3: Non-empty-after-trim website field triggers honeypot
+   *
+   * For any string that contains at least one non-whitespace character,
+   * HoneypotGuard.check() returns { trapped: true } with the original value.
+   *
+   * Validates: Requirements 2.1
+   */
+  describe('Property 3: Non-empty-after-trim website field triggers honeypot', () => {
+    it('should return trapped: true with the original value for any non-empty-after-trim website field', function () {
+      this.timeout(30000);
+      fc.assert(
+        fc.property(nonEmptyAfterTrim, (website) => {
+          const result = HoneypotGuard.check({ website });
+          should(result.trapped).be.true();
+          should(result.value).equal(website);
+        }),
+        { numRuns: 100 }
+      );
+    });
   });
-});
 
-/**
- * Property 4: Empty or whitespace-only website field passes honeypot
- *
- * For any string composed entirely of whitespace characters (or undefined/null/absent),
- * HoneypotGuard.check() returns { trapped: false }.
- *
- * Validates: Requirements 2.3
- */
-describe('Feature: signup-anti-bot-protection, Property 4: Empty or whitespace-only website field passes honeypot', () => {
-  it('should return trapped: false for whitespace-only website field', function () {
-    this.timeout(30000);
-    fc.assert(
-      fc.property(whitespaceOnly, (website) => {
-        const result = HoneypotGuard.check({ website });
-        should(result.trapped).be.false();
-      }),
-      { numRuns: 100 }
-    );
+  /**
+   * Property 4: Empty or whitespace-only website field passes honeypot
+   *
+   * For any string composed entirely of whitespace characters (or undefined/null/absent),
+   * HoneypotGuard.check() returns { trapped: false }.
+   *
+   * Validates: Requirements 2.3
+   */
+  describe('Property 4: Empty or whitespace-only website field passes honeypot', () => {
+    it('should return trapped: false for whitespace-only website field', function () {
+      this.timeout(30000);
+      fc.assert(
+        fc.property(whitespaceOnly, (website) => {
+          const result = HoneypotGuard.check({ website });
+          should(result.trapped).be.false();
+        }),
+        { numRuns: 100 }
+      );
+    });
   });
 });

--- a/test/integration/1_services/HoneypotGuard.property.test.js
+++ b/test/integration/1_services/HoneypotGuard.property.test.js
@@ -1,0 +1,62 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const HoneypotGuard = require('../../../api/services/HoneypotGuard');
+
+// --- Shared arbitraries ---
+
+// Non-empty-after-trim strings (for Property 3)
+const nonEmptyAfterTrim = fc
+  .string({ minLength: 1 })
+  .filter((s) => s.trim().length > 0);
+
+// Whitespace-only strings (for Property 4)
+const whitespaceOnly = fc
+  .array(
+    fc.constantFrom(' ', '\t', '\n', '\r', '\v', '\f', '\u00A0', '\u2003'),
+    { minLength: 0, maxLength: 50 }
+  )
+  .map((chars) => chars.join(''));
+
+/**
+ * Property 3: Non-empty-after-trim website field triggers honeypot
+ *
+ * For any string that contains at least one non-whitespace character,
+ * HoneypotGuard.check() returns { trapped: true } with the original value.
+ *
+ * Validates: Requirements 2.1
+ */
+describe('Feature: signup-anti-bot-protection, Property 3: Non-empty-after-trim website field triggers honeypot', () => {
+  it('should return trapped: true with the original value for any non-empty-after-trim website field', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(nonEmptyAfterTrim, (website) => {
+        const result = HoneypotGuard.check({ website });
+        should(result.trapped).be.true();
+        should(result.value).equal(website);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 4: Empty or whitespace-only website field passes honeypot
+ *
+ * For any string composed entirely of whitespace characters (or undefined/null/absent),
+ * HoneypotGuard.check() returns { trapped: false }.
+ *
+ * Validates: Requirements 2.3
+ */
+describe('Feature: signup-anti-bot-protection, Property 4: Empty or whitespace-only website field passes honeypot', () => {
+  it('should return trapped: false for whitespace-only website field', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(whitespaceOnly, (website) => {
+        const result = HoneypotGuard.check({ website });
+        should(result.trapped).be.false();
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/1_services/HoneypotGuard.test.js
+++ b/test/integration/1_services/HoneypotGuard.test.js
@@ -1,0 +1,51 @@
+const should = require('should');
+const HoneypotGuard = require('../../../api/services/HoneypotGuard');
+
+describe('HoneypotGuard', () => {
+  describe('check()', () => {
+    it('should return trapped: false when website is absent from body', () => {
+      const result = HoneypotGuard.check({ name: 'John' });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when body is undefined', () => {
+      const result = HoneypotGuard.check(undefined);
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when body is null', () => {
+      const result = HoneypotGuard.check(null);
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when website is empty string', () => {
+      const result = HoneypotGuard.check({ website: '' });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: true with original value when field is populated', () => {
+      const result = HoneypotGuard.check({ website: 'http://spam.com' });
+      should(result).deepEqual({ trapped: true, value: 'http://spam.com' });
+    });
+
+    it('should return trapped: false when website is a single space', () => {
+      const result = HoneypotGuard.check({ website: ' ' });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when website is a tab character', () => {
+      const result = HoneypotGuard.check({ website: '\t' });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when website is mixed whitespace', () => {
+      const result = HoneypotGuard.check({ website: ' \t \n \r ' });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: true preserving the original value including whitespace', () => {
+      const result = HoneypotGuard.check({ website: '  bot  ' });
+      should(result).deepEqual({ trapped: true, value: '  bot  ' });
+    });
+  });
+});

--- a/test/integration/1_services/HoneypotGuard.test.js
+++ b/test/integration/1_services/HoneypotGuard.test.js
@@ -47,5 +47,27 @@ describe('HoneypotGuard', () => {
       const result = HoneypotGuard.check({ website: '  bot  ' });
       should(result).deepEqual({ trapped: true, value: '  bot  ' });
     });
+
+    it('should return trapped: true when website is an array (coerced to string)', () => {
+      const result = HoneypotGuard.check({ website: ['spam'] });
+      should(result.trapped).be.true();
+      should(result.value).equal('spam');
+    });
+
+    it('should return trapped: true when website is a plain object (coerced to string)', () => {
+      const result = HoneypotGuard.check({ website: { a: 1 } });
+      should(result.trapped).be.true();
+      should(result.value).equal('[object Object]');
+    });
+
+    it('should return trapped: false when website is null', () => {
+      const result = HoneypotGuard.check({ website: null });
+      should(result).deepEqual({ trapped: false });
+    });
+
+    it('should return trapped: false when website is undefined', () => {
+      const result = HoneypotGuard.check({ website: undefined });
+      should(result).deepEqual({ trapped: false });
+    });
   });
 });

--- a/test/integration/1_services/TurnstileService.property.test.js
+++ b/test/integration/1_services/TurnstileService.property.test.js
@@ -25,177 +25,179 @@ const caseTrue = fc.constantFrom(
 );
 const notTrue = fc.string().filter((s) => s.toLowerCase() !== 'true');
 
-/**
- * Property 1: Missing or whitespace-only captchaToken is always rejected
- *
- * For any string composed entirely of whitespace characters (including the empty
- * string) or for undefined/null, the verifyToken function returns
- * { pass: false, errorCode: 'CAPTCHA_MISSING' }.
- *
- * Validates: Requirements 1.1
- */
-describe('Feature: signup-anti-bot-protection, Property 1: Missing or whitespace-only captchaToken is always rejected', () => {
-  it('should reject whitespace-only tokens with CAPTCHA_MISSING', async function () {
-    this.timeout(30000);
-    await fc.assert(
-      fc.asyncProperty(whitespaceOnly, async (token) => {
-        const result = await TurnstileService.verifyToken(token, '127.0.0.1');
-        should(result.pass).be.false();
-        should(result.errorCode).equal('CAPTCHA_MISSING');
-      }),
-      { numRuns: 100 }
-    );
+describe('signup-anti-bot-protection', () => {
+  /**
+   * Property 1: Missing or whitespace-only captchaToken is always rejected
+   *
+   * For any string composed entirely of whitespace characters (including the empty
+   * string) or for undefined/null, the verifyToken function returns
+   * { pass: false, errorCode: 'CAPTCHA_MISSING' }.
+   *
+   * Validates: Requirements 1.1
+   */
+  describe('Property 1: Missing or whitespace-only captchaToken is always rejected', () => {
+    it('should reject whitespace-only tokens with CAPTCHA_MISSING', async function () {
+      this.timeout(30000);
+      await fc.assert(
+        fc.asyncProperty(whitespaceOnly, async (token) => {
+          const result = await TurnstileService.verifyToken(token, '127.0.0.1');
+          should(result.pass).be.false();
+          should(result.errorCode).equal('CAPTCHA_MISSING');
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should reject empty string token with CAPTCHA_MISSING', async function () {
+      this.timeout(30000);
+      const result = await TurnstileService.verifyToken('', '127.0.0.1');
+      should(result.pass).be.false();
+      should(result.errorCode).equal('CAPTCHA_MISSING');
+    });
+
+    it('should reject undefined token with CAPTCHA_MISSING', async function () {
+      this.timeout(30000);
+      const result = await TurnstileService.verifyToken(undefined, '127.0.0.1');
+      should(result.pass).be.false();
+      should(result.errorCode).equal('CAPTCHA_MISSING');
+    });
+
+    it('should reject null token with CAPTCHA_MISSING', async function () {
+      this.timeout(30000);
+      const result = await TurnstileService.verifyToken(null, '127.0.0.1');
+      should(result.pass).be.false();
+      should(result.errorCode).equal('CAPTCHA_MISSING');
+    });
   });
 
-  it('should reject empty string token with CAPTCHA_MISSING', async function () {
-    this.timeout(30000);
-    const result = await TurnstileService.verifyToken('', '127.0.0.1');
-    should(result.pass).be.false();
-    should(result.errorCode).equal('CAPTCHA_MISSING');
-  });
+  /**
+   * Property 2: Siteverify request body is correctly constructed
+   *
+   * For any valid captcha token string, secret key string, and IP address string,
+   * the outbound POST body sent to Cloudflare contains all three values mapped to
+   * the keys 'response', 'secret', and 'remoteip' respectively.
+   *
+   * Validates: Requirements 1.2
+   */
+  describe('Property 2: Siteverify request body is correctly constructed', () => {
+    let originalSecretKey;
 
-  it('should reject undefined token with CAPTCHA_MISSING', async function () {
-    this.timeout(30000);
-    const result = await TurnstileService.verifyToken(undefined, '127.0.0.1');
-    should(result.pass).be.false();
-    should(result.errorCode).equal('CAPTCHA_MISSING');
-  });
+    beforeEach(() => {
+      originalSecretKey = process.env.TURNSTILE_SECRET_KEY;
+    });
 
-  it('should reject null token with CAPTCHA_MISSING', async function () {
-    this.timeout(30000);
-    const result = await TurnstileService.verifyToken(null, '127.0.0.1');
-    should(result.pass).be.false();
-    should(result.errorCode).equal('CAPTCHA_MISSING');
-  });
-});
+    afterEach(() => {
+      sinon.restore();
+      if (originalSecretKey !== undefined) {
+        process.env.TURNSTILE_SECRET_KEY = originalSecretKey;
+      } else {
+        delete process.env.TURNSTILE_SECRET_KEY;
+      }
+    });
 
-/**
- * Property 2: Siteverify request body is correctly constructed
- *
- * For any valid captcha token string, secret key string, and IP address string,
- * the outbound POST body sent to Cloudflare contains all three values mapped to
- * the keys 'response', 'secret', and 'remoteip' respectively.
- *
- * Validates: Requirements 1.2
- */
-describe('Feature: signup-anti-bot-protection, Property 2: Siteverify request body is correctly constructed', () => {
-  let originalSecretKey;
+    it('should POST correct body with secret, response, and remoteip', async function () {
+      this.timeout(30000);
 
-  beforeEach(() => {
-    originalSecretKey = process.env.TURNSTILE_SECRET_KEY;
-  });
+      // Token must be non-blank and within the 2048-char limit
+      const nonBlankToken = fc
+        .string({ minLength: 1, maxLength: 2048 })
+        .filter((s) => s.trim().length > 0);
+      const secretKey = fc.string({ minLength: 1, maxLength: 100 });
+      const ipAddress = fc.string({ minLength: 1, maxLength: 45 });
 
-  afterEach(() => {
-    sinon.restore();
-    if (originalSecretKey !== undefined) {
-      process.env.TURNSTILE_SECRET_KEY = originalSecretKey;
-    } else {
-      delete process.env.TURNSTILE_SECRET_KEY;
-    }
-  });
+      await fc.assert(
+        fc.asyncProperty(
+          nonBlankToken,
+          secretKey,
+          ipAddress,
+          async (token, secret, ip) => {
+            process.env.TURNSTILE_SECRET_KEY = secret;
 
-  it('should POST correct body with secret, response, and remoteip', async function () {
-    this.timeout(30000);
+            const fetchStub = sinon.stub(global, 'fetch').resolves({
+              ok: true,
+              status: 200,
+              json: async () => ({ success: true }),
+            });
 
-    // Token must be non-blank (whitespace-only tokens are rejected before fetch)
-    const nonBlankToken = fc
-      .string({ minLength: 1, maxLength: 2048 })
-      .filter((s) => s.trim().length > 0);
-    const secretKey = fc.string({ minLength: 1, maxLength: 100 });
-    const ipAddress = fc.string({ minLength: 1, maxLength: 45 });
+            try {
+              await TurnstileService.verifyToken(token, ip);
 
-    await fc.assert(
-      fc.asyncProperty(
-        nonBlankToken,
-        secretKey,
-        ipAddress,
-        async (token, secret, ip) => {
-          process.env.TURNSTILE_SECRET_KEY = secret;
+              should(fetchStub.calledOnce).be.true();
 
-          const fetchStub = sinon.stub(global, 'fetch').resolves({
-            ok: true,
-            status: 200,
-            json: async () => ({ success: true }),
-          });
+              const [url, options] = fetchStub.firstCall.args;
+              should(url).equal(
+                'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+              );
+              should(options.method).equal('POST');
+              should(options.headers['Content-Type']).equal(
+                'application/x-www-form-urlencoded'
+              );
 
-          try {
-            await TurnstileService.verifyToken(token, ip);
-
-            should(fetchStub.calledOnce).be.true();
-
-            const [url, options] = fetchStub.firstCall.args;
-            should(url).equal(
-              'https://challenges.cloudflare.com/turnstile/v0/siteverify'
-            );
-            should(options.method).equal('POST');
-            should(options.headers['Content-Type']).equal(
-              'application/x-www-form-urlencoded'
-            );
-
-            // Parse the URLSearchParams body to verify field values
-            const body = new URLSearchParams(options.body.toString());
-            should(body.get('secret')).equal(secret);
-            should(body.get('response')).equal(token);
-            should(body.get('remoteip')).equal(ip);
-          } finally {
-            fetchStub.restore();
+              // Parse the URLSearchParams body to verify field values
+              const body = new URLSearchParams(options.body.toString());
+              should(body.get('secret')).equal(secret);
+              should(body.get('response')).equal(token);
+              should(body.get('remoteip')).equal(ip);
+            } finally {
+              fetchStub.restore();
+            }
           }
-        }
-      ),
-      { numRuns: 100 }
-    );
-  });
-});
-
-/**
- * Property 6: Only case-insensitive "true" enables Turnstile
- *
- * For any string value of TURNSTILE_ENABLED that is NOT case-insensitively equal
- * to "true", isEnabled() returns false. Conversely, for any case variation of
- * "true", it returns true.
- *
- * Validates: Requirements 4.2
- */
-describe('Feature: signup-anti-bot-protection, Property 6: Only case-insensitive true enables Turnstile', () => {
-  let originalEnabled;
-
-  beforeEach(() => {
-    originalEnabled = process.env.TURNSTILE_ENABLED;
+        ),
+        { numRuns: 100 }
+      );
+    });
   });
 
-  afterEach(() => {
-    if (originalEnabled !== undefined) {
-      process.env.TURNSTILE_ENABLED = originalEnabled;
-    } else {
+  /**
+   * Property 6: Only case-insensitive "true" enables Turnstile
+   *
+   * For any string value of TURNSTILE_ENABLED that is NOT case-insensitively equal
+   * to "true", isEnabled() returns false. Conversely, for any case variation of
+   * "true", it returns true.
+   *
+   * Validates: Requirements 4.2
+   */
+  describe('Property 6: Only case-insensitive true enables Turnstile', () => {
+    let originalEnabled;
+
+    beforeEach(() => {
+      originalEnabled = process.env.TURNSTILE_ENABLED;
+    });
+
+    afterEach(() => {
+      if (originalEnabled !== undefined) {
+        process.env.TURNSTILE_ENABLED = originalEnabled;
+      } else {
+        delete process.env.TURNSTILE_ENABLED;
+      }
+    });
+
+    it('should return true for any case variation of "true"', function () {
+      this.timeout(30000);
+      fc.assert(
+        fc.property(caseTrue, (value) => {
+          process.env.TURNSTILE_ENABLED = value;
+          should(TurnstileService.isEnabled()).be.true();
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should return false for any string that is not case-insensitively "true"', function () {
+      this.timeout(30000);
+      fc.assert(
+        fc.property(notTrue, (value) => {
+          process.env.TURNSTILE_ENABLED = value;
+          should(TurnstileService.isEnabled()).be.false();
+        }),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should return false when TURNSTILE_ENABLED is unset', function () {
+      this.timeout(30000);
       delete process.env.TURNSTILE_ENABLED;
-    }
-  });
-
-  it('should return true for any case variation of "true"', function () {
-    this.timeout(30000);
-    fc.assert(
-      fc.property(caseTrue, (value) => {
-        process.env.TURNSTILE_ENABLED = value;
-        should(TurnstileService.isEnabled()).be.true();
-      }),
-      { numRuns: 100 }
-    );
-  });
-
-  it('should return false for any string that is not case-insensitively "true"', function () {
-    this.timeout(30000);
-    fc.assert(
-      fc.property(notTrue, (value) => {
-        process.env.TURNSTILE_ENABLED = value;
-        should(TurnstileService.isEnabled()).be.false();
-      }),
-      { numRuns: 100 }
-    );
-  });
-
-  it('should return false when TURNSTILE_ENABLED is unset', function () {
-    this.timeout(30000);
-    delete process.env.TURNSTILE_ENABLED;
-    should(TurnstileService.isEnabled()).be.false();
+      should(TurnstileService.isEnabled()).be.false();
+    });
   });
 });

--- a/test/integration/1_services/TurnstileService.property.test.js
+++ b/test/integration/1_services/TurnstileService.property.test.js
@@ -1,0 +1,201 @@
+/* eslint-disable func-names */
+const should = require('should');
+const sinon = require('sinon');
+const fc = require('fast-check');
+const TurnstileService = require('../../../api/services/TurnstileService');
+
+// --- Shared arbitraries ---
+
+// Whitespace-only strings (for Property 1)
+const whitespaceOnly = fc
+  .array(
+    fc.constantFrom(' ', '\t', '\n', '\r', '\v', '\f', '\u00A0', '\u2003'),
+    { minLength: 0, maxLength: 50 }
+  )
+  .map((chars) => chars.join(''));
+
+// Case variations of "true" (for Property 6)
+const caseTrue = fc.constantFrom(
+  'true',
+  'True',
+  'TRUE',
+  'tRuE',
+  'truE',
+  'tRUE'
+);
+const notTrue = fc.string().filter((s) => s.toLowerCase() !== 'true');
+
+/**
+ * Property 1: Missing or whitespace-only captchaToken is always rejected
+ *
+ * For any string composed entirely of whitespace characters (including the empty
+ * string) or for undefined/null, the verifyToken function returns
+ * { pass: false, errorCode: 'CAPTCHA_MISSING' }.
+ *
+ * Validates: Requirements 1.1
+ */
+describe('Feature: signup-anti-bot-protection, Property 1: Missing or whitespace-only captchaToken is always rejected', () => {
+  it('should reject whitespace-only tokens with CAPTCHA_MISSING', async function () {
+    this.timeout(30000);
+    await fc.assert(
+      fc.asyncProperty(whitespaceOnly, async (token) => {
+        const result = await TurnstileService.verifyToken(token, '127.0.0.1');
+        should(result.pass).be.false();
+        should(result.errorCode).equal('CAPTCHA_MISSING');
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should reject empty string token with CAPTCHA_MISSING', async function () {
+    this.timeout(30000);
+    const result = await TurnstileService.verifyToken('', '127.0.0.1');
+    should(result.pass).be.false();
+    should(result.errorCode).equal('CAPTCHA_MISSING');
+  });
+
+  it('should reject undefined token with CAPTCHA_MISSING', async function () {
+    this.timeout(30000);
+    const result = await TurnstileService.verifyToken(undefined, '127.0.0.1');
+    should(result.pass).be.false();
+    should(result.errorCode).equal('CAPTCHA_MISSING');
+  });
+
+  it('should reject null token with CAPTCHA_MISSING', async function () {
+    this.timeout(30000);
+    const result = await TurnstileService.verifyToken(null, '127.0.0.1');
+    should(result.pass).be.false();
+    should(result.errorCode).equal('CAPTCHA_MISSING');
+  });
+});
+
+/**
+ * Property 2: Siteverify request body is correctly constructed
+ *
+ * For any valid captcha token string, secret key string, and IP address string,
+ * the outbound POST body sent to Cloudflare contains all three values mapped to
+ * the keys 'response', 'secret', and 'remoteip' respectively.
+ *
+ * Validates: Requirements 1.2
+ */
+describe('Feature: signup-anti-bot-protection, Property 2: Siteverify request body is correctly constructed', () => {
+  let originalSecretKey;
+
+  beforeEach(() => {
+    originalSecretKey = process.env.TURNSTILE_SECRET_KEY;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    if (originalSecretKey !== undefined) {
+      process.env.TURNSTILE_SECRET_KEY = originalSecretKey;
+    } else {
+      delete process.env.TURNSTILE_SECRET_KEY;
+    }
+  });
+
+  it('should POST correct body with secret, response, and remoteip', async function () {
+    this.timeout(30000);
+
+    // Token must be non-blank (whitespace-only tokens are rejected before fetch)
+    const nonBlankToken = fc
+      .string({ minLength: 1, maxLength: 2048 })
+      .filter((s) => s.trim().length > 0);
+    const secretKey = fc.string({ minLength: 1, maxLength: 100 });
+    const ipAddress = fc.string({ minLength: 1, maxLength: 45 });
+
+    await fc.assert(
+      fc.asyncProperty(
+        nonBlankToken,
+        secretKey,
+        ipAddress,
+        async (token, secret, ip) => {
+          process.env.TURNSTILE_SECRET_KEY = secret;
+
+          const fetchStub = sinon.stub(global, 'fetch').resolves({
+            ok: true,
+            status: 200,
+            json: async () => ({ success: true }),
+          });
+
+          try {
+            await TurnstileService.verifyToken(token, ip);
+
+            should(fetchStub.calledOnce).be.true();
+
+            const [url, options] = fetchStub.firstCall.args;
+            should(url).equal(
+              'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+            );
+            should(options.method).equal('POST');
+            should(options.headers['Content-Type']).equal(
+              'application/x-www-form-urlencoded'
+            );
+
+            // Parse the URLSearchParams body to verify field values
+            const body = new URLSearchParams(options.body.toString());
+            should(body.get('secret')).equal(secret);
+            should(body.get('response')).equal(token);
+            should(body.get('remoteip')).equal(ip);
+          } finally {
+            fetchStub.restore();
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 6: Only case-insensitive "true" enables Turnstile
+ *
+ * For any string value of TURNSTILE_ENABLED that is NOT case-insensitively equal
+ * to "true", isEnabled() returns false. Conversely, for any case variation of
+ * "true", it returns true.
+ *
+ * Validates: Requirements 4.2
+ */
+describe('Feature: signup-anti-bot-protection, Property 6: Only case-insensitive true enables Turnstile', () => {
+  let originalEnabled;
+
+  beforeEach(() => {
+    originalEnabled = process.env.TURNSTILE_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalEnabled !== undefined) {
+      process.env.TURNSTILE_ENABLED = originalEnabled;
+    } else {
+      delete process.env.TURNSTILE_ENABLED;
+    }
+  });
+
+  it('should return true for any case variation of "true"', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(caseTrue, (value) => {
+        process.env.TURNSTILE_ENABLED = value;
+        should(TurnstileService.isEnabled()).be.true();
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return false for any string that is not case-insensitively "true"', function () {
+    this.timeout(30000);
+    fc.assert(
+      fc.property(notTrue, (value) => {
+        process.env.TURNSTILE_ENABLED = value;
+        should(TurnstileService.isEnabled()).be.false();
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return false when TURNSTILE_ENABLED is unset', function () {
+    this.timeout(30000);
+    delete process.env.TURNSTILE_ENABLED;
+    should(TurnstileService.isEnabled()).be.false();
+  });
+});

--- a/test/integration/1_services/TurnstileService.test.js
+++ b/test/integration/1_services/TurnstileService.test.js
@@ -1,0 +1,188 @@
+const should = require('should');
+const sinon = require('sinon');
+const TurnstileService = require('../../../api/services/TurnstileService');
+
+describe('TurnstileService', () => {
+  let originalEnabled;
+  let originalSecret;
+
+  beforeEach(() => {
+    originalEnabled = process.env.TURNSTILE_ENABLED;
+    originalSecret = process.env.TURNSTILE_SECRET_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) {
+      delete process.env.TURNSTILE_ENABLED;
+    } else {
+      process.env.TURNSTILE_ENABLED = originalEnabled;
+    }
+    if (originalSecret === undefined) {
+      delete process.env.TURNSTILE_SECRET_KEY;
+    } else {
+      process.env.TURNSTILE_SECRET_KEY = originalSecret;
+    }
+    sinon.restore();
+  });
+
+  describe('isEnabled()', () => {
+    it('should return false when TURNSTILE_ENABLED env var is absent', () => {
+      delete process.env.TURNSTILE_ENABLED;
+      should(TurnstileService.isEnabled()).be.false();
+    });
+
+    it('should return false when TURNSTILE_ENABLED is empty string', () => {
+      process.env.TURNSTILE_ENABLED = '';
+      should(TurnstileService.isEnabled()).be.false();
+    });
+
+    it('should return false when TURNSTILE_ENABLED is "false"', () => {
+      process.env.TURNSTILE_ENABLED = 'false';
+      should(TurnstileService.isEnabled()).be.false();
+    });
+
+    it('should return true when TURNSTILE_ENABLED is "true"', () => {
+      process.env.TURNSTILE_ENABLED = 'true';
+      should(TurnstileService.isEnabled()).be.true();
+    });
+
+    it('should return true when TURNSTILE_ENABLED is "TRUE"', () => {
+      process.env.TURNSTILE_ENABLED = 'TRUE';
+      should(TurnstileService.isEnabled()).be.true();
+    });
+  });
+
+  describe('validateConfig()', () => {
+    it('should throw when enabled without secret key', () => {
+      process.env.TURNSTILE_ENABLED = 'true';
+      delete process.env.TURNSTILE_SECRET_KEY;
+      should(() => TurnstileService.validateConfig()).throw(
+        'TURNSTILE_SECRET_KEY is required when TURNSTILE_ENABLED is set to true'
+      );
+    });
+
+    it('should throw when enabled with empty secret key', () => {
+      process.env.TURNSTILE_ENABLED = 'true';
+      process.env.TURNSTILE_SECRET_KEY = '   ';
+      should(() => TurnstileService.validateConfig()).throw(
+        'TURNSTILE_SECRET_KEY is required when TURNSTILE_ENABLED is set to true'
+      );
+    });
+
+    it('should not throw when disabled without secret key', () => {
+      delete process.env.TURNSTILE_ENABLED;
+      delete process.env.TURNSTILE_SECRET_KEY;
+      should(() => TurnstileService.validateConfig()).not.throw();
+    });
+
+    it('should not throw when enabled with valid secret key', () => {
+      process.env.TURNSTILE_ENABLED = 'true';
+      process.env.TURNSTILE_SECRET_KEY = 'my-secret-key';
+      should(() => TurnstileService.validateConfig()).not.throw();
+    });
+  });
+
+  describe('verifyToken()', () => {
+    beforeEach(() => {
+      process.env.TURNSTILE_SECRET_KEY = 'test-secret-key';
+    });
+
+    it('should return CAPTCHA_MISSING when token is undefined', async () => {
+      const result = await TurnstileService.verifyToken(undefined, '1.2.3.4');
+      should(result).deepEqual({ pass: false, errorCode: 'CAPTCHA_MISSING' });
+    });
+
+    it('should return CAPTCHA_MISSING when token is null', async () => {
+      const result = await TurnstileService.verifyToken(null, '1.2.3.4');
+      should(result).deepEqual({ pass: false, errorCode: 'CAPTCHA_MISSING' });
+    });
+
+    it('should return CAPTCHA_MISSING when token is empty string', async () => {
+      const result = await TurnstileService.verifyToken('', '1.2.3.4');
+      should(result).deepEqual({ pass: false, errorCode: 'CAPTCHA_MISSING' });
+    });
+
+    it('should return CAPTCHA_MISSING when token is whitespace-only', async () => {
+      const result = await TurnstileService.verifyToken('   ', '1.2.3.4');
+      should(result).deepEqual({ pass: false, errorCode: 'CAPTCHA_MISSING' });
+    });
+
+    it('should return pass when Cloudflare responds success: true', async () => {
+      sinon.stub(global, 'fetch').resolves({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      const result = await TurnstileService.verifyToken(
+        'valid-token',
+        '1.2.3.4'
+      );
+      should(result).deepEqual({ pass: true, errorCode: null });
+    });
+
+    it('should return CAPTCHA_INVALID when Cloudflare responds success: false', async () => {
+      sinon.stub(global, 'fetch').resolves({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: false,
+          'error-codes': ['invalid-input-response'],
+        }),
+      });
+
+      const result = await TurnstileService.verifyToken(
+        'invalid-token',
+        '1.2.3.4'
+      );
+      should(result).deepEqual({ pass: false, errorCode: 'CAPTCHA_INVALID' });
+    });
+
+    it('should return CAPTCHA_SERVICE_UNAVAILABLE on network error', async () => {
+      sinon.stub(global, 'fetch').rejects(new Error('Network error'));
+
+      const result = await TurnstileService.verifyToken(
+        'some-token',
+        '1.2.3.4'
+      );
+      should(result).deepEqual({
+        pass: false,
+        errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE',
+      });
+    });
+
+    it('should return CAPTCHA_SERVICE_UNAVAILABLE on HTTP 5xx response', async () => {
+      sinon.stub(global, 'fetch').resolves({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+
+      const result = await TurnstileService.verifyToken(
+        'some-token',
+        '1.2.3.4'
+      );
+      should(result).deepEqual({
+        pass: false,
+        errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE',
+      });
+    });
+
+    it('should return CAPTCHA_SERVICE_UNAVAILABLE on timeout (AbortError)', async () => {
+      const abortError = new DOMException(
+        'The operation was aborted',
+        'AbortError'
+      );
+      sinon.stub(global, 'fetch').rejects(abortError);
+
+      const result = await TurnstileService.verifyToken(
+        'some-token',
+        '1.2.3.4'
+      );
+      should(result).deepEqual({
+        pass: false,
+        errorCode: 'CAPTCHA_SERVICE_UNAVAILABLE',
+      });
+    });
+  });
+});

--- a/test/integration/1_services/sign-up.property.test.js
+++ b/test/integration/1_services/sign-up.property.test.js
@@ -22,69 +22,72 @@ const arbitraryCaptchaToken = fc.oneof(
   fc.string({ minLength: 1, maxLength: 2048 })
 );
 
-/**
- * Property 5: Honeypot rejection short-circuits Turnstile verification
- *
- * For any request body with a `website` field containing at least one
- * non-whitespace character, the Turnstile verification function SHALL NOT
- * be invoked — regardless of the `captchaToken` value.
- *
- * Validates: Requirements 3.1, 3.2
- */
-describe('Feature: signup-anti-bot-protection, Property 5: Honeypot rejection short-circuits Turnstile verification', () => {
-  let verifyTokenStub;
+describe('signup-anti-bot-protection', () => {
+  /**
+   * Property 5: Honeypot rejection short-circuits Turnstile verification
+   *
+   * For any request body with a `website` field containing at least one
+   * non-whitespace character, the Turnstile verification function SHALL NOT
+   * be invoked — regardless of the `captchaToken` value.
+   *
+   * Validates: Requirements 3.1, 3.2
+   */
+  describe('Property 5: Honeypot rejection short-circuits Turnstile verification', () => {
+    let verifyTokenStub;
 
-  beforeEach(() => {
-    verifyTokenStub = sinon.stub(TurnstileService, 'verifyToken').resolves({
-      pass: true,
-      errorCode: null,
+    beforeEach(() => {
+      verifyTokenStub = sinon.stub(TurnstileService, 'verifyToken').resolves({
+        pass: true,
+        errorCode: null,
+      });
+      sinon.stub(TurnstileService, 'isEnabled').returns(true);
+      sinon.stub(sails.log, 'warn');
     });
-    sinon.stub(TurnstileService, 'isEnabled').returns(true);
-    sinon.stub(sails.log, 'warn');
-  });
 
-  afterEach(() => {
-    sinon.restore();
-  });
+    afterEach(() => {
+      sinon.restore();
+    });
 
-  it('should never call TurnstileService.verifyToken when honeypot traps', async function () {
-    this.timeout(30000);
+    it('should never call TurnstileService.verifyToken when honeypot traps', async function () {
+      this.timeout(30000);
 
-    await fc.assert(
-      fc.asyncProperty(
-        nonEmptyAfterTrim,
-        arbitraryCaptchaToken,
-        async (website, captchaToken) => {
-          // Reset call counts between iterations
-          verifyTokenStub.resetHistory();
+      await fc.assert(
+        fc.asyncProperty(
+          nonEmptyAfterTrim,
+          arbitraryCaptchaToken,
+          async (website, captchaToken) => {
+            // Reset call counts between iterations
+            verifyTokenStub.resetHistory();
 
-          const req = {
-            body: { website, captchaToken },
-            ip: '192.168.1.1',
-            param: (name) => req.body[name],
-          };
+            const req = {
+              body: { website, captchaToken },
+              ip: '192.168.1.1',
+              param: (name) => req.body[name],
+              allParams: () => req.body,
+            };
 
-          let responseSent = false;
-          const res = {
-            ok: () => {
-              responseSent = true;
-            },
-            status: () => res,
-            json: () => res,
-            badRequest: () => res,
-            conflict: () => res,
-          };
+            let responseSent = false;
+            const res = {
+              ok: () => {
+                responseSent = true;
+              },
+              status: () => res,
+              json: () => res,
+              badRequest: () => res,
+              conflict: () => res,
+            };
 
-          await signUpController(req, res);
+            await signUpController(req, res);
 
-          // The honeypot should have intercepted and returned 200
-          should(responseSent).be.true();
+            // The honeypot should have intercepted and returned 200
+            should(responseSent).be.true();
 
-          // TurnstileService.verifyToken must NOT have been called
-          should(verifyTokenStub.callCount).equal(0);
-        }
-      ),
-      { numRuns: 100 }
-    );
+            // TurnstileService.verifyToken must NOT have been called
+            should(verifyTokenStub.callCount).equal(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
   });
 });

--- a/test/integration/1_services/sign-up.property.test.js
+++ b/test/integration/1_services/sign-up.property.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable func-names */
+const should = require('should');
+const sinon = require('sinon');
+const fc = require('fast-check');
+const TurnstileService = require('../../../api/services/TurnstileService');
+
+// Require the controller directly to test defense ordering logic
+const signUpController = require('../../../api/controllers/v1/auth/sign-up');
+
+// --- Shared arbitraries ---
+
+// Non-empty-after-trim strings (for Property 5)
+const nonEmptyAfterTrim = fc
+  .string({ minLength: 1 })
+  .filter((s) => s.trim().length > 0);
+
+// Arbitrary captcha tokens — may or may not be present
+const arbitraryCaptchaToken = fc.oneof(
+  fc.constant(undefined),
+  fc.constant(null),
+  fc.constant(''),
+  fc.string({ minLength: 1, maxLength: 2048 })
+);
+
+/**
+ * Property 5: Honeypot rejection short-circuits Turnstile verification
+ *
+ * For any request body with a `website` field containing at least one
+ * non-whitespace character, the Turnstile verification function SHALL NOT
+ * be invoked — regardless of the `captchaToken` value.
+ *
+ * Validates: Requirements 3.1, 3.2
+ */
+describe('Feature: signup-anti-bot-protection, Property 5: Honeypot rejection short-circuits Turnstile verification', () => {
+  let verifyTokenStub;
+
+  beforeEach(() => {
+    verifyTokenStub = sinon.stub(TurnstileService, 'verifyToken').resolves({
+      pass: true,
+      errorCode: null,
+    });
+    sinon.stub(TurnstileService, 'isEnabled').returns(true);
+    sinon.stub(sails.log, 'warn');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should never call TurnstileService.verifyToken when honeypot traps', async function () {
+    this.timeout(30000);
+
+    await fc.assert(
+      fc.asyncProperty(
+        nonEmptyAfterTrim,
+        arbitraryCaptchaToken,
+        async (website, captchaToken) => {
+          // Reset call counts between iterations
+          verifyTokenStub.resetHistory();
+
+          const req = {
+            body: { website, captchaToken },
+            ip: '192.168.1.1',
+            param: (name) => req.body[name],
+          };
+
+          let responseSent = false;
+          const res = {
+            ok: () => {
+              responseSent = true;
+            },
+            status: () => res,
+            json: () => res,
+            badRequest: () => res,
+            conflict: () => res,
+          };
+
+          await signUpController(req, res);
+
+          // The honeypot should have intercepted and returned 200
+          should(responseSent).be.true();
+
+          // TurnstileService.verifyToken must NOT have been called
+          should(verifyTokenStub.callCount).equal(0);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/test/integration/4_routes/Auth/sign-up-anti-bot.test.js
+++ b/test/integration/4_routes/Auth/sign-up-anti-bot.test.js
@@ -1,0 +1,236 @@
+const supertest = require('supertest');
+const should = require('should');
+const sinon = require('sinon');
+
+describe('Auth features', () => {
+  describe('Sign-up anti-bot protection', () => {
+    let originalEnabled;
+    let originalSecret;
+    const createdEmails = [];
+
+    beforeEach(() => {
+      originalEnabled = process.env.TURNSTILE_ENABLED;
+      originalSecret = process.env.TURNSTILE_SECRET_KEY;
+    });
+
+    afterEach(async () => {
+      // Restore env vars
+      if (originalEnabled === undefined) {
+        delete process.env.TURNSTILE_ENABLED;
+      } else {
+        process.env.TURNSTILE_ENABLED = originalEnabled;
+      }
+      if (originalSecret === undefined) {
+        delete process.env.TURNSTILE_SECRET_KEY;
+      } else {
+        process.env.TURNSTILE_SECRET_KEY = originalSecret;
+      }
+      sinon.restore();
+    });
+
+    after(async () => {
+      // Clean up any cavers created during tests
+      if (createdEmails.length > 0) {
+        await TCaver.destroy({ mail: createdEmails });
+      }
+    });
+
+    describe('Defense ordering', () => {
+      it('should return 204 when honeypot is filled, even with invalid captcha (honeypot wins)', async () => {
+        process.env.TURNSTILE_ENABLED = 'true';
+        process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+
+        // Stub fetch to reject with CAPTCHA_INVALID if called
+        sinon.stub(global, 'fetch').resolves({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: false }),
+        });
+
+        await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: 'honeypot-ordering@example.com',
+            nickname: 'honeypotorder',
+            password: 'Secure_pass1!',
+            website: 'http://spam.example.com',
+            captchaToken: 'invalid-token',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+      });
+    });
+
+    describe('Honeypot rejection', () => {
+      it('should not create a caver when honeypot is triggered', async () => {
+        process.env.TURNSTILE_ENABLED = 'false';
+
+        const testEmail = `honeypot-nocreate-${Date.now()}@example.com`;
+
+        await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: `hpnc${Date.now()}`,
+            password: 'Secure_pass1!',
+            website: 'http://bot.example.com',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).be.undefined();
+      });
+    });
+
+    describe('Turnstile rejection (missing token)', () => {
+      it('should return 400 with CAPTCHA_MISSING and not create a caver', async () => {
+        process.env.TURNSTILE_ENABLED = 'true';
+        process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+
+        const testEmail = `turnstile-missing-${Date.now()}@example.com`;
+
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: `tsmiss${Date.now()}`,
+            password: 'Secure_pass1!',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400);
+
+        should(res.body).have.property('error', 'CAPTCHA_MISSING');
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).be.undefined();
+      });
+    });
+
+    describe('Turnstile rejection (invalid token)', () => {
+      it('should return 400 with CAPTCHA_INVALID and not create a caver', async () => {
+        process.env.TURNSTILE_ENABLED = 'true';
+        process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+
+        sinon.stub(global, 'fetch').resolves({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: false,
+            'error-codes': ['invalid-input-response'],
+          }),
+        });
+
+        const testEmail = `turnstile-invalid-${Date.now()}@example.com`;
+
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: `tsinv${Date.now()}`,
+            password: 'Secure_pass1!',
+            captchaToken: 'bad-token',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400);
+
+        should(res.body).have.property('error', 'CAPTCHA_INVALID');
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).be.undefined();
+      });
+    });
+
+    describe('Turnstile service unavailable', () => {
+      it('should return 503 with CAPTCHA_SERVICE_UNAVAILABLE', async () => {
+        process.env.TURNSTILE_ENABLED = 'true';
+        process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+
+        sinon.stub(global, 'fetch').rejects(new Error('Network error'));
+
+        const testEmail = `turnstile-503-${Date.now()}@example.com`;
+
+        const res = await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: `ts503${Date.now()}`,
+            password: 'Secure_pass1!',
+            captchaToken: 'some-token',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(503);
+
+        should(res.body).have.property('error', 'CAPTCHA_SERVICE_UNAVAILABLE');
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).be.undefined();
+      });
+    });
+
+    describe('Happy path (Turnstile enabled)', () => {
+      it('should create a caver when honeypot is empty and captcha is valid', async () => {
+        process.env.TURNSTILE_ENABLED = 'true';
+        process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+
+        sinon.stub(global, 'fetch').resolves({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true }),
+        });
+
+        const testEmail = `antibot-happy-${Date.now()}@example.com`;
+        const testNickname = `abhappy${Date.now()}`;
+        createdEmails.push(testEmail);
+
+        await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: testNickname,
+            password: 'Secure_pass1!',
+            captchaToken: 'valid-token',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).not.be.undefined();
+        should(caver.nickname).equal(testNickname);
+        should(caver.activated).be.false();
+      });
+    });
+
+    describe('Happy path (Turnstile disabled)', () => {
+      it('should create a caver without captchaToken when Turnstile is disabled', async () => {
+        process.env.TURNSTILE_ENABLED = 'false';
+
+        const testEmail = `antibot-disabled-${Date.now()}@example.com`;
+        const testNickname = `abdis${Date.now()}`;
+        createdEmails.push(testEmail);
+
+        await supertest(sails.hooks.http.app)
+          .post('/api/v1/signup')
+          .send({
+            email: testEmail,
+            nickname: testNickname,
+            password: 'Secure_pass1!',
+          })
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const caver = await TCaver.findOne({ mail: testEmail });
+        should(caver).not.be.undefined();
+        should(caver.nickname).equal(testNickname);
+        should(caver.activated).be.false();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🤔 What

Add two defense layers to `POST /api/v1/signup` to block automated bot registrations:
- **Honeypot field rejection** — catches naive bots that auto-fill a hidden `website` field
- **Cloudflare Turnstile token verification** — validates the front-end CAPTCHA token via the Cloudflare siteverify API

Closes #1727

## 🤷‍♂️ Why

The signup endpoint is being abused by bots creating fake accounts in bulk. The front-end companion ticket introduces a Turnstile widget, but the back-end must independently verify the token — otherwise bots can POST directly to the endpoint.

## 🔍 How

- **Defense ordering**: honeypot first (zero-cost string check), then Turnstile (external API call). Each layer short-circuits on rejection.
- **HoneypotGuard** (`api/services/HoneypotGuard.js`): stateless check using existing `isNonBlankString` utility. Returns deceptive 204 on trap (bot thinks signup succeeded).
- **TurnstileService** (`api/services/TurnstileService.js`): reusable service with `isEnabled()`, `validateConfig()`, and `verifyToken()`. Uses native `fetch` with `AbortSignal.timeout(3000)`. Fail-closed design (any error → `CAPTCHA_SERVICE_UNAVAILABLE`).
- **Bootstrap validation** (`config/bootstrap.js`): app refuses to start if `TURNSTILE_ENABLED=true` without `TURNSTILE_SECRET_KEY`. Logs warning when disabled.
- **Controller preamble** (`api/controllers/v1/auth/sign-up.js`): inserts both checks before existing logic. Existing signup flow unchanged.
- Configurable via `TURNSTILE_ENABLED` and `TURNSTILE_SECRET_KEY` env vars.

## 🧪 Testing

- Property tests (6 properties, `fast-check` with 100 runs each)
- Unit tests for both services (HoneypotGuard: 9, TurnstileService: 18)
- Integration tests via supertest (7 route-level tests covering defense ordering, rejections, and happy paths)
- All anti-bot tests pass. Full suite: same 17 pre-existing failures unrelated to this feature (now fixed — `global.sails` restoration).

To run just the anti-bot tests:
```bash
npm run test -- --grep "HoneypotGuard|TurnstileService|anti-bot|Property 5"
```

## 📸 Previews

N/A — backend-only change.
