### PR TITLE
fix(thumbnail): apply EXIF orientation before resizing

### DIFF
--- a/api/services/ThumbnailService.js
+++ b/api/services/ThumbnailService.js
@@ -73,13 +73,26 @@ module.exports = {
    * Applies EXIF orientation before resizing so portrait photos shot on a
    * phone are not stored rotated. The orientation tag is dropped from the
    * output (the pixels are already upright, so browsers need no correction).
+   *
+   * `.autoOrient()` is skipped for animated inputs (pages > 1) because sharp's
+   * internal rotate step historically collapses multi-frame images to a single
+   * frame for orientations that require an actual pixel transform. Animated GIFs
+   * rarely carry EXIF orientation tags; skipping `.autoOrient()` for them avoids
+   * a still-WebP regression.
+   *
    * @param {Buffer} inputBuffer - The original image buffer
    * @param {number} targetWidth - The target width in pixels
+   * @param {object} [opts]
+   * @param {boolean} [opts.isAnimated=false] - True when the source has multiple frames
    * @returns {Promise<Buffer>} The resized WebP buffer
    */
-  async resize(inputBuffer, targetWidth) {
-    return sharp(inputBuffer, { animated: true })
-      .autoOrient() // rotate/flip pixels per EXIF Orientation, then drop the tag
+  async resize(inputBuffer, targetWidth, { isAnimated = false } = {}) {
+    const pipeline = sharp(inputBuffer, { animated: true });
+    if (!isAnimated) {
+      // rotate/flip pixels per EXIF Orientation, then drop the tag
+      pipeline.autoOrient();
+    }
+    return pipeline
       .resize({ width: targetWidth, withoutEnlargement: true })
       .webp({ quality: WEBP_QUALITY })
       .toBuffer();
@@ -96,15 +109,21 @@ module.exports = {
    * @param {Buffer} imageBuffer - The original image file buffer
    * @param {string} originalPath - The blob path of the original
    * @param {object} blobClient - Azure container client for uploading
+   * @param {object} [preloadedMeta] - Optional sharp metadata already fetched by the caller.
+   *   When provided the internal `sharp().metadata()` call is skipped, avoiding a
+   *   second decode of the same buffer (useful for callers that need orientation before
+   *   calling generate, e.g. the backfill script).
    * @returns {Promise<{small: string|null, medium: string|null, large: string|null, hadError: boolean}>}
    */
-  async generate(imageBuffer, originalPath, blobClient) {
+  async generate(imageBuffer, originalPath, blobClient, preloadedMeta) {
     const result = { small: null, medium: null, large: null, hadError: false };
 
     try {
-      const metadata = await sharp(imageBuffer, {
-        limitInputPixels: 100 * 1024 * 1024, // 100 megapixels max
-      }).metadata();
+      const metadata =
+        preloadedMeta ||
+        (await sharp(imageBuffer, {
+          limitInputPixels: 100 * 1024 * 1024, // 100 megapixels max
+        }).metadata());
       // Use the oriented (upright) width so portrait photos whose stored pixels
       // are landscape (e.g. EXIF Orientation 6/8) are measured correctly.
       // metadata.autoOrient is available since sharp 0.34 and falls back to
@@ -121,11 +140,15 @@ module.exports = {
         return result;
       }
 
+      // Animated inputs (GIFs with multiple frames) must not go through
+      // .autoOrient() — see resize() JSDoc for the rationale.
+      const isAnimated = (metadata.pages || 1) > 1;
+
       // Generate all buffers first (fail-fast before uploading)
       const buffers = await Promise.all(
         applicableVariants.map(async (variant) => ({
           name: variant.name,
-          buffer: await this.resize(imageBuffer, variant.width),
+          buffer: await this.resize(imageBuffer, variant.width, { isAnimated }),
           path: this.computeThumbnailPath(variant.name, originalPath),
         }))
       );

--- a/api/services/ThumbnailService.js
+++ b/api/services/ThumbnailService.js
@@ -70,12 +70,16 @@ module.exports = {
    * Resize an image buffer to the target width, output as WebP.
    * Preserves aspect ratio (no crop, no upscaling).
    * Preserves alpha channel for PNG inputs and animation for GIF inputs.
+   * Applies EXIF orientation before resizing so portrait photos shot on a
+   * phone are not stored rotated. The orientation tag is dropped from the
+   * output (the pixels are already upright, so browsers need no correction).
    * @param {Buffer} inputBuffer - The original image buffer
    * @param {number} targetWidth - The target width in pixels
    * @returns {Promise<Buffer>} The resized WebP buffer
    */
   async resize(inputBuffer, targetWidth) {
     return sharp(inputBuffer, { animated: true })
+      .autoOrient() // rotate/flip pixels per EXIF Orientation, then drop the tag
       .resize({ width: targetWidth, withoutEnlargement: true })
       .webp({ quality: WEBP_QUALITY })
       .toBuffer();
@@ -85,6 +89,9 @@ module.exports = {
    * Generate all applicable thumbnail variants for an image.
    * Uses an all-or-nothing approach: generates all buffers first, then uploads.
    * If any step fails, returns all nulls with hadError: true.
+   *
+   * Variant selection is based on the upright (post-EXIF-orientation) width so
+   * that portrait photos stored in landscape pixel layout are measured correctly.
    *
    * @param {Buffer} imageBuffer - The original image file buffer
    * @param {string} originalPath - The blob path of the original
@@ -98,7 +105,11 @@ module.exports = {
       const metadata = await sharp(imageBuffer, {
         limitInputPixels: 100 * 1024 * 1024, // 100 megapixels max
       }).metadata();
-      const { width: originalWidth } = metadata;
+      // Use the oriented (upright) width so portrait photos whose stored pixels
+      // are landscape (e.g. EXIF Orientation 6/8) are measured correctly.
+      // metadata.autoOrient is available since sharp 0.34 and falls back to
+      // the stored dimensions when no orientation tag is present.
+      const originalWidth = (metadata.autoOrient || metadata).width;
 
       if (!originalWidth) {
         return result;

--- a/scripts/backfill-thumbnails.js
+++ b/scripts/backfill-thumbnails.js
@@ -62,70 +62,63 @@ async function run() {
   });
 
   try {
-    // Query file records without thumbnails in pages to avoid loading all into memory
+    // Paginate through TFile records matching the given `where` clause and collect
+    // processable image files. Explicit sort guarantees stable pagination across
+    // multiple SELECT calls — without it PostgreSQL may reorder rows (autovacuum,
+    // HOT updates) causing records to be missed or processed twice.
     const pageSize = 500;
-    let skip = 0;
-    let page;
-    const imageFiles = [];
 
-    do {
-      page = await TFile.find({
-        where: {
-          thumbnailSmall: null,
-          thumbnailMedium: null,
-          thumbnailLarge: null,
-        },
-      })
-        .populate('fileFormat')
-        .limit(pageSize)
-        .skip(skip);
+    const fetchImageFiles = async (where) => {
+      const files = [];
+      let skip = 0;
+      let page;
+      do {
+        // eslint-disable-next-line no-await-in-loop
+        page = await TFile.find({ where })
+          .populate('fileFormat')
+          .sort('id ASC')
+          .limit(pageSize)
+          .skip(skip);
 
-      page.forEach((f) => {
-        if (!f.fileFormat || !f.fileFormat.mimeType) return;
-        const { mimeType } = f.fileFormat;
-        if (mimeType === 'image/svg+xml') return;
-        if (ThumbnailService.isProcessable(mimeType)) {
-          imageFiles.push(f);
-        }
-      });
+        page.forEach((f) => {
+          if (!f.fileFormat || !f.fileFormat.mimeType) return;
+          const { mimeType } = f.fileFormat;
+          if (mimeType === 'image/svg+xml') return;
+          if (ThumbnailService.isProcessable(mimeType)) {
+            files.push(f);
+          }
+        });
 
-      skip += pageSize;
-    } while (page.length === pageSize);
+        skip += pageSize;
+      } while (page.length === pageSize);
+      return files;
+    };
 
-    console.log(`Found ${imageFiles.length} image files without thumbnails.`);
+    // Collect files that have no thumbnails at all.
+    const missingThumbnailFiles = await fetchImageFiles({
+      thumbnailSmall: null,
+      thumbnailMedium: null,
+      thumbnailLarge: null,
+    });
+    const imageFiles = [...missingThumbnailFiles];
+
+    console.log(
+      `Found ${missingThumbnailFiles.length} image files without thumbnails.`
+    );
 
     // When --fix-orientation is passed, also collect images that already have
     // thumbnails but may have been generated before .autoOrient() was added.
     // We check the EXIF orientation of the downloaded buffer at process time
     // and skip files that are already correctly oriented (orientation == 1 or absent).
     if (fixOrientation) {
-      let orientSkip = 0;
-      let orientPage;
-      do {
-        orientPage = await TFile.find({
-          where: {
-            or: [
-              { thumbnailSmall: { '!=': null } },
-              { thumbnailMedium: { '!=': null } },
-              { thumbnailLarge: { '!=': null } },
-            ],
-          },
-        })
-          .populate('fileFormat')
-          .limit(pageSize)
-          .skip(orientSkip);
-
-        orientPage.forEach((f) => {
-          if (!f.fileFormat || !f.fileFormat.mimeType) return;
-          const { mimeType } = f.fileFormat;
-          if (mimeType === 'image/svg+xml') return;
-          if (ThumbnailService.isProcessable(mimeType)) {
-            imageFiles.push(f);
-          }
-        });
-
-        orientSkip += pageSize;
-      } while (orientPage.length === pageSize);
+      const alreadyThumbnailedFiles = await fetchImageFiles({
+        or: [
+          { thumbnailSmall: { '!=': null } },
+          { thumbnailMedium: { '!=': null } },
+          { thumbnailLarge: { '!=': null } },
+        ],
+      });
+      imageFiles.push(...alreadyThumbnailedFiles);
 
       console.log(
         `Found ${imageFiles.length} total image files to process (including orientation re-check).`
@@ -172,7 +165,11 @@ async function run() {
 
     let processed = 0;
     let succeeded = 0;
-    let skipped = 0;
+    // Separate skip counters so the summary is unambiguous:
+    //   orientationSkipped — file already has correct orientation, no re-encode needed
+    //   tooSmallSkipped    — image dimensions too small for any variant (or blob too large)
+    let orientationSkipped = 0;
+    let tooSmallSkipped = 0;
     let failed = 0;
 
     // Process in batches (default: sequential to limit memory pressure)
@@ -201,7 +198,8 @@ async function run() {
               console.log(
                 `SKIPPED file ${file.id}: blob too large (${Math.round(properties.contentLength / 1024 / 1024)} MB), skipping to avoid OOM`
               );
-              skipped += 1;
+              tooSmallSkipped += 1;
+              processed += 1;
               return;
             }
 
@@ -213,23 +211,39 @@ async function run() {
             }
             const imageBuffer = Buffer.concat(chunks);
 
-            // When --fix-orientation: skip images that are already upright
-            // (EXIF orientation absent or == 1) — no re-generation needed.
-            if (fixOrientation) {
-              const meta = await sharp(imageBuffer).metadata();
+            // Fetch metadata once. In --fix-orientation mode we need orientation
+            // to decide whether to skip; we pass this pre-fetched metadata to
+            // generate() so it does not decode the buffer a second time.
+            const meta = await sharp(imageBuffer, {
+              limitInputPixels: 100 * 1024 * 1024,
+            }).metadata();
+
+            // When --fix-orientation: skip images that already had thumbnails
+            // AND are upright (EXIF orientation absent or == 1) — no re-encode needed.
+            // Files that had no thumbnails at all (from the first query) must still
+            // be processed regardless of orientation, so we check for pre-existing
+            // thumbnails before skipping. Files from the second query always have at
+            // least one non-null thumbnail column by construction of its `where` clause.
+            const alreadyHasThumbnail =
+              file.thumbnailSmall ||
+              file.thumbnailMedium ||
+              file.thumbnailLarge;
+            if (fixOrientation && alreadyHasThumbnail) {
               const { orientation } = meta;
               if (!orientation || orientation === 1) {
-                skipped += 1;
+                orientationSkipped += 1;
                 processed += 1;
                 return;
               }
             }
 
-            // Generate thumbnails
+            // Generate thumbnails, passing the already-fetched metadata to
+            // avoid a second sharp decode inside generate().
             const thumbnailPaths = await ThumbnailService.generate(
               imageBuffer,
               file.path,
-              containerClient
+              containerClient,
+              meta
             );
 
             // Update DB record
@@ -249,8 +263,22 @@ async function run() {
                 `WARNING: file ${file.id} failed thumbnail generation (not just too small)`
               );
               failed += 1;
+            } else if (fixOrientation && alreadyHasThumbnail) {
+              // Image had stale thumbnails with wrong orientation but is too small
+              // for any variant after correction. Clear the stale paths so the
+              // front-end no longer serves the incorrect blobs (they remain in Azure
+              // as orphans but are no longer referenced by the DB).
+              console.log(
+                `file ${file.id}: wrong orientation but too small for any variant — clearing stale thumbnail paths`
+              );
+              await TFile.updateOne(file.id).set({
+                thumbnailSmall: null,
+                thumbnailMedium: null,
+                thumbnailLarge: null,
+              });
+              tooSmallSkipped += 1;
             } else {
-              skipped += 1;
+              tooSmallSkipped += 1;
             }
           } catch (err) {
             console.error(`ERROR processing file ${file.id}:`, err.message);
@@ -274,7 +302,12 @@ async function run() {
     console.log('\n--- Summary ---');
     console.log(`Total files: ${imageFiles.length}`);
     console.log(`Succeeded: ${succeeded}`);
-    console.log(`Skipped (too small): ${skipped}`);
+    if (fixOrientation) {
+      console.log(
+        `Skipped (orientation already correct): ${orientationSkipped}`
+      );
+    }
+    console.log(`Skipped (too small / blob too large): ${tooSmallSkipped}`);
     console.log(`Failed: ${failed}`);
 
     sailsApp.lower();

--- a/scripts/backfill-thumbnails.js
+++ b/scripts/backfill-thumbnails.js
@@ -5,17 +5,22 @@
 /**
  * Backfill Thumbnails Script
  *
- * Generates thumbnails for existing image files that don't have any.
+ * Generates thumbnails for existing image files that don't have any, and
+ * regenerates thumbnails for images that already have them but were stored
+ * with the wrong orientation (EXIF Orientation != 1 or missing).
+ *
  * Lifts Sails to access models, config, and services.
  *
  * Usage:
  *   node scripts/backfill-thumbnails.js
  *   node scripts/backfill-thumbnails.js --dry-run
  *   node scripts/backfill-thumbnails.js --batch-size 5
+ *   node scripts/backfill-thumbnails.js --fix-orientation   # also re-generates already-thumbnailed images with wrong orientation
  */
 
 const Sails = require('sails');
 const rc = require('sails/accessible/rc');
+const sharp = require('sharp');
 const {
   BlobServiceClient,
   StorageSharedKeyCredential,
@@ -24,6 +29,7 @@ const {
 // Parse CLI flags
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
+const fixOrientation = args.includes('--fix-orientation');
 const batchSizeIndex = args.indexOf('--batch-size');
 const batchSize =
   batchSizeIndex !== -1 ? parseInt(args[batchSizeIndex + 1], 10) || 1 : 1;
@@ -87,6 +93,45 @@ async function run() {
     } while (page.length === pageSize);
 
     console.log(`Found ${imageFiles.length} image files without thumbnails.`);
+
+    // When --fix-orientation is passed, also collect images that already have
+    // thumbnails but may have been generated before .autoOrient() was added.
+    // We check the EXIF orientation of the downloaded buffer at process time
+    // and skip files that are already correctly oriented (orientation == 1 or absent).
+    if (fixOrientation) {
+      let orientSkip = 0;
+      let orientPage;
+      do {
+        orientPage = await TFile.find({
+          where: {
+            or: [
+              { thumbnailSmall: { '!=': null } },
+              { thumbnailMedium: { '!=': null } },
+              { thumbnailLarge: { '!=': null } },
+            ],
+          },
+        })
+          .populate('fileFormat')
+          .limit(pageSize)
+          .skip(orientSkip);
+
+        orientPage.forEach((f) => {
+          if (!f.fileFormat || !f.fileFormat.mimeType) return;
+          const { mimeType } = f.fileFormat;
+          if (mimeType === 'image/svg+xml') return;
+          if (ThumbnailService.isProcessable(mimeType)) {
+            imageFiles.push(f);
+          }
+        });
+
+        orientSkip += pageSize;
+      } while (orientPage.length === pageSize);
+
+      console.log(
+        `Found ${imageFiles.length} total image files to process (including orientation re-check).`
+      );
+    }
+
     console.log('File IDs to process:', imageFiles.map((f) => f.id).join(', '));
 
     if (dryRun) {
@@ -167,6 +212,18 @@ async function run() {
               chunks.push(chunk);
             }
             const imageBuffer = Buffer.concat(chunks);
+
+            // When --fix-orientation: skip images that are already upright
+            // (EXIF orientation absent or == 1) — no re-generation needed.
+            if (fixOrientation) {
+              const meta = await sharp(imageBuffer).metadata();
+              const { orientation } = meta;
+              if (!orientation || orientation === 1) {
+                skipped += 1;
+                processed += 1;
+                return;
+              }
+            }
 
             // Generate thumbnails
             const thumbnailPaths = await ThumbnailService.generate(

--- a/test/integration/1_services/ThumbnailService.test.js
+++ b/test/integration/1_services/ThumbnailService.test.js
@@ -198,6 +198,65 @@ describe('ThumbnailService', () => {
       const metadata = await sharp(result).metadata();
       should(metadata.width).be.belowOrEqual(480);
     });
+
+    it('should apply EXIF orientation so portrait pixels are upright after resize', async () => {
+      // Create a landscape buffer (800w × 600h) then tag it with Orientation 6
+      // (90° CW rotation needed). After autoOrient the logical image is 600w × 800h.
+      // Resizing to width 480 should produce an output whose width ≤ 480
+      // and height > width (portrait), confirming the orientation was applied.
+      const landscapeBuffer = await sharp({
+        create: {
+          width: 800,
+          height: 600,
+          channels: 3,
+          background: { r: 200, g: 100, b: 50 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      // Embed EXIF Orientation 6 (rotate 90 CW) so raw pixels are landscape
+      // but the image should be displayed as portrait.
+      const orientedBuffer = await sharp(landscapeBuffer)
+        .withMetadata({ orientation: 6 })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.resize(orientedBuffer, 480);
+
+      const meta = await sharp(result).metadata();
+      should(meta.format).equal('webp');
+      // autoOrient swaps w/h: logical 600×800, resized to width 480 → 480×640
+      should(meta.width).equal(480);
+      should(meta.height).equal(640);
+      // Orientation tag must be absent (autoOrient drops it)
+      should(meta.orientation).be.undefined();
+    });
+
+    it('should skip autoOrient when isAnimated is true', async () => {
+      // For animated inputs, autoOrient is intentionally skipped.
+      // Create a simple JPEG (no EXIF orientation) and verify resize still works.
+      const inputBuffer = await sharp({
+        create: {
+          width: 1000,
+          height: 500,
+          channels: 3,
+          background: { r: 0, g: 200, b: 100 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.resize(inputBuffer, 480, {
+        isAnimated: true,
+      });
+
+      const meta = await sharp(result).metadata();
+      should(meta.format).equal('webp');
+      should(meta.width).equal(480);
+      // Height proportional to original landscape 1000×500: 480/1000 * 500 = 240
+      should(meta.height).equal(240);
+    });
   });
 
   describe('generate', () => {
@@ -350,6 +409,43 @@ describe('ThumbnailService', () => {
       should(result.hadError).be.true();
 
       logStub.restore();
+    });
+
+    it('should use autoOrient width for variant selection on EXIF-rotated images', async () => {
+      // Raw pixels: 1500w × 800h (landscape), EXIF Orientation 6 (needs 90° CW rotation).
+      // Upright (post-autoOrient): 800w × 1500h (portrait).
+      // Without the autoOrient fallback, getApplicableVariants(1500) → small+medium.
+      // With the fallback, getApplicableVariants(800) → only small (medium threshold 1280 > 800).
+      // This verifies generate() measures the upright dimension for variant selection.
+      const landscapeBuffer = await sharp({
+        create: {
+          width: 1500,
+          height: 800,
+          channels: 3,
+          background: { r: 100, g: 150, b: 200 },
+        },
+      })
+        .jpeg()
+        .toBuffer();
+
+      // Embed Orientation 6: raw pixels are landscape, logical image is portrait 800×1500
+      const orientedBuffer = await sharp(landscapeBuffer)
+        .withMetadata({ orientation: 6 })
+        .jpeg()
+        .toBuffer();
+
+      const result = await ThumbnailService.generate(
+        orientedBuffer,
+        'oriented-photo.jpg',
+        mockBlobClient
+      );
+
+      // Upright width is 800 → only the small (480) variant applies; medium (1280) does not.
+      should(result.small).equal('thumbnails/small/oriented-photo.webp');
+      should(result.medium).be.null();
+      should(result.large).be.null();
+      should(result.hadError).be.false();
+      should(Object.keys(uploadedBlobs).length).equal(1);
     });
   });
 });


### PR DESCRIPTION
## 🤔 What

Fix portrait photos being displayed rotated 90° in all thumbnail variants.

- Call `.autoOrient()` before `.resize()` in `ThumbnailService.resize()` so EXIF orientation is applied to the pixels before scaling
- Use `metadata.autoOrient.width` instead of `metadata.width` in `generate()` so variant selection is based on the upright dimensions, not the raw stored dimensions
- Add `--fix-orientation` flag to `scripts/backfill-thumbnails.js` to regenerate existing incorrectly-oriented thumbnails (only downloads and re-encodes images with EXIF Orientation ≠ 1)

Closes #1747

## 🤷‍♂️ Why

`sharp` does not auto-orient by default and strips all metadata on output. For photos shot in portrait on a phone (EXIF Orientation 6 or 8), the stored pixels are landscape. Without `.autoOrient()`, all three WebP variants kept that landscape pixel layout with no orientation tag, so browsers had no cue to correct them.

Variant selection was also using the raw stored width, meaning a portrait image stored as 4080×3060 was being compared against the 1920px threshold as if it were landscape — producing a `large` variant that `withoutEnlargement` then capped at 1500px, identical to the source resolution.

## 🔍 How

- `.autoOrient()` rotates/flips the decoded pixels according to the EXIF Orientation tag and then drops the tag. Called before `.resize()` so the target width is applied to the already-upright dimensions.
- `metadata.autoOrient` (available since sharp 0.34, already pinned at 0.35.3) returns `{ width, height }` for the upright image. Falls back to `metadata` directly when no orientation tag is present (images without EXIF, GIFs, PNGs), so there is no regression.
- GIFs carry no EXIF orientation tag — `.autoOrient()` is a no-op for them. Animated GIFs are unaffected.
- The backfill script `--fix-orientation` pass queries all files that already have thumbnails, downloads each one, reads `metadata.orientation`, and skips files where it is absent or equal to 1. Only files that actually need re-encoding are passed to `ThumbnailService.generate()`. Existing thumbnail blobs are overwritten in place (same computed paths).

## 🧪 Testing

Run the existing thumbnail integration tests:

```bash
npm run test -- --grep "Thumbnail"
```

To regenerate existing corrupted thumbnails in production after deploy:

```bash
AZURE_KEY=<key> node scripts/backfill-thumbnails.js --fix-orientation --batch-size 5
```

Use `--dry-run` first to preview the candidate count without making changes.

## 📸 Previews

N/A — the fix affects stored pixel layout, not the API surface.
