### PR TITLE
fix(csvImport): fix batch status=failed on successful import

### DIFF
--- a/api/services/CSVImportQueueService.js
+++ b/api/services/CSVImportQueueService.js
@@ -505,14 +505,13 @@ module.exports = {
       );
     } catch (err) {
       sails.log.error(
-        `CSVImportQueueService: aggregation failed for batch ${batchId}:`,
+        `CSVImportQueueService: report generation failed for batch ${batchId} (rows were already imported):`,
         err
       );
-      await TJobBatch.updateOne({ id: batchId }).set({
-        status: 'failed',
-        completedAt: new Date(),
-      });
-      return;
+      // Report upload failed, but the rows were already imported successfully.
+      // Mark the batch as completed with null reportUrls so the front-end
+      // can show accurate import counts instead of a misleading "failed" status.
+      reportUrls = { successes: null, duplicates: null, failures: null };
     }
 
     const resultPayload = {

--- a/api/services/CSVImportQueueService.js
+++ b/api/services/CSVImportQueueService.js
@@ -530,45 +530,57 @@ module.exports = {
 
   /**
    * Generate CSV reports and upload to Azure Blob Storage.
+   * Each report is uploaded independently; a failure on one does not prevent
+   * the others from being uploaded. URLs for successfully uploaded reports are
+   * returned; failed ones stay null and a warning is logged.
    * @param {string} batchId
    * @param {Array} successes
    * @param {Array} duplicates
    * @param {Array} failures
-   * @returns {Object} { success: url|null, duplicates: url|null, failures: url|null }
+   * @returns {Object} { successes: url|null, duplicates: url|null, failures: url|null }
    */
   async generateAndUploadReports(batchId, successes, duplicates, failures) {
     const reportUrls = { successes: null, duplicates: null, failures: null };
 
     const prefix = `csv-import-reports/${batchId}`;
 
-    if (successes.length > 0) {
-      const csv = module.exports.toCSV(
-        ['line', 'caveId', 'entranceId', 'latitude', 'longitude'],
-        successes
-      );
-      reportUrls.successes = await module.exports.uploadReport(
-        prefix,
-        'successes.csv',
-        csv
-      );
-    }
+    const uploads = [
+      {
+        key: 'successes',
+        rows: successes,
+        columns: ['line', 'caveId', 'entranceId', 'latitude', 'longitude'],
+        filename: 'successes.csv',
+      },
+      {
+        key: 'duplicates',
+        rows: duplicates,
+        columns: ['line', 'message'],
+        filename: 'duplicates.csv',
+      },
+      {
+        key: 'failures',
+        rows: failures,
+        columns: ['line', 'message'],
+        filename: 'failures.csv',
+      },
+    ];
 
-    if (duplicates.length > 0) {
-      const csv = module.exports.toCSV(['line', 'message'], duplicates);
-      reportUrls.duplicates = await module.exports.uploadReport(
-        prefix,
-        'duplicates.csv',
-        csv
-      );
-    }
-
-    if (failures.length > 0) {
-      const csv = module.exports.toCSV(['line', 'message'], failures);
-      reportUrls.failures = await module.exports.uploadReport(
-        prefix,
-        'failures.csv',
-        csv
-      );
+    for (const { key, rows, columns, filename } of uploads) {
+      if (rows.length === 0) continue; // eslint-disable-line no-continue
+      const csv = module.exports.toCSV(columns, rows);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        reportUrls[key] = await module.exports.uploadReport(
+          prefix,
+          filename,
+          csv
+        );
+      } catch (err) {
+        sails.log.warn(
+          `CSVImportQueueService: failed to upload ${filename} for batch ${batchId}:`,
+          err
+        );
+      }
     }
 
     return reportUrls;

--- a/api/services/CSVImportQueueService.js
+++ b/api/services/CSVImportQueueService.js
@@ -8,10 +8,6 @@
  */
 
 const { v4: uuidv4 } = require('uuid');
-const {
-  BlobSASPermissions,
-  generateBlobSASQueryParameters,
-} = require('@azure/storage-blob');
 const { ENTRANCE_MANDATORY_COLUMNS } = require('../utils/csvHelper');
 
 const QUEUE_NAME = 'csv-import';
@@ -343,14 +339,14 @@ module.exports = {
       /* eslint-enable no-await-in-loop, no-continue */
 
       if (hasSuccessfulImport) {
-        sails.services.coordinatessnapshotservice
-          .invalidate()
-          .catch((err) =>
-            sails.log.error(
-              'CSVImportQueueService: coordinates snapshot invalidation failed:',
-              err
-            )
-          );
+        // eslint-disable-next-line global-require
+        const CoordinatesSnapshotService = require('./CoordinatesSnapshotService');
+        CoordinatesSnapshotService.invalidate().catch((err) =>
+          sails.log.error(
+            'CSVImportQueueService: coordinates snapshot invalidation failed:',
+            err
+          )
+        );
       }
     } catch (err) {
       sails.log.error(
@@ -601,19 +597,17 @@ module.exports = {
   },
 
   /**
-   * Upload a CSV report to Azure Blob Storage and return a SAS URL.
+   * Upload a CSV report to Azure Blob Storage and return the blob URL.
    *
-   * NOTE: The documents container allows anonymous access, so the SAS token
-   * is not strictly required for read access. However, it provides a
-   * time-bounded URL (7 days) which signals expiry intent to consumers,
-   * and access control effectively relies on the unguessability of the
-   * batch UUID in the blob path. This is acceptable given report contents
-   * are limited to line numbers and messages (no PII).
+   * The documents container allows anonymous read access, so no SAS token
+   * is generated. The URL is returned directly after upload. The batch UUID
+   * in the blob path provides sufficient access control for report contents,
+   * which are limited to line numbers and messages (no PII).
    *
    * @param {string} prefix
    * @param {string} filename
    * @param {string} content
-   * @returns {string} SAS URL valid for 7 days
+   * @returns {string} Public URL of the uploaded blob
    */
   async uploadReport(prefix, filename, content) {
     const blobPath = `${prefix}/${filename}`;
@@ -624,27 +618,7 @@ module.exports = {
       blobHTTPHeaders: { blobContentType: 'text/csv' },
     });
 
-    const sharedKeyCredential = FileService.getSharedKeyCredential();
-
-    // In dev mode (no Azure credentials), return the local URL directly
-    if (sharedKeyCredential && sharedKeyCredential.isLocalStub) {
-      return blockBlobClient.url;
-    }
-
-    const expiresOn = new Date();
-    expiresOn.setDate(expiresOn.getDate() + 7);
-
-    const sasToken = generateBlobSASQueryParameters(
-      {
-        containerName: containerClient.containerName,
-        blobName: blobPath,
-        permissions: BlobSASPermissions.parse('r'),
-        expiresOn,
-      },
-      sharedKeyCredential
-    ).toString();
-
-    return `${blockBlobClient.url}?${sasToken}`;
+    return blockBlobClient.url;
   },
 
   /**

--- a/api/services/FileService.js
+++ b/api/services/FileService.js
@@ -146,19 +146,6 @@ module.exports = {
     return credentials.documentsBlobClient;
   },
 
-  /**
-   * Get the shared key credential for SAS generation.
-   * In dev mode (no credentials), returns a stub that produces a no-op query string.
-   * @returns {import('@azure/storage-blob').StorageSharedKeyCredential|object|null}
-   */
-  getSharedKeyCredential() {
-    if (!credentials) {
-      // Return a stub; in dev mode URLs point to localhost so no real SAS needed
-      return { accountName: 'local-dev', isLocalStub: true };
-    }
-    return credentials.sharedKeyCredential;
-  },
-
   document: {
     getUrl(filePath) {
       if (!credentials) {

--- a/test/integration/1_services/CSVImportQueueService.property.test.js
+++ b/test/integration/1_services/CSVImportQueueService.property.test.js
@@ -2,8 +2,7 @@ const should = require('should');
 const fc = require('fast-check');
 
 describe('CSVImportQueueService - Property: affinity chunking co-location and completeness', () => {
-  it('should place all rows with the same key in the same chunk and preserve total count', function () {
-    this.timeout(30000);
+  it('should place all rows with the same key in the same chunk and preserve total count', () => {
     fc.assert(
       fc.property(
         fc.array(
@@ -67,5 +66,5 @@ describe('CSVImportQueueService - Property: affinity chunking co-location and co
       ),
       { numRuns: 100 }
     );
-  });
+  }).timeout(30000);
 });

--- a/test/integration/1_services/CSVImportQueueService.test.js
+++ b/test/integration/1_services/CSVImportQueueService.test.js
@@ -300,6 +300,122 @@ describe('CSVImportQueueService', () => {
     });
   });
 
+  describe('aggregateBatch', () => {
+    let findOneStub;
+    let updateStub;
+    let generateStub;
+    let notifyStub;
+    let setStub;
+
+    before(() => {
+      findOneStub = sinon
+        .stub(TJobBatch, 'findOne')
+        .resolves({ id: 'batch-abc', totalChunks: 1, totalRows: 2 });
+      setStub = sinon.stub().resolves({ id: 'batch-abc' });
+      updateStub = sinon.stub(TJobBatch, 'updateOne').returns({ set: setStub });
+      generateStub = sinon.stub(
+        CSVImportQueueService,
+        'generateAndUploadReports'
+      );
+      notifyStub = sinon
+        .stub(CSVImportQueueService, 'notifyCompletion')
+        .resolves();
+    });
+
+    after(() => {
+      findOneStub.restore();
+      updateStub.restore();
+      generateStub.restore();
+      notifyStub.restore();
+    });
+
+    afterEach(() => {
+      findOneStub.resetHistory();
+      updateStub.resetHistory();
+      setStub.resetHistory();
+      generateStub.resetHistory();
+      notifyStub.resetHistory();
+    });
+
+    it('should mark batch as completed with null reportUrls when report upload fails', async () => {
+      const jobs = [
+        {
+          state: 'completed',
+          output: {
+            successes: [{ line: 2, caveId: 10, entranceId: 20 }],
+            duplicates: [],
+            failures: [],
+          },
+          data: { batchId: 'batch-abc', rows: [{}] },
+        },
+        {
+          state: 'completed',
+          output: {
+            successes: [],
+            duplicates: [],
+            failures: [{ line: 3, message: 'Missing column' }],
+          },
+          data: { batchId: 'batch-abc', rows: [{}] },
+        },
+      ];
+
+      generateStub.rejects(new Error('Azure upload failed'));
+
+      await CSVImportQueueService.aggregateBatch('batch-abc', jobs);
+
+      // Batch must be marked completed, not failed
+      should(updateStub.callCount).equal(1);
+      should(setStub.callCount).equal(1);
+      const setArgs = setStub.firstCall.args[0];
+      should(setArgs.status).equal('completed');
+      should(setArgs.result).not.be.null();
+      should(setArgs.result.summary.successes).equal(1);
+      should(setArgs.result.summary.failures).equal(1);
+      should(setArgs.result.reportUrls.successes).be.null();
+      should(setArgs.result.reportUrls.duplicates).be.null();
+      should(setArgs.result.reportUrls.failures).be.null();
+
+      // Notification must still be sent
+      should(notifyStub.callCount).equal(1);
+      const notifyArgs = notifyStub.firstCall.args;
+      should(notifyArgs[0]).equal('batch-abc');
+      should(notifyArgs[1].summary.successes).equal(1);
+    });
+
+    it('should mark batch as completed with reportUrls when upload succeeds', async () => {
+      const jobs = [
+        {
+          state: 'completed',
+          output: {
+            successes: [{ line: 2, caveId: 10, entranceId: 20 }],
+            duplicates: [],
+            failures: [],
+          },
+          data: { batchId: 'batch-abc', rows: [{}] },
+        },
+      ];
+
+      const urls = {
+        successes: 'https://example.com/s.csv',
+        duplicates: null,
+        failures: null,
+      };
+      generateStub.resolves(urls);
+
+      await CSVImportQueueService.aggregateBatch('batch-abc', jobs);
+
+      should(updateStub.callCount).equal(1);
+      should(setStub.callCount).equal(1);
+      const setArgs = setStub.firstCall.args[0];
+      should(setArgs.status).equal('completed');
+      should(setArgs.result.reportUrls.successes).equal(
+        'https://example.com/s.csv'
+      );
+      should(setArgs.result.summary.successes).equal(1);
+      should(notifyStub.callCount).equal(1);
+    });
+  });
+
   describe('getBatchProgress', () => {
     let findOneStub;
     let queryStub;


### PR DESCRIPTION
## Summary

Fixes the bug reported in [grottocenter-front#1464](https://github.com/GrottoCenter/grottocenter-front/pull/1464) where a successful CSV entrance import displayed `status: "failed"` with the message "L'import a échoué. 0 lignes n'ont pas pu être importées."

Production logs (July 23–24) confirmed two root causes.

## Why

### Root cause 1 — `processOneChunk` crashes after a successful import

```
TypeError: Cannot read properties of undefined (reading 'catch')
    at Object.processOneChunk (.../CSVImportQueueService.js:348:11)
```

`sails.services.coordinatessnapshotservice` is `undefined` in the pg-boss worker context (workers run outside Sails' normal request lifecycle). The crash happens after rows have already been imported, causing the pg-boss job to be marked `failed` despite successful work. The fix replaces the `sails.services.*` reference with a direct `require()`, consistent with all other service calls in `processOneChunk`.

### Root cause 2 — `uploadReport` crashes on SAS token generation

```
TypeError: Invalid sharedKeyCredential, userDelegationKey or accountName.
    at generateBlobSASQueryParametersInternal (.../BlobSASSignatureValues.js:50:11)
    at Object.uploadReport (.../CSVImportQueueService.js:638:22)
```

`generateBlobSASQueryParameters` performs an `instanceof` check on the credential. When `FileService` is required across different Node require-cache contexts (which happens with Sails' module loader), the `StorageSharedKeyCredential` instance fails the check even though the object is structurally valid. The documents container already allows anonymous read access (noted in the original code comment), so SAS tokens were never necessary here. The fix drops SAS generation entirely and returns the plain blob URL directly, removing the fragile credential dependency.

### Why the batch showed `status: "failed"` despite `successes: 1`

Because `aggregateBatch` caught the `uploadReport` error and set `status = "failed"` without persisting the result payload. `getBatchProgress` independently queries pg-boss job outputs and correctly shows `successes: 1` — the two fields were sourced independently and could diverge. A third commit addresses this: report upload failures no longer set `status: "failed"`; the batch is marked `completed` with `reportUrls: null` so the front-end always receives accurate row counts.

## What

Three commits:

1. **`aggregateBatch` resilience**: when `generateAndUploadReports` throws, fall back to `reportUrls: null` and mark the batch `completed` instead of `failed`. Summary counts are always persisted.
2. **`processOneChunk` crash fix**: replace `sails.services.coordinatessnapshotservice` with `require('./CoordinatesSnapshotService')`.
3. **`uploadReport` SAS fix**: drop `generateBlobSASQueryParameters` entirely. Return `blockBlobClient.url` directly. Remove now-unused `BlobSASPermissions` and `generateBlobSASQueryParameters` imports.

New unit tests cover the `aggregateBatch` upload-failure path and happy path.

## Related

- Front-end bug report: [grottocenter-front#1464 (comment)](https://github.com/GrottoCenter/grottocenter-front/pull/1464#issuecomment-5064689743)
- Original async import PR: [grottocenter-api#1708](https://github.com/GrottoCenter/grottocenter-api/pull/1708)
